### PR TITLE
Bind audio stream, timing and control sockets to available port

### DIFF
--- a/rtp.c
+++ b/rtp.c
@@ -416,10 +416,10 @@ void rtp_setup(SOCKADDR *remote, int cport, int tport, int *lsport, int *lcport,
     }
     
     // now, we open three sockets -- one for the audio stream, one for the timing and one for the control
-    
-     *lsport = bind_port(remote,&audio_socket,6000);
-     *lcport = bind_port(remote,&control_socket,6001);
-     *ltport = bind_port(remote,&timing_socket,6002);
+    // bind to an available port
+     *lsport = bind_port(remote,&audio_socket,0);
+     *lcport = bind_port(remote,&control_socket,0);
+     *ltport = bind_port(remote,&timing_socket,0);
 
     debug(2, "listening for audio, control and timing on ports %d, %d, %d.", *lsport, *lcport, *ltport);
 


### PR DESCRIPTION
Hi Mike,

Thank you very much for all your great work on shairport-sync. The synchronisation is a great feature to have on top of the excellent work by @abrasive.

I am running multiple shairport instances on a machine with multiple audio interfaces. This worked great with 
shairport, however with shairport-sync I get an `could not bind a UDP port!` error.

Herewith a small change to `rtp.c` that binds audio stream, timing and control sockets to available port instead of hard coded ports 6000, 6001, 6002. This seems to do the trick for me.

Pieter
