### PR TITLE
Fix static linking (branch yem/static-link)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,10 @@ fi
 AC_CHECK_LIB([daemon],[daemon_log], , AC_MSG_ERROR(libdaemon needed))
 AC_CHECK_LIB([pthread],[pthread_create], , AC_MSG_ERROR(pthread library needed))
 AC_CHECK_LIB([m],[exp], , AC_MSG_ERROR(maths library needed))
-AC_CHECK_LIB([popt],[poptGetContext], , AC_MSG_ERROR(libpopt needed))
+PKG_CHECK_MODULES(
+    [POPT], [popt],
+    [LIBS="${POPT_LIBS} ${LIBS}"
+     AC_DEFINE([HAVE_LIBPOPT],[1],[Define to 1 if you have popt])])
 
 # Look for piddir flag
 AC_ARG_WITH(piddir, [ --with-piddir=<pathname> Specify a pathname to a directory in which to write the PID file.], [


### PR DESCRIPTION
Hello!

This few patches makes it possible to statically link shairport-sync.

The issues were found using [Buildroot](http://buildroot.org/). We have [autobuilders](http://autobuild.buildroot.org/) that do a lot of different builds a day, with a lot of toolchain combinations (glibc/uClibc/musl, static/shared, x86/arm/mips/..., threads/no-threads, and so on...)

Some of the builds of shairport-sync are [failing](http://autobuild.buildroot.org/?reason=shairport-sync-2.1.8) because shairport-sync fails to account for extra dependencies of some libraries. For example, -lssl needs to be linked with -lz, which is dealt with in shared builds, thanks to DT_NEEDED ELF tags, but is missing for static builds, since there is no way to have DT_NEEDED in a static library.

Instead of using AC_CHECK_LIB, use pkg-config via PKG_CHECK_MODULES to find the needed libraries, which erturns all the depending libraries if any.

Note that I fixed those libraries I had issues with, and that some may be left around. Hopefully, the provided patches can serve as an example of what should be done to the other libraries. ;-)

Thank you! :-)

Regards,
Yann E. MORIN.
