### PR TITLE
Fix segfault with musl libc

### DIFF
--- a/player.c
+++ b/player.c
@@ -36,7 +36,7 @@
 #include <pthread.h>
 #include <math.h>
 #include <sys/stat.h>
-#include <sys/signal.h>
+#include <signal.h>
 #include <sys/syslog.h>
 #include <assert.h>
 #include <fcntl.h>

--- a/rtsp.c
+++ b/rtsp.c
@@ -39,7 +39,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 #include "config.h"
 


### PR DESCRIPTION
shairport-sync crashes on musl libc when accessing the `statistics` array in `player_thread_func()`. This array is quite large (60128 bytes) and altogether the data for this thread exceed the the default stack size on musl libc of 80k [1].

Safe and portable programs should not depend upon the default stack limit, but instead, explicitly allocate enough stack for each thread by using the pthread_attr_setstacksize routine [2].

So, lets set the stack size for the `player_thread` to 128k. A follow-up patch may set the stack sizes for the other threads, too. The difficulty here is to decide how much memory to allocate for the stack.

[1]
http://wiki.musl-libc.org/wiki/Functional_differences_from_glibc#Thread_stack_size

[2]
https://computing.llnl.gov/tutorials/pthreads/#Stack