### PR TITLE
minor changes to support fedora and systemd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,11 +52,16 @@ endif
 
 install-exec-hook:
 if INSTALL_CONFIG_FILES
-	cp scripts/shairport-sync.conf /etc/shairport-sync.conf.sample
-	[ -f /etc/shairport-sync.conf ] || cp scripts/shairport-sync.conf /etc/shairport-sync.conf
+	[ -e $(DESTDIR)/etc ] || mkdir $(DESTDIR)/etc
+	cp scripts/shairport-sync.conf $(DESTDIR)/etc/shairport-sync.conf.sample
+	[ -f $(DESTDIR)/etc/shairport-sync.conf ] || cp scripts/shairport-sync.conf $(DESTDIR)/etc/shairport-sync.conf
 endif
 if INSTALL_INITSCRIPT
-	[ -f /etc/init.d/shairport-sync ] || cp scripts/shairport-sync /etc/init.d/
+	[ -e $(DESTDIR)/etc/init.d ] || mkdir -p $(DESTDIR)/etc/init.d
+	[ -f /etc/init.d/shairport-sync ] || cp scripts/shairport-sync $(DESTDIR)/etc/init.d/
 	update-rc.d shairport-sync defaults 90 10
 endif
-
+if INSTALL_SYSTEMD
+	[ -e $(DESTDIR)/usr/lib/systemd/system ] || mkdir -p $(DESTDIR)/usr/lib/systemd/system
+	cp scripts/shairport-sync.service $(DESTDIR)/usr/lib/systemd/system
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,10 @@ AC_ARG_WITH([initscript],
 [  --with-initscript = include a startup script], ,[with_initscript=1])
 AM_CONDITIONAL([INSTALL_INITSCRIPT], [test "x$with_initscript" = "x1"])
 
+AC_ARG_WITH([systemd],
+[  --with-systemd = include a systemd service], ,[with_systemd=1])
+AM_CONDITIONAL([INSTALL_SYSTEMD], [test "x$with_systemd" = "x1"])
+
 # Check if we want to support reading arguments from the command line     
 AC_ARG_WITH([command_line_argument_support],
 [  --with-command-line-argument-support = read configuration from command line arguments], ,[with_command_line_argument_support=1])

--- a/scripts/shairport-sync.service
+++ b/scripts/shairport-sync.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=ShairportSync AirTunes receiver
+After=sound.target
+Requires=avahi-daemon.service
+After=avahi-daemon.service
+
+[Service]
+ExecStart=/usr/bin/shairport-sync
+User=shairport-sync
+Group=shairport-sync
+
+[Install]
+WantedBy=multi-user.target

--- a/shairport-sync.spec
+++ b/shairport-sync.spec
@@ -1,0 +1,63 @@
+Name:		shairport-sync
+Version:	2.3.7
+Release:	1%{?dist}
+Summary:	AirTunes emulator. Shairport Sync adds multi-room capability with Audio Synchronisation
+
+Group:		Applications/Multimedia
+License:	GPL
+URL:		https://github.com/mikebrady/shairport-sync
+Source0:	https://github.com/mikebrady/%{name}/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:		shairport-sync-systemd.patch
+
+BuildRequires:	autoconf
+BuildRequires:	automake
+BuildRequires:	libconfig-devel
+BuildRequires:	popt-devel
+BuildRequires:	openssl-devel
+BuildRequires:	libdaemon-devel
+BuildRequires:	avahi-devel
+BuildRequires:	alsa-lib-devel
+BuildRequires:	systemd-units
+BuildRequires:	soxr-devel
+Requires:	popt
+Requires:	openssl
+Requires:	avahi
+Requires:	libdaemon
+Requires:	alsa-lib
+Requires:	soxr
+
+%description
+Shairport Sync emulates an AirPort Express for the purpose of streaming audio from iTunes, iPods, iPhones, iPads and AppleTVs. Audio played by a Shairport Sync-powered device stays synchronised with the source and hence with similar devices playing the same source. Thus, for example, synchronised multi-room audio is possible without difficulty. (Hence the name Shairport Sync, BTW.)
+
+Shairport Sync does not support AirPlay video or photo streaming.
+
+%prep
+%setup -q
+%patch0 -p1
+
+%build
+autoreconf -i -f
+%configure --with-avahi --with-alsa --with-ssl=openssl --with-soxr --without-initscript
+make %{?_smp_mflags}
+
+
+%install
+make install DESTDIR=%{buildroot}
+rm %{buildroot}/etc/shairport-sync.conf.sample
+
+%pre
+getent group %{name} &>/dev/null || groupadd --system %{name} >/dev/null
+getent passwd %{name} &> /dev/null || useradd --system -c "%{name} User" \
+	-d %{_localstatedir}/%{name} -m -g %{name} -s /sbin/nologin \
+	-G audio %{name} >/dev/null
+
+%files
+%config /etc/shairport-sync.conf
+/usr/bin/shairport-sync
+/usr/share/man/man7/shairport-sync.7.gz
+%{_unitdir}/%{name}.service
+%doc AUTHORS LICENSES README.md
+
+%changelog
+* Fri Jul 24 2015 Bill Peck <bill@pecknet.com> 2.3.7-1
+- Initial spec file


### PR DESCRIPTION
I'm not entirely sure how you want to handle the difference between system V init scripts and systemd.  The way the --with and --without options are currently you could end up with both.