### PR TITLE
Use DESTDIR when checking systemv script exists

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,7 @@ if INSTALL_CONFIG_FILES
 endif
 if INSTALL_SYSTEMV
 	[ -e $(DESTDIR)/etc/init.d ] || mkdir -p $(DESTDIR)/etc/init.d
-	[ -f /etc/init.d/shairport-sync ] || cp scripts/shairport-sync $(DESTDIR)/etc/init.d/
+	[ -f $(DESTDIR)/etc/init.d/shairport-sync ] || cp scripts/shairport-sync $(DESTDIR)/etc/init.d/
 	update-rc.d shairport-sync defaults 90 10
 endif
 if INSTALL_SYSTEMD


### PR DESCRIPTION
There looks to be a missing `$DESTDIR` in the systemv init script part of the makefile. 

I noticed this when trying to [create a Debian package](https://github.com/kingosticks/shairport-sync/tree/debian) and had tried to use a `dh_installinit --onlyscripts` rule. 

The call to `update-rc.d` then also gave problems.  Would it be reasonable to only perform that command when $(DESTDIR) is unset? Something like:
```
[ -n $(DESTDIR) ] || update-rc.d shairport-sync defaults 90 10
```