### PR TITLE
Separate system config from installation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,13 +55,21 @@ if INSTALL_CONFIG_FILES
 	[ -e $(DESTDIR)/etc ] || mkdir $(DESTDIR)/etc
 	cp scripts/shairport-sync.conf $(DESTDIR)/etc/shairport-sync.conf.sample
 	[ -f $(DESTDIR)/etc/shairport-sync.conf ] || cp scripts/shairport-sync.conf $(DESTDIR)/etc/shairport-sync.conf
-endif
 if INSTALL_SYSTEMV
 	[ -e $(DESTDIR)/etc/init.d ] || mkdir -p $(DESTDIR)/etc/init.d
 	[ -f $(DESTDIR)/etc/init.d/shairport-sync ] || cp scripts/shairport-sync $(DESTDIR)/etc/init.d/
-	update-rc.d shairport-sync defaults 90 10
 endif
 if INSTALL_SYSTEMD
 	[ -e $(DESTDIR)/usr/lib/systemd/system ] || mkdir -p $(DESTDIR)/usr/lib/systemd/system
 	cp scripts/shairport-sync.service $(DESTDIR)/usr/lib/systemd/system
+endif
+endif
+
+if CONFIGURE_SERVICE
+if INSTALL_SYSTEMV
+	update-rc.d shairport-sync defaults 90 10
+endif
+if INSTALL_SYSTEMD
+	systemctl enable shairport-sync
+endif
 endif


### PR DESCRIPTION
### NOTE: I have not actually built and tested this.  This is just to express my view of it.

The way I see it, _/etc/shairport-sync.conf_ and _/etc/init.d/shairport-sync_ are both configuration files.
As such, they should always be installed **--with-configfiles**.

The _update-rc.d_ command is part of system configuration for SystemV systems. So, it should be under the new flag.

Since SystemV and SystemD are independent and apply to both config files and service configuration, they can go under each block.  (They are misnomers now)