### PR TITLE
No custom PID directory because USE_CUSTOM_LOCAL_STATE_DIR macro still used.

### DIFF
--- a/shairport.c
+++ b/shairport.c
@@ -680,8 +680,8 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-#if USE_CUSTOM_LOCAL_STATE_DIR
-  debug(1, "Locating localstatedir at \"%s\"", LOCALSTATEDIR);
+#if USE_CUSTOM_PID_DIR
+  debug(1, "Locating custom pid dir at \"%s\"", PIDDIR);
   /* Point to a function to help locate where the PID file will go */
   daemon_pid_file_proc = pid_file_proc;
 #endif


### PR DESCRIPTION
You couldn't set a custom pid directory because the USE_CUSTOM_LOCAL_STATE_DIR macro was still used. Therefore the daemon_pid_file_proc would never point to the function locating the custom pid directory.