### PR TITLE
Added a new event on volume change

### DIFF
--- a/common.h
+++ b/common.h
@@ -70,7 +70,7 @@ typedef struct {
   uint32_t ForkedDaapdLatency; // supplied with --ForkedDaapdLatency option
   int daemonise;
   int statistics_requested;
-  char *cmd_start, *cmd_stop;
+  char *cmd_start, *cmd_stop, *cmd_volChange;
   int cmd_blocking;
   int tolerance; // allow this much drift before attempting to correct it
   enum stuffing_type packet_stuffing;
@@ -127,6 +127,7 @@ uint64_t play_segment_reference_frame_remote_time;
 
 void command_start(void);
 void command_stop(void);
+void command_volChange(double volume);
 
 void shairport_shutdown();
 // void shairport_startup_complete(void);

--- a/man/shairport-sync.7
+++ b/man/shairport-sync.7
@@ -232,6 +232,11 @@ Execute \fIprogram\f1 when playback has ended. Specify the full path to the prog
 
 If you want shairport-sync to wait until the command has completed before continuing, select the \fB-w\f1 option as well. 
 .TP
+\fB-C \f1\fIprogram\f1\fB | --on-vol-change=\f1\fIprogram\f1
+Execute \fIprogram\f1 when the volume of the audio source has changed. Specify the full path to the program, e.g. \fI/usr/bin/logger\f1. Executable scripts can be used, but they must have \fI#!/bin/sh\f1 (or whatever is appropriate) in the headline.
+
+If you want shairport-sync to wait until the command has completed before continuing, select the \fB-w\f1 option as well.
+.TP
 \fB--forkedDaapdLatency=\f1\fIlatency\f1
 Use this \fIlatency\f1, in frames, for audio streamed from a forked-daapd based source. The default is 99,400 frames, where there are 44,100 frames to the second. 
 .TP

--- a/man/shairport-sync.7
+++ b/man/shairport-sync.7
@@ -2,7 +2,7 @@
 .SH NAME
 shairport-sync \- Synchronised Audio Player for iTunes / AirPlay
 .SH SYNOPSIS
-\fBshairport-sync [-dvw]\fB [-a \fB\fIname\fB]\fB [-A \fB\fIlatency\fB]\fB [-B \fB\fIcommand\fB]\fB [-c \fB\fIconfigurationfile\fB]\fB [-E \fB\fIcommand\fB]\fB [--forkedDaapdLatency=\fB\fIlatency\fB]\fB [--get-cover-art]\fB [-i \fB\fIlatency\fB]\fB [-L \fB\fIlatency\fB]\fB [-m \fB\fIbackend\fB]\fB [--meta-dir=\fB\fIdirectory\fB]\fB [-o \fB\fIbackend\fB]\fB [--password=\fB\fIsecret\fB]\fB [-r \fB\fIthreshold\fB]\fB [--statistics]\fB [-S \fB\fImode\fB]\fB [-t \fB\fItimeout\fB]\fB [--tolerance=\fB\fIframes\fB]\fB [-- \fB\fIaudio_backend_options\fB]\fB
+\fBshairport-sync [-dvw]\fB [-a \fB\fIname\fB]\fB [-A \fB\fIlatency\fB]\fB [-B \fB\fIcommand\fB]\fB [-c \fB\fIconfigurationfile\fB]\fB [-E \fB\fIcommand\fB]\fB [-C \fB\fIcommand\fB]\fB [--forkedDaapdLatency=\fB\fIlatency\fB]\fB [--get-cover-art]\fB [-i \fB\fIlatency\fB]\fB [-L \fB\fIlatency\fB]\fB [-m \fB\fIbackend\fB]\fB [--meta-dir=\fB\fIdirectory\fB]\fB [-o \fB\fIbackend\fB]\fB [--password=\fB\fIsecret\fB]\fB [-r \fB\fIthreshold\fB]\fB [--statistics]\fB [-S \fB\fImode\fB]\fB [-t \fB\fItimeout\fB]\fB [--tolerance=\fB\fIframes\fB]\fB [-- \fB\fIaudio_backend_options\fB]\fB
 
 shairport-sync -D\fB
 
@@ -19,7 +19,7 @@ shairport-sync -V\fB
 .SH DESCRIPTION
 shairport-sync plays audio streamed from iTunes or from an AirPlay device to an ALSA-compatible audio output device.
 
-A feature of shairport-sync is that the audio is played synchronously. This means that if many devices are playing the same stream at the same time, all the outputs will stay in step with one another. This allows multiple devices play the same source without getting out of phase with one another, enabling, for example, simultaneous multi-room operation. 
+A feature of shairport-sync is that the audio is played synchronously. This means that if many devices are playing the same stream at the same time, all the outputs will stay in step with one another. This allows multiple devices play the same source without getting out of phase with one another, enabling, for example, simultaneous multi-room operation.
 
 shairport-sync can additionally be compiled and configured to stream raw audio to a pipe or to stdout.
 
@@ -61,43 +61,43 @@ The configuration file is processed using the \fIlibconfig\f1 library -- see \fB
 These are the settings available within the \fBgeneral\f1 group:
 .TP
 \fBname=\f1\fI"service_name"\f1\fB;\f1
-Use this \fIservice_name\f1 to identify this player in iTunes, etc. The default name is "Shairport Sync on <hostname>". 
+Use this \fIservice_name\f1 to identify this player in iTunes, etc. The default name is "Shairport Sync on <hostname>".
 .TP
 \fBpassword=\f1\fI"password"\f1\fB;\f1
-Require the password \fIpassword\f1 to connect to the service. If you leave this setting commented out, no password is needed. 
+Require the password \fIpassword\f1 to connect to the service. If you leave this setting commented out, no password is needed.
 .TP
 \fBinterpolation=\f1\fI"mode"\f1\fB;\f1
-Interpolate, or "stuff", the audio stream using the \fImode\f1. Interpolation here refers to the process of adding or removing frames of audio to or from the stream sent to the output device to keep it exactly in synchrony with the player. The default mode, "basic", is normally almost completely inaudible. The alternative mode, "soxr", is even less obtrusive but requires much more processing power. For this mode, support for libsoxr, the SoX Resampler Library, must be selected when shairport-sync is compiled. 
+Interpolate, or "stuff", the audio stream using the \fImode\f1. Interpolation here refers to the process of adding or removing frames of audio to or from the stream sent to the output device to keep it exactly in synchrony with the player. The default mode, "basic", is normally almost completely inaudible. The alternative mode, "soxr", is even less obtrusive but requires much more processing power. For this mode, support for libsoxr, the SoX Resampler Library, must be selected when shairport-sync is compiled.
 .TP
 \fBstatistics=\f1\fI"setting"\f1\fB;\f1
-Use this \fIsetting\f1 to enable ("yes") or disable ("no") the output of some statistical information on the console or in the log. The default is to disable statistics. 
+Use this \fIsetting\f1 to enable ("yes") or disable ("no") the output of some statistical information on the console or in the log. The default is to disable statistics.
 .TP
 \fBmdns_backend=\f1\fI"backend"\f1\fB;\f1
-shairport-sync has a number of modules of code ("backends") for interacting with the mDNS service to be used to advertise itself. Normally, the first mDNS backend that works is selected. This setting forces the selection of the specific mDNS \fIbackend\f1. The default is "avahi". Perform the command \fBshairport-sync -h\f1 to get a list of available mDNS modules. 
+shairport-sync has a number of modules of code ("backends") for interacting with the mDNS service to be used to advertise itself. Normally, the first mDNS backend that works is selected. This setting forces the selection of the specific mDNS \fIbackend\f1. The default is "avahi". Perform the command \fBshairport-sync -h\f1 to get a list of available mDNS modules.
 .TP
 \fBoutput_backend=\f1\fI"backend"\f1\fB;\f1
-shairport-sync has a number of modules of code ("backends") through which audio is output. Normally, the first audio backend that works is selected. This setting forces the selection of the specific audio \fIbackend\f1. The default is "alsa". Perform the command \fBshairport-sync -h\f1 to get a list of available audio backends. Only the alsa backend supports synchronisation. 
+shairport-sync has a number of modules of code ("backends") through which audio is output. Normally, the first audio backend that works is selected. This setting forces the selection of the specific audio \fIbackend\f1. The default is "alsa". Perform the command \fBshairport-sync -h\f1 to get a list of available audio backends. Only the alsa backend supports synchronisation.
 .TP
 \fBport=\f1\fIportnumber\f1\fB;\f1
-Use this to specify the \fIportnumber\f1 shairport-sync uses to listen for service requests from iTunes, etc. The default is port 5000. 
+Use this to specify the \fIportnumber\f1 shairport-sync uses to listen for service requests from iTunes, etc. The default is port 5000.
 .TP
 \fBudp_port_base=\f1\fIportnumber\f1\fB;\f1
-When shairport-sync starts to play audio, it establises three UDP connections to the audio source. Use this setting to specify the starting \fIportnumber\f1 for these three ports. It will pick the first three unused ports starting from \fIportnumber\f1. The default is port 6001. 
+When shairport-sync starts to play audio, it establises three UDP connections to the audio source. Use this setting to specify the starting \fIportnumber\f1 for these three ports. It will pick the first three unused ports starting from \fIportnumber\f1. The default is port 6001.
 .TP
 \fBudp_port_range=\f1\fIrange\f1\fB;\f1
-Use this in conjunction with the prevous setting to specify the \fIrange\f1 of ports that can be checked for availability. Only three ports are needed. The default is 100, thus 100 ports will be checked from port 6001 upwards until three are found. 
+Use this in conjunction with the prevous setting to specify the \fIrange\f1 of ports that can be checked for availability. Only three ports are needed. The default is 100, thus 100 ports will be checked from port 6001 upwards until three are found.
 .TP
 \fBdrift=\f1\fIframes\f1\fB;\f1
-Allow playback to drift up to \fIframes\f1 out of exact synchronization before attempting to correct it. The default is 88 frames, i.e. 2 ms. The smaller the tolerance, the more likely it is that overcorrection will occur. Overcorrection is when more corrections (insertions and deletions) are made than are strictly necessary to keep the stream in sync. Use the \fBstatistics\f1 setting to monitor correction levels. Corrections should not greatly exceed net corrections. 
+Allow playback to drift up to \fIframes\f1 out of exact synchronization before attempting to correct it. The default is 88 frames, i.e. 2 ms. The smaller the tolerance, the more likely it is that overcorrection will occur. Overcorrection is when more corrections (insertions and deletions) are made than are strictly necessary to keep the stream in sync. Use the \fBstatistics\f1 setting to monitor correction levels. Corrections should not greatly exceed net corrections.
 .TP
 \fBresync_threshold=\f1\fIthreshold\f1\fB;\f1
-Resynchronise if timings differ by more than \fIthreshold\f1 frames. If the output timing differs from the source timing by more than the threshold, output will be muted and a full resynchronisation will occur. The default threshold is 2,205 frames, i.e. 50 milliseconds. Specify 0 to disable resynchronisation. 
+Resynchronise if timings differ by more than \fIthreshold\f1 frames. If the output timing differs from the source timing by more than the threshold, output will be muted and a full resynchronisation will occur. The default threshold is 2,205 frames, i.e. 50 milliseconds. Specify 0 to disable resynchronisation.
 .TP
 \fBlog_verbosity=\f1\fI0\f1\fB;\f1
-Use this to specify how much debugging information should be output or logged. "0" means no debug information, "3" means most debug information. The default is "0". 
+Use this to specify how much debugging information should be output or logged. "0" means no debug information, "3" means most debug information. The default is "0".
 .TP
 \fBignore_volume_control=\f1\fI"choice"\f1\fB;\f1
-Set this \fIchoice\f1 to "yes" if you want the volume to be at 100% no matter what the source's volume control is set to. This might be useful if you want to set the volume on the output device, independently of the setting at the source. The default is "no". 
+Set this \fIchoice\f1 to "yes" if you want the volume to be at 100% no matter what the source's volume control is set to. This might be useful if you want to set the volume on the output device, independently of the setting at the source. The default is "no".
 .TP
 \fB"LATENCIES" SETTINGS\f1
 There are four default latency settings, chosen automatically. One latency matches the latency used by recent versions of iTunes when playing audio and another matches the latency used by so-called "AirPlay" devices, including iOS devices and iTunes and Quicktime Player when they are playing video. A third latency is used when the audio source is forked-daapd. The fourth latency is the default if no other latency is chosen and is used for older versions of iTunes.
@@ -105,16 +105,16 @@ There are four default latency settings, chosen automatically. One latency match
 If you want to change latencies to compensate for a delay in the audio output device (which will have the same effect on all sources), instead of changing these individual latencies, consider using the \fBaudio_backend_latency_offset\f1 setting in the \fBalsa\f1 group (or the appropriate other group if you're not outputing through the alsa backend).
 .TP
 \fBitunes=\f1\fIlatency\f1\fB;\f1
-This is the \fIlatency\f1, in frames, used for iTunes 10 or later. Default is 99,400. 
+This is the \fIlatency\f1, in frames, used for iTunes 10 or later. Default is 99,400.
 .TP
 \fBairplay=\f1\fIlatency\f1\fB;\f1
-This is the \fIlatency\f1, in frames, used for AirPlay devices, including iOS devices and iTunes and Quicktime Player when they are playing video. Default is 88,200. 
+This is the \fIlatency\f1, in frames, used for AirPlay devices, including iOS devices and iTunes and Quicktime Player when they are playing video. Default is 88,200.
 .TP
 \fBforkedDaapd=\f1\fIlatency\f1\fB;\f1
-This is the \fIlatency\f1, in frames, used for forkedDaapd sources. Default is 99,400. 
+This is the \fIlatency\f1, in frames, used for forkedDaapd sources. Default is 99,400.
 .TP
 \fBdefault=\f1\fIlatency\f1\fB;\f1
-This is the \fIlatency\f1, in frames, used when the source is unrecognised. Default is 88,200. 
+This is the \fIlatency\f1, in frames, used when the source is unrecognised. Default is 88,200.
 .TP
 \fB"METADATA" SETTINGS\f1
 shairport-sync can process metadata provided by the source, such as Track Number, Album Name, cover art, etc. and can provide additional metadata such as volume level, pause/resume, etc. It provides the metadata to a pipe, by default \fI/tmp/shairport-sync-metadata\f1. To process metadata, shairport-sync must have been compiled with metadata support included. You can check that this is so by running \fBshairport-sync -V\f1; the identification string will contain the word \fBmetadata\f1.
@@ -122,51 +122,54 @@ shairport-sync can process metadata provided by the source, such as Track Number
 The \fBmetadata\f1 group of settings allow you to enable metadata handling and to control certain aspects of it:
 .TP
 \fBenabled=\f1\fI"choice"\f1\fB;\f1
-Set the \fIchoice\f1 to "yes" to enable shairport-sync to look for metadata from the audio source and to forward it, along with metadata generated by shairport-sync itself, to the metadata pipe. The default is "no". 
+Set the \fIchoice\f1 to "yes" to enable shairport-sync to look for metadata from the audio source and to forward it, along with metadata generated by shairport-sync itself, to the metadata pipe. The default is "no".
 .TP
 \fBinclude_cover_art=\f1\fI"choice"\f1\fB;\f1
-Set the \fIchoice\f1 to "yes" to enable shairport-sync to look for cover art from the audio source and to include it in the feed to the metadata pipe. You must also enable metadata (see above). One reason for not including cover art is that the images can sometimes be very large and may delay transmission of subsequent metadata through the pipe. The default is "no". 
+Set the \fIchoice\f1 to "yes" to enable shairport-sync to look for cover art from the audio source and to include it in the feed to the metadata pipe. You must also enable metadata (see above). One reason for not including cover art is that the images can sometimes be very large and may delay transmission of subsequent metadata through the pipe. The default is "no".
 .TP
 \fBpipe_name=\f1\fI"filepathname"\f1\fB;\f1
-Specify the absolute path name of the pipe through which metadata should be sent The default is \fI/tmp/shairport-sync-metadata\f1". 
+Specify the absolute path name of the pipe through which metadata should be sent The default is \fI/tmp/shairport-sync-metadata\f1".
 .TP
 \fB"SESSIONCONTROL" SETTINGS\f1
-shairport-sync can run programs just before it starts to play an audio stream and just after it finishes. You specify them using the settings \fBrun_this_before_play_begins\f1 and \fBrun_this_after_play_ends\f1. 
+shairport-sync can run programs just before it starts to play an audio stream and just after it finishes. You specify them using the settings \fBrun_this_before_play_begins\f1 and \fBrun_this_after_play_ends\f1.
 .TP
 \fBrun_this_before_play_begins=\f1\fI"/path/to/application and args"\f1\fB;\f1
-Here you can specify a program and its arguments that will be run just before a play session begins. Be careful to include the full path to the application. The application must be marked as executable and, if it is a script, its first line must begin with the standard \fI#!/bin/...\f1 as appropriate. 
+Here you can specify a program and its arguments that will be run just before a play session begins. Be careful to include the full path to the application. The application must be marked as executable and, if it is a script, its first line must begin with the standard \fI#!/bin/...\f1 as appropriate.
 .TP
 \fBrun_this_after_play_ends=\f1\fI"/path/to/application and args"\f1\fB;\f1
-Here you can specify a program and its arguments that will be run just after a play session ends. Be careful to include the full path to the application. The application must be marked as executable and, if it is a script, its first line must begin with the standard \fI#!/bin/...\f1 as appropriate. 
+Here you can specify a program and its arguments that will be run just after a play session ends. Be careful to include the full path to the application. The application must be marked as executable and, if it is a script, its first line must begin with the standard \fI#!/bin/...\f1 as appropriate.
+.TP
+\fBrun_this_on_volume_change=\f1\fI"/path/to/application"\f1\fB;\f1
+Here you can specify a program that will be run when the audio source changes the volume. Be careful to include the full path to the application. The application must be marked as executable and, if it is a script, its first line must begin with the standard \fI#!/bin/...\f1 as appropriate. There are no user specified arguments allowed for the program. Only the current volume will be passed as the first parameter to the program.
 .TP
 \fBwait_for_completion=\f1\fI"choice"\f1\fB;\f1
-Set \fIchoice\f1 to "yes" to make shairport-sync wait until the programs specified in the \fBrun_this_before_play_begins\f1 and \fBrun_this_after_play_ends\f1 have completed execution before continuing. The default is "no". 
+Set \fIchoice\f1 to "yes" to make shairport-sync wait until the programs specified in the \fBrun_this_before_play_begins\f1, \fBrun_this_after_play_ends\f1 and \fBrun_this_on_volume_change\f1 have completed execution before continuing. The default is "no".
 .TP
 \fBallow_session_interruption=\f1\fI"choice"\f1\fB;\f1
-If \fBchoice\f1 is set to "yes", then another source will be able to interrupt an existing play session and start a new one. When set to "no" (the default), other devices attempting to interrupt a session will fail, receiving a busy signal. 
+If \fBchoice\f1 is set to "yes", then another source will be able to interrupt an existing play session and start a new one. When set to "no" (the default), other devices attempting to interrupt a session will fail, receiving a busy signal.
 .TP
 \fBsession_timeout=\f1\fIseconds\f1\fB;\f1
-If a play session has been established and the source disappears without warning (such as a device going out of range of a network) then wait for \fIseconds\f1 seconds before ending the session. Once the session has terminated, other devices can use it. The default is 120 seconds. 
+If a play session has been established and the source disappears without warning (such as a device going out of range of a network) then wait for \fIseconds\f1 seconds before ending the session. Once the session has terminated, other devices can use it. The default is 120 seconds.
 .TP
 \fB"ALSA" SETTINGS\f1
 These settings are for the ALSA back end, used to communicate with audio output devices in the ALSA system. (By the way, you can use tools such as \fBalsamixer\f1 or \fBaplay\f1 to discover what devices are available.) Use these settings to select the output device and the mixer control to be used to control the output volume. You can additionally set the desired size of the output buffer and you can adjust overall latency. Here are the \fBalsa\f1 group settings:
 .TP
 \fBoutput_device=\f1\fI"output_device"\f1\fB;\f1
-Use the output device called \fIoutput_device\f1. The default is the device called "default". 
+Use the output device called \fIoutput_device\f1. The default is the device called "default".
 .TP
 .TP
 \fBmixer_control_name=\f1\fI"name"\f1\fB;\f1
 Specify the \fIname\f1 of the mixer control to be used by shairport-sync to control the volume. The mixer control must be on the mixer device, which by default is the output device. If you do not specify a mixer control name, shairport-sync will adjust the volume in software. \fBmixer_type=\f1\fI"mixer_type"\f1\fB;\f1
-This setting is deprecated and is ignored. For your information, its functionality has been automatically incorporated in the mixer_control_name setting -- if you specify a mixer name with the mixer_control_name setting, it is assumed that the mixer is implemented in hardware. 
+This setting is deprecated and is ignored. For your information, its functionality has been automatically incorporated in the mixer_control_name setting -- if you specify a mixer name with the mixer_control_name setting, it is assumed that the mixer is implemented in hardware.
 .TP
 \fBmixer_device=\f1\fI"mixer_device"\f1\fB;\f1
-By default, the mixer is assumed to be output_device. Use this setting to specify a device other than the output device. 
+By default, the mixer is assumed to be output_device. Use this setting to specify a device other than the output device.
 .TP
 \fBaudio_backend_latency_offset=\f1\fIoffset\f1\fB;\f1
-Set this \fIoffset\f1, in frames, to compensate for a fixed delay in the audio back end. For example, if the output device delays by 100 ms, set this to -4410. 
+Set this \fIoffset\f1, in frames, to compensate for a fixed delay in the audio back end. For example, if the output device delays by 100 ms, set this to -4410.
 .TP
 \fBaudio_backend_buffer_desired_length=\f1\fIlength\f1\fB;\f1
-Use this to set the desired number frames to be in the output device's hardware output buffer. The default is 6,615 frames, or 0.15 seconds. If set too small, buffer underflow may occur on low-powered machines. If too large, the response times when using software volume control (i.e. when not using a mixer control to control volume) become annoying, or it may exceed the hardware buffer size. It may need to be larger on low-powered machines that are also performing other tasks, such as processing metadata. 
+Use this to set the desired number frames to be in the output device's hardware output buffer. The default is 6,615 frames, or 0.15 seconds. If set too small, buffer underflow may occur on low-powered machines. If too large, the response times when using software volume control (i.e. when not using a mixer control to control volume) become annoying, or it may exceed the hardware buffer size. It may need to be larger on low-powered machines that are also performing other tasks, such as processing metadata.
 .TP
 \fB"PIPE" SETTINGS\f1
 These settings are for the PIPE backend, used to route audio to a named unix pipe. The audio is in raw CD audio format: PCM 16 bit little endian, 44,100 samples per second, stereo.
@@ -178,13 +181,13 @@ There are two further settings affecting timing that might be useful if the pipe
 These are the settings available within the \fBpipe\f1 group:
 .TP
 \fBname=\f1\fI"/path/to/pipe"\f1\fB;\f1
-Use this to specify the name and location of the pipe. The pipe will be created and opened when shairport-sync starts up and will be closed upon shutdown. Frames of audio will be sent to the pipe in packets of 352 frames and will be discarded if the pipe has not have a reader attached. The sender will wait for up to five seconds for a packet to be written before discarding it. 
+Use this to specify the name and location of the pipe. The pipe will be created and opened when shairport-sync starts up and will be closed upon shutdown. Frames of audio will be sent to the pipe in packets of 352 frames and will be discarded if the pipe has not have a reader attached. The sender will wait for up to five seconds for a packet to be written before discarding it.
 .TP
 \fBaudio_backend_latency_offset=\f1\fIoffset_in_frames\f1\fB;\f1
-Packets of audio frames are written to the pipe synchronously -- that is, they are written to at exactly the time they should be played. You can offset the time of initial audio output relative to its nominal time using this setting. For example to send an audio stream to the pipe 100 milliseconds before it is due to be played, set this to -4410. Default setting is 0. 
+Packets of audio frames are written to the pipe synchronously -- that is, they are written to at exactly the time they should be played. You can offset the time of initial audio output relative to its nominal time using this setting. For example to send an audio stream to the pipe 100 milliseconds before it is due to be played, set this to -4410. Default setting is 0.
 .TP
 \fBaudio_backend_buffer_desired_length=\f1\fIbuffer_length_in_frames\f1\fB;\f1
-Use this setting, in frames, to set the size of the output buffer. It works by determining how soon the second and subsequent packets of audio frames are sent to the pipe. For example, if you send the first packet of audio exactly when it is due and, using a \fIaudio_backend_buffer_desired_length\f1 setting of 44100, send subsequent packets of audio a second before they are due to be played, they will be buffered in the pipe reader's buffer, giving it a nominal buffer size of 44,100 frames. Note that if the pipe reader consumes audio packets faster or slower than they are supplied, the buffer will eventually empty or overflow -- shairport-sync performs no stuffing or interpolation when writing to a pipe. Default setting is 44,100 frames. 
+Use this setting, in frames, to set the size of the output buffer. It works by determining how soon the second and subsequent packets of audio frames are sent to the pipe. For example, if you send the first packet of audio exactly when it is due and, using a \fIaudio_backend_buffer_desired_length\f1 setting of 44100, send subsequent packets of audio a second before they are due to be played, they will be buffered in the pipe reader's buffer, giving it a nominal buffer size of 44,100 frames. Note that if the pipe reader consumes audio packets faster or slower than they are supplied, the buffer will eventually empty or overflow -- shairport-sync performs no stuffing or interpolation when writing to a pipe. Default setting is 44,100 frames.
 .TP
 \fB"STDOUT" SETTINGS\f1
 These settings are for the STDOUT backend, used to route audio to standard output ("stdout"). The audio is in raw CD audio format: PCM 16 bit little endian, 44,100 samples per second, stereo.
@@ -194,10 +197,10 @@ There are two settings affecting timing that might be useful if the stdout reade
 These are the settings available within the \fBstdout\f1 group:
 .TP
 \fBaudio_backend_latency_offset=\f1\fIoffset_in_frames\f1\fB;\f1
-Packets of audio frames are written to stdout synchronously -- that is, they are written at exactly the time they should be played. You can offset the time of initial audio output relative to its nominal time using this setting. For example to send an audio stream to stdout 100 milliseconds before it is due to be played, set this to -4410. Default setting is 0. 
+Packets of audio frames are written to stdout synchronously -- that is, they are written at exactly the time they should be played. You can offset the time of initial audio output relative to its nominal time using this setting. For example to send an audio stream to stdout 100 milliseconds before it is due to be played, set this to -4410. Default setting is 0.
 .TP
 \fBaudio_backend_buffer_desired_length=\f1\fIbuffer_length_in_frames\f1\fB;\f1
-Use this setting, in frames, to set the size of the output buffer. It works by determining how soon the second and subsequent packets of audio frames are sent to stdout. For example, if you send the first packet of audio exactly when it is due and, using a \fIaudio_backend_buffer_desired_length\f1 setting of 44100, send subsequent packets of audio a second before they are due to be played, they will be buffered in the stdout reader's buffer, giving it a nominal buffer size of 44,100 frames. Note that if the stdout reader consumes audio packets faster or slower than they are supplied, the buffer will eventually empty or overflow -- shairport-sync performs no stuffing or interpolation when writing to stdout. Default setting is 44,100 frames. 
+Use this setting, in frames, to set the size of the output buffer. It works by determining how soon the second and subsequent packets of audio frames are sent to stdout. For example, if you send the first packet of audio exactly when it is due and, using a \fIaudio_backend_buffer_desired_length\f1 setting of 44100, send subsequent packets of audio a second before they are due to be played, they will be buffered in the stdout reader's buffer, giving it a nominal buffer size of 44,100 frames. Note that if the stdout reader consumes audio packets faster or slower than they are supplied, the buffer will eventually empty or overflow -- shairport-sync performs no stuffing or interpolation when writing to stdout. Default setting is 44,100 frames.
 .SH OPTIONS
 Note: if you are setting up shairport-sync for the first time or are updating an existing installation, you are encouraged to use the configuration file settings described above. Most of the options described below simply replicate the configuration settings and are retained to provide backward compatability with older installations of shairport-sync.
 
@@ -208,29 +211,29 @@ The command line for shairport-sync can take two kinds of options: regular \fBpr
 These options are used by shairport-sync itself.
 .TP
 \fB-a \f1\fIservice name\f1\fB | --name=\f1\fIservice name\f1
-Use this \fIservice name\f1 to identify this player in iTunes, etc. The default name is "Shairport Sync on <hostname>". 
+Use this \fIservice name\f1 to identify this player in iTunes, etc. The default name is "Shairport Sync on <hostname>".
 .TP
 \fB-A | --AirPlayLatency=\f1\fIlatency\f1
-Use this \fIlatency\f1, in frames, for audio streamed from an AirPlay device. The default is 88,200 frames, where there are 44,100 frames to the second. 
+Use this \fIlatency\f1, in frames, for audio streamed from an AirPlay device. The default is 88,200 frames, where there are 44,100 frames to the second.
 .TP
 \fB-B \f1\fIprogram\f1\fB | --on-start=\f1\fIprogram\f1
 Execute \fIprogram\f1 when playback is about to begin. Specify the full path to the program, e.g. \fI/usr/bin/logger\f1. Executable scripts can be used, but they must have \fI#!/bin/sh\f1 (or whatever is appropriate) in the headline.
 
-If you want shairport-sync to wait until the command has completed before starting to play, select the \fB-w\f1 option as well. 
+If you want shairport-sync to wait until the command has completed before starting to play, select the \fB-w\f1 option as well.
 .TP
 \fB-c \f1\fIfilename\f1\fB | --configfile=\f1\fIfilename\f1
-Read configuration settings from \fIfilename\f1. The default is to read them from \fI/etc/shairport-sync.conf\f1. For information about configuration settings, see the "Configuration File Settings" section above. 
+Read configuration settings from \fIfilename\f1. The default is to read them from \fI/etc/shairport-sync.conf\f1. For information about configuration settings, see the "Configuration File Settings" section above.
 .TP
 \fB-D | --disconnectFromOutput\f1
-Disconnect the shairport-sync daemon from the output device and exit. (Requires that the daemon has written its PID to an agreed file -- see the \fB-d\f1 option). 
+Disconnect the shairport-sync daemon from the output device and exit. (Requires that the daemon has written its PID to an agreed file -- see the \fB-d\f1 option).
 .TP
 \fB-d | --daemon\f1
-Instruct shairport-sync to demonise itself. It will write its Process ID (PID) to a file, usually at \fI/var/run/shairport-sync.pid\f1, which is used by the \fB-k\f1, \fB-D\f1 and \fB-R\f1 options to locate the daemon at a later time. 
+Instruct shairport-sync to demonise itself. It will write its Process ID (PID) to a file, usually at \fI/var/run/shairport-sync.pid\f1, which is used by the \fB-k\f1, \fB-D\f1 and \fB-R\f1 options to locate the daemon at a later time.
 .TP
 \fB-E \f1\fIprogram\f1\fB | --on-stop=\f1\fIprogram\f1
 Execute \fIprogram\f1 when playback has ended. Specify the full path to the program, e.g. \fI/usr/bin/logger\f1. Executable scripts can be used, but they must have \fI#!/bin/sh\f1 (or whatever is appropriate) in the headline.
 
-If you want shairport-sync to wait until the command has completed before continuing, select the \fB-w\f1 option as well. 
+If you want shairport-sync to wait until the command has completed before continuing, select the \fB-w\f1 option as well.
 .TP
 \fB-C \f1\fIprogram\f1\fB | --on-vol-change=\f1\fIprogram\f1
 Execute \fIprogram\f1 when the volume of the audio source has changed. Specify the full path to the program, e.g. \fI/usr/bin/logger\f1. Executable scripts can be used, but they must have \fI#!/bin/sh\f1 (or whatever is appropriate) in the headline.
@@ -238,90 +241,90 @@ Execute \fIprogram\f1 when the volume of the audio source has changed. Specify t
 If you want shairport-sync to wait until the command has completed before continuing, select the \fB-w\f1 option as well.
 .TP
 \fB--forkedDaapdLatency=\f1\fIlatency\f1
-Use this \fIlatency\f1, in frames, for audio streamed from a forked-daapd based source. The default is 99,400 frames, where there are 44,100 frames to the second. 
+Use this \fIlatency\f1, in frames, for audio streamed from a forked-daapd based source. The default is 99,400 frames, where there are 44,100 frames to the second.
 .TP
 \fB--get-coverart\f1
 This option requires the \fB--meta-dir\f1 option to be set, and enables shairport-sync to request cover art from the source and to transmit it through the metadata pipe.
 
-Please note that cover art data may be very large, and may place too great a burden on your network. 
+Please note that cover art data may be very large, and may place too great a burden on your network.
 .TP
 \fB-h | --help\f1
-Print brief help message and exit. 
+Print brief help message and exit.
 .TP
 \fB-i | --iTunesLatency=\f1\fIlatency\f1
-Use this \fIlatency\f1, in frames, for audio streamed from an iTunes source, where iTunes is Version 10 or later. The default is 99,400 frames, where there are 44,100 frames to the second. If the source is iTunes but is earler than Version 10, the \fIdefault latency\f1 is used (see the \fB-L\f1 option). Some third party programs masquerade as older versions of iTunes. 
+Use this \fIlatency\f1, in frames, for audio streamed from an iTunes source, where iTunes is Version 10 or later. The default is 99,400 frames, where there are 44,100 frames to the second. If the source is iTunes but is earler than Version 10, the \fIdefault latency\f1 is used (see the \fB-L\f1 option). Some third party programs masquerade as older versions of iTunes.
 .TP
 \fB-k | --kill\f1
-Kill the shairport-sync daemon and exit. (Requires that the daemon has written its PID to an agreed file -- see the \fB-d\f1 option). 
+Kill the shairport-sync daemon and exit. (Requires that the daemon has written its PID to an agreed file -- see the \fB-d\f1 option).
 .TP
 \fB-L | --latency=\f1\fIlatency\f1
-Use this to set the \fIdefault latency\f1, in frames, for audio coming from an unidentified source or from an iTunes Version 9 or earlier source. The standard value for the \fIdefault latency\f1 is 88,200 frames, where there are 44,100 frames to the second. 
+Use this to set the \fIdefault latency\f1, in frames, for audio coming from an unidentified source or from an iTunes Version 9 or earlier source. The standard value for the \fIdefault latency\f1 is 88,200 frames, where there are 44,100 frames to the second.
 .TP
 \fB--meta-dir=\f1\fIdirectory\f1
-Listen for metadata coming from the source and send it, along with metadata from shairport-sync itself, to a pipe called \fIshairport-sync-metadata\f1 in the \fIdirectory\f1 you specify. If you add the \fB--get-cover-art\f1 then cover art will be sent through the pipe too. See \fBhttps://github.com/mikebrady/shairport-sync-metadata-reader\f1 for a sample metadata reader. 
+Listen for metadata coming from the source and send it, along with metadata from shairport-sync itself, to a pipe called \fIshairport-sync-metadata\f1 in the \fIdirectory\f1 you specify. If you add the \fB--get-cover-art\f1 then cover art will be sent through the pipe too. See \fBhttps://github.com/mikebrady/shairport-sync-metadata-reader\f1 for a sample metadata reader.
 .TP
 \fB-m \f1\fImdnsbackend\f1\fB | --mdns=\f1\fImdnsbackend\f1
-Force the use of the specified mDNS backend to advertise the player on the network. The default is to try all mDNS backends until one works. 
+Force the use of the specified mDNS backend to advertise the player on the network. The default is to try all mDNS backends until one works.
 .TP
 \fB-o \f1\fIoutputbackend\f1\fB | --output=\f1\fIoutputbackend\f1
-Force the use of the specified output backend to play the audio. The default is to try the first one. (This is not used at present.) 
+Force the use of the specified output backend to play the audio. The default is to try the first one. (This is not used at present.)
 .TP
 \fB-p \f1\fIport\f1\fB | --port=\f1\fIport\f1
-Listen for play requests on \fIport\f1. The default is to use port 5000. 
+Listen for play requests on \fIport\f1. The default is to use port 5000.
 .TP
 \fB--password=\f1\fIsecret\f1
-Require the password \fIsecret\f1 to be able to connect and stream to the service. 
+Require the password \fIsecret\f1 to be able to connect and stream to the service.
 .TP
 \fB-R | --reconnectToOutput\f1
-Reconnect the shairport-sync daemon to the output device and exit. It may take a few seconds to synchronise. (Requires that the daemon has written its PID to an agreed file -- see the \fB-d\f1 option). 
+Reconnect the shairport-sync daemon to the output device and exit. It may take a few seconds to synchronise. (Requires that the daemon has written its PID to an agreed file -- see the \fB-d\f1 option).
 .TP
 \fB-r \f1\fIthreshold\f1\fB | --resync=\f1\fIthreshold\f1
-Resynchronise if timings differ by more than \fIthreshold\f1 frames. If the output timing differs from the source timing by more than the threshold, output will be muted and a full resynchronisation will occur. The default threshold is 2,205 frames, i.e. 50 milliseconds. Specify \fB0\f1 to disable resynchronisation. 
+Resynchronise if timings differ by more than \fIthreshold\f1 frames. If the output timing differs from the source timing by more than the threshold, output will be muted and a full resynchronisation will occur. The default threshold is 2,205 frames, i.e. 50 milliseconds. Specify \fB0\f1 to disable resynchronisation.
 .TP
 \fB--statistics\f1
-Print some statistics in the standard output, or in the logfile if in daemon mode. 
+Print some statistics in the standard output, or in the logfile if in daemon mode.
 .TP
 \fB-S \f1\fImode\f1\fB | --stuffing=\f1\fImode\f1
-Stuff the audio stream using the \fImode\f1. "Stuffing" refers to the process of adding or removing frames of audio to or from the stream sent to the output device to keep it exactly in synchrony with the player. The default mode, \fBbasic\f1, is normally almost completely inaudible. The alternative mode, \fBsoxr\f1, is even less obtrusive but requires much more processing power. For this mode, support for libsoxr, the SoX Resampler Library, must be selected when shairport-sync is compiled. 
+Stuff the audio stream using the \fImode\f1. "Stuffing" refers to the process of adding or removing frames of audio to or from the stream sent to the output device to keep it exactly in synchrony with the player. The default mode, \fBbasic\f1, is normally almost completely inaudible. The alternative mode, \fBsoxr\f1, is even less obtrusive but requires much more processing power. For this mode, support for libsoxr, the SoX Resampler Library, must be selected when shairport-sync is compiled.
 .TP
 \fB-t \f1\fItimeout\f1\fB | --timeout=\f1\fItimeout\f1
 Exit play mode if the stream disappears for more than \fItimeout\f1 seconds.
 
-When shairport-sync plays an audio stream, it starts a play session and will return a busy signal to any other sources that attempt to use it. If the audio stream disappears for longer than \fItimeout\f1 seconds, the play session will be terminated. If you specify a timeout time of \fB0\f1, shairport-sync will never signal that it is busy and will not prevent other sources from "barging in" on an existing play session. The default value is 120 seconds. 
+When shairport-sync plays an audio stream, it starts a play session and will return a busy signal to any other sources that attempt to use it. If the audio stream disappears for longer than \fItimeout\f1 seconds, the play session will be terminated. If you specify a timeout time of \fB0\f1, shairport-sync will never signal that it is busy and will not prevent other sources from "barging in" on an existing play session. The default value is 120 seconds.
 .TP
 \fB--tolerance=\f1\fIframes\f1
-Allow playback to be up to \fIframes\f1 out of exact synchronization before attempting to correct it. The default is 88 frames, i.e. 2 ms. The smaller the tolerance, the more likely it is that overcorrection will occur. Overcorrection is when more corrections (insertions and deletions) are made than are strictly necessary to keep the stream in sync. Use the \fB--statistics\f1 option to monitor correction levels. Corrections should not greatly exceed net corrections. 
+Allow playback to be up to \fIframes\f1 out of exact synchronization before attempting to correct it. The default is 88 frames, i.e. 2 ms. The smaller the tolerance, the more likely it is that overcorrection will occur. Overcorrection is when more corrections (insertions and deletions) are made than are strictly necessary to keep the stream in sync. Use the \fB--statistics\f1 option to monitor correction levels. Corrections should not greatly exceed net corrections.
 .TP
 \fB-V | --version\f1
-Print version information and exit. 
+Print version information and exit.
 .TP
 \fB-v | --verbose\f1
-Print debug information. Repeat up to three times to get more detail. 
+Print debug information. Repeat up to three times to get more detail.
 .TP
 \fB-w | --wait-cmd\f1
-Wait for commands specified using \fB-B\f1 or \fB-E\f1 to complete before continuing execution. 
+Wait for commands specified using \fB-B\f1 or \fB-E\f1 to complete before continuing execution.
 .SH AUDIO BACKEND OPTIONS
 These options are passed to the chosen audio backend. (At present, the only backend implemented is for ALSA.) The audio backend options are preceded by a \fB--\f1 symbol to introduce them and to separate them from any program options. In this way, option letters can be used as program options and also as audio backend options without ambiguity.
 
 In the ALSA backend, audio is sent to an output device which you can specify using the \fB-d\f1 option. The output level (the "volume") is controlled using a level control associated with a mixer. By default, the mixer is implemented in shairport-sync itself, i.e. the type of the mixer is "software". To use a level control on a mixer on the sound card, you must (a) specify that the mixer's type is "hardware" with the \fB-t\f1 option; (b) you must specify where the mixer is to be found using the \fB-m\f1 option and finally (c) you must specify the name of the level control you are using with the \fB-c\f1 option.
 .TP
 \fB-c \f1\fIcontrolname\f1
-Use the level control called \fIcontrolname\f1 on the hardware mixer for controlling volume. This is needed if the mixer type is specified, using the \fB-t\f1 option, to be \fBhardware\f1. There is no default. 
+Use the level control called \fIcontrolname\f1 on the hardware mixer for controlling volume. This is needed if the mixer type is specified, using the \fB-t\f1 option, to be \fBhardware\f1. There is no default.
 .TP
 \fB-d \f1\fIdevice\f1
-Use the specified output \fIdevice\f1. You may specify a card, e.g. \fBhw:0\f1, in which case the default output device on the card will be chosen. Alternatively, you can specify a specific device on a card, e.g. \fBhw:0,0\f1. The default is the device named \fBdefault\f1. 
+Use the specified output \fIdevice\f1. You may specify a card, e.g. \fBhw:0\f1, in which case the default output device on the card will be chosen. Alternatively, you can specify a specific device on a card, e.g. \fBhw:0,0\f1. The default is the device named \fBdefault\f1.
 .TP
 \fB-m \f1\fImixer\f1
-Use the specified hardware \fImixer\f1 for volume control. Use this to specify where the mixer is to be found. For example, if the mixer is associated with a card, as is often the case, specify the card, e.g. \fBhw:0\f1. If (unusually) the mixer is associated with a specific device on a card, specify the device, e.g. \fBhw:0,1\f1. The default is the device named in the \fB-d\f1 option, if given, or the device named \fBdefault\f1. 
+Use the specified hardware \fImixer\f1 for volume control. Use this to specify where the mixer is to be found. For example, if the mixer is associated with a card, as is often the case, specify the card, e.g. \fBhw:0\f1. If (unusually) the mixer is associated with a specific device on a card, specify the device, e.g. \fBhw:0,1\f1. The default is the device named in the \fB-d\f1 option, if given, or the device named \fBdefault\f1.
 .TP
 \fB-t \f1\fIdevicetype\f1
-This option is deprecated and is ignored. For your information, its functionality has been automatically incorporated in the -c option -- if you specify a mixer name with the -c option, it is assumed that the mixer is implemented in hardware. 
+This option is deprecated and is ignored. For your information, its functionality has been automatically incorporated in the -c option -- if you specify a mixer name with the -c option, it is assumed that the mixer is implemented in hardware.
 .SH EXAMPLES
 Here is a slightly contrived but typical example:
 
 shairport-sync \fB-d\f1 \fB-a "Joe's Stereo"\f1 \fB-S soxr\f1 \fB--\f1 \fB-d hw:1,0\f1 \fB-m hw:1\f1 \fB-c PCM\f1
 
-The program will run in daemon mode ( \fB-d\f1 ), will be visible as "Joe's Stereo" ( \fB-a "Joe's Stereo"\f1 ) and will use the SoX Resampler Library-based stuffing ( \fB-S soxr\f1 ). The audio backend options following the \fB--\f1 separator specify that the audio will be output on output 0 of soundcard 1 ( \fB-d hw:1,0\f1 ) and will take advantage of the same sound card's mixer ( \fB-m hw:1\f1 ) using the level control named "PCM" ( \fB-c "PCM"\f1 ). 
+The program will run in daemon mode ( \fB-d\f1 ), will be visible as "Joe's Stereo" ( \fB-a "Joe's Stereo"\f1 ) and will use the SoX Resampler Library-based stuffing ( \fB-S soxr\f1 ). The audio backend options following the \fB--\f1 separator specify that the audio will be output on output 0 of soundcard 1 ( \fB-d hw:1,0\f1 ) and will take advantage of the same sound card's mixer ( \fB-m hw:1\f1 ) using the level control named "PCM" ( \fB-c "PCM"\f1 ).
 
 The example above is slightly contrived in order to show the use of the \fB-m\f1 option. Typically, output 0 is the default output of a card, so the output device could be written \fB-d hw:1\f1 and then the mixer option would be unnecessary, giving the following, simpler, command:
 

--- a/man/shairport-sync.7.xml
+++ b/man/shairport-sync.7.xml
@@ -461,6 +461,18 @@
 		</p></optdesc>
 	  </option>
 
+    <option>
+		<p><opt>-C </opt><arg>program</arg><opt> | --on-vol-change=</opt><arg>program</arg></p>
+		<optdesc><p>
+		Execute <arg>program</arg> when the volume of the audio source has changed.
+    Specify the full path to the program, e.g. <file>/usr/bin/logger</file>.
+		Executable scripts can be used, but they must have <file>#!/bin/sh</file> (or
+		whatever is appropriate) in the headline.</p>
+		<p>If you want shairport-sync to wait until the command has
+		completed before continuing, select the <opt>-w</opt> option as well.
+		</p></optdesc>
+	  </option>
+
 	  <option>
 		<p><opt>--forkedDaapdLatency=</opt><arg>latency</arg></p>
 		<optdesc><p>

--- a/man/shairport-sync.7.xml
+++ b/man/shairport-sync.7.xml
@@ -7,7 +7,7 @@
   Copyright (c) Mike Brady 2014-2015
 
   All rights reserved.
- 
+
   Permission is hereby granted, free of charge, to any person
   obtaining a copy of this software and associated documentation
   files (the "Software"), to deal in the Software without
@@ -15,10 +15,10 @@
   copy, modify, merge, publish, distribute, sublicense, and/or
   sell copies of the Software, and to permit persons to whom the
   Software is furnished to do so, subject to the following conditions:
- 
+
   The above copyright notice and this permission notice shall be
   included in all copies or substantial portions of the Software.
- 
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
   OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -41,6 +41,7 @@
       <opt>[-B </opt><arg>command</arg><opt>]</opt>
       <opt>[-c </opt><arg>configurationfile</arg><opt>]</opt>
       <opt>[-E </opt><arg>command</arg><opt>]</opt>
+      <opt>[-C </opt><arg>command</arg><opt>]</opt>
       <opt>[--forkedDaapdLatency=</opt><arg>latency</arg><opt>]</opt>
       <opt>[--get-cover-art]</opt>
       <opt>[-i </opt><arg>latency</arg><opt>]</opt>
@@ -74,22 +75,22 @@
     This allows multiple devices play the same source without getting out of phase with one another,
     enabling, for example, simultaneous multi-room operation.
     </p>
-    
+
     <p>shairport-sync can additionally be compiled and configured to stream raw audio to a pipe or to stdout.</p>
-    
+
     <p>Settings can be made using the configuration file (recommended for all new installations) or by using command-line options.</p>
- 
+
 	</description>
-	
+
 	<section name="Configuration File Settings">
 	   <p>You should use the configuration file for setting up shairport-sync.
 	  This file is normally <file>/etc/shairport-sync.conf</file>.
 	  You may need to have root privileges to modify it.</p>
-	  
+
 	  <p>Settings are organised into <i>groups</i>, for example, there is a "general" group of
 	  standard settings, and there is an "alsa" group with settings that pertain to the ALSA
 	  back end. Here is an example of a typical configuration file:</p>
-	  
+
 	  <p><opt>general = {</opt></p>
     <p><p><opt>name = "Mike's Boombox";</opt></p></p>
     <p><p><opt>interpolation = "soxr";</opt></p></p>
@@ -100,12 +101,12 @@
     <p><p><opt>output_device = "hw:0";</opt></p></p>
     <p><p><opt>mixer_control_name = "PCM";</opt></p></p>
     <p><opt>};</opt></p>
-	  
+
 	  <p>Most settings have sensible default values, so -- as in the example above -- users generally only need to set (1) the service name, (2) a password (if desired) and
 	  (3) the output device. If the output device has a mixer that can be used for volume control, then (4) the volume control's name should be specificed. It is highly desirable to use the output device's mixer for volume control, if available -- response time is reduced to zero and the processor load is reduced. In the example above, "soxr" interpolation was also enabled.</p>
-	  
+
 	  <p>A sample configuration file with all possible settings, but with all of them commented out, is installed at <file>/etc/shairport-sync.conf.sample</file>.</p>
-	  
+
 	  <p>To retain backwards compatability with previous versions of shairport-sync
 	  you can use still use command line options, but any new features, etc. will
 	  be available only via configuration file settings.</p>
@@ -123,7 +124,7 @@
     The default name is "Shairport Sync on &lt;hostname&gt;".
     </optdesc>
 	  </option>
-	  
+
 	  <option>
     <p><opt>password=</opt><arg>"password"</arg><opt>;</opt></p>
     <optdesc>Require the password <arg>password</arg> to connect to the service. If you leave this setting commented out, no password is needed.</optdesc>
@@ -141,7 +142,7 @@
     shairport-sync is compiled.
 		</optdesc>
     </option>
-    
+
     <option>
     <p><opt>statistics=</opt><arg>"setting"</arg><opt>;</opt></p>
     <optdesc>Use this <arg>setting</arg> to enable ("yes") or disable ("no") the output of some statistical information on the console or in the log. The default is to disable statistics.</optdesc>
@@ -238,11 +239,11 @@
     <p><opt>pipe_name=</opt><arg>"filepathname"</arg><opt>;</opt></p>
     <optdesc>Specify the absolute path name of the pipe through which metadata should be sent The default is <file>/tmp/shairport-sync-metadata</file>".</optdesc>
     </option>
-    
+
     <option><p><opt>"SESSIONCONTROL" SETTINGS</opt></p></option>
-    <p>shairport-sync can run programs just before it starts to play an audio stream and just after it finishes.
-    You specify them using the settings <opt>run_this_before_play_begins</opt> and <opt>run_this_after_play_ends</opt>. </p>
-    
+    <p>shairport-sync can run programs just before it starts to play an audio stream and just after it finishes or when the audio source changes it's volume.
+    You specify them using the settings <opt>run_this_before_play_begins</opt>, <opt>run_this_after_play_ends</opt> and <opt>run_this_on_volume_change</opt>. </p>
+
     <option>
     <p><opt>run_this_before_play_begins=</opt><arg>"/path/to/application and args"</arg><opt>;</opt></p>
     <optdesc>Here you can specify a program and its arguments that will be run just before a play session begins. Be careful to include the full path to the application.
@@ -254,9 +255,15 @@
     The application must be marked as executable and, if it is a script, its first line must begin with the standard <file>#!/bin/...</file> as appropriate.</optdesc>
     </option>
     <option>
+    <p><opt>run_this_on_volume_change=</opt><arg>"/path/to/application"</arg><opt>;</opt></p>
+    <optdesc>Here you can specify a program that will be run when the audio source changes the volume. Be careful to include the full path to the application.
+    The application must be marked as executable and, if it is a script, its first line must begin with the standard <file>#!/bin/...</file> as appropriate.
+    There are no user specified arguments allowed for the program. Only the current volume will be passed as the first parameter to the program.</optdesc>
+    </option>
+    <option>
     <p><opt>wait_for_completion=</opt><arg>"choice"</arg><opt>;</opt></p>
-    <optdesc>Set <arg>choice</arg> to "yes" to make shairport-sync wait until the programs specified in the <opt>run_this_before_play_begins</opt>
-    and <opt>run_this_after_play_ends</opt> have completed execution before continuing. The default is "no".</optdesc>
+    <optdesc>Set <arg>choice</arg> to "yes" to make shairport-sync wait until the programs specified in the <opt>run_this_before_play_begins</opt>, <opt>run_this_after_play_ends</opt>
+    and <opt>run_this_on_volume_change</opt> have completed execution before continuing. The default is "no".</optdesc>
     </option>
     <option>
     <p><opt>allow_session_interruption=</opt><arg>"choice"</arg><opt>;</opt></p>
@@ -269,7 +276,7 @@
     then wait for <arg>seconds</arg> seconds before ending the session. Once the session has terminated, other devices can use it.
     The default is 120 seconds.</optdesc>
     </option>
-    
+
     <option><p><opt>"ALSA" SETTINGS</opt></p></option>
     <p>These settings are for the ALSA back end, used to communicate with audio output devices in the ALSA system.
     (By the way, you can use tools such as <opt>alsamixer</opt> or <opt>aplay</opt> to discover what devices are available.)
@@ -308,7 +315,7 @@
     or it may exceed the hardware buffer size.
     It may need to be larger on low-powered machines that are also performing other tasks, such as processing metadata.</optdesc>
     </option>
-    
+
     <option><p><opt>"PIPE" SETTINGS</opt></p></option>
     <p>These settings are for the PIPE backend, used to route audio to a named unix pipe. The audio is in raw CD audio format: PCM 16 bit little endian, 44,100 samples per second,
     stereo.</p>
@@ -332,10 +339,10 @@
     You can offset the time of initial audio output relative to its nominal time using this setting.
     For example to send an audio stream to the pipe 100 milliseconds before it is due to be played, set this to -4410. Default setting is 0.</optdesc>
     </option>
-    
+
     <option>
     <p><opt>audio_backend_buffer_desired_length=</opt><arg>buffer_length_in_frames</arg><opt>;</opt></p>
-    <optdesc>    
+    <optdesc>
     Use this setting, in frames, to set the size of the output buffer. It works by determining how soon the second and subsequent packets of audio frames are sent to the pipe.
     For example, if you send the first packet of audio exactly when it is due and, using a <arg>audio_backend_buffer_desired_length</arg> setting of 44100,
     send subsequent packets of audio a second before they are due to be played, they will be buffered in the pipe reader's buffer, giving it a nominal buffer size of 44,100 frames.
@@ -343,7 +350,7 @@
     shairport-sync performs no stuffing or interpolation when writing to a pipe. Default setting is 44,100 frames.
     </optdesc>
     </option>
-     
+
     <option><p><opt>"STDOUT" SETTINGS</opt></p></option>
     <p>These settings are for the STDOUT backend, used to route audio to standard output ("stdout").
     The audio is in raw CD audio format: PCM 16 bit little endian, 44,100 samples per second, stereo.</p>
@@ -359,10 +366,10 @@
     You can offset the time of initial audio output relative to its nominal time using this setting.
     For example to send an audio stream to stdout 100 milliseconds before it is due to be played, set this to -4410. Default setting is 0.</optdesc>
     </option>
-    
+
     <option>
     <p><opt>audio_backend_buffer_desired_length=</opt><arg>buffer_length_in_frames</arg><opt>;</opt></p>
-    <optdesc>    
+    <optdesc>
     Use this setting, in frames, to set the size of the output buffer. It works by determining how soon the second and subsequent packets of audio frames are sent to stdout.
     For example, if you send the first packet of audio exactly when it is due and, using a <arg>audio_backend_buffer_desired_length</arg> setting of 44100,
     send subsequent packets of audio a second before they are due to be played, they will be buffered in the stdout reader's buffer, giving it a nominal buffer size of 44,100 frames.
@@ -370,7 +377,7 @@
     shairport-sync performs no stuffing or interpolation when writing to stdout. Default setting is 44,100 frames.
     </optdesc>
     </option>
-     
+
 	</section>
 
 	<options>
@@ -378,7 +385,7 @@
     <p>Note: if you are setting up shairport-sync for the first time or are updating an existing installation,
     you are encouraged to use the configuration file settings described above. Most of the options described below
     simply replicate the configuration settings and are retained to provide backward compatability with older installations of shairport-sync.</p>
-    
+
     <p>Many  of  the options take sensible default values, so you can normally
     ignore most of them. See the EXAMPLES section for typical usages.</p>
 
@@ -387,11 +394,11 @@
     Program options are
     always listed first, followed by any audio backend options, preceded by
     a <opt>--</opt> symbol.</p>
-    
+
   <section name="Program Options">
   <p>These options are used by shairport-sync itself.</p>
   </section>
-  
+
 	  <option>
 		<p><opt>-a </opt><arg>service name</arg><opt> | --name=</opt><arg>service name</arg></p>
 		<optdesc><p>
@@ -412,11 +419,11 @@
 	  <option>
 		<p><opt>-B </opt><arg>program</arg><opt> | --on-start=</opt><arg>program</arg></p>
 		<optdesc><p>
-		Execute <arg>program</arg> when playback is about to begin. Specify the 
+		Execute <arg>program</arg> when playback is about to begin. Specify the
 		full path to the program, e.g. <file>/usr/bin/logger</file>.
 		Executable scripts can be used, but they must have <file>#!/bin/sh</file> (or
 		whatever is appropriate) in the headline.</p>
-		
+
 		<p>If you want shairport-sync to wait until the command has
 		completed before starting to play, select the <opt>-w</opt> option as well.
 		</p></optdesc>
@@ -452,10 +459,10 @@
 	  <option>
 		<p><opt>-E </opt><arg>program</arg><opt> | --on-stop=</opt><arg>program</arg></p>
 		<optdesc><p>
-		Execute <arg>program</arg> when playback has ended. Specify the 
+		Execute <arg>program</arg> when playback has ended. Specify the
 		full path to the program, e.g. <file>/usr/bin/logger</file>.
 		Executable scripts can be used, but they must have <file>#!/bin/sh</file> (or
-		whatever is appropriate) in the headline.</p>		
+		whatever is appropriate) in the headline.</p>
 		<p>If you want shairport-sync to wait until the command has
 		completed before continuing, select the <opt>-w</opt> option as well.
 		</p></optdesc>
@@ -481,7 +488,7 @@
     frames to the second.
     </p></optdesc>
 	  </option>
-	  
+
 	  <option>
 		<p><opt>--get-coverart</opt></p>
 		<optdesc><p>
@@ -677,7 +684,7 @@
   and finally (c) you must specify the name of the level control you are using
   with the <opt>-c</opt> option.</p>
   </section>
-  
+
   <option>
   <p><opt>-c </opt><arg>controlname</arg></p>
   <optdesc><p>
@@ -729,7 +736,7 @@
       <opt>--</opt>
       <opt>-d hw:1,0</opt>
       <opt>-m hw:1</opt>
-      <opt>-c PCM</opt>      
+      <opt>-c PCM</opt>
       </cmd>
   <p>The program will run in daemon mode ( <opt>-d</opt> ), will be  visible  as
   "Joe's Stereo" ( <opt>-a "Joe's Stereo"</opt> ) and will use the SoX Resampler
@@ -748,9 +755,9 @@
       <opt>-S soxr</opt>
       <opt>--</opt>
       <opt>-d hw:1</opt>
-      <opt>-c PCM</opt>      
+      <opt>-c PCM</opt>
       </cmd>
- 
+
   </section>
 
 	<section name="Credits">

--- a/man/shairport-sync.html
+++ b/man/shairport-sync.html
@@ -5,13 +5,14 @@
 
 	<h2>Synopsis</h2>
 <b>
-	
+
       shairport-sync  <b>[-dvw]</b>
       <b>[-a </b><em>name</em><b>]</b>
       <b>[-A </b><em>latency</em><b>]</b>
       <b>[-B </b><em>command</em><b>]</b>
       <b>[-c </b><em>configurationfile</em><b>]</b>
       <b>[-E </b><em>command</em><b>]</b>
+			<b>[-C </b><em>command</em><b>]</b>
       <b>[--forkedDaapdLatency=</b><em>latency</em><b>]</b>
       <b>[--get-cover-art]</b>
       <b>[-i </b><em>latency</em><b>]</b>
@@ -54,24 +55,24 @@
     This allows multiple devices play the same source without getting out of phase with one another,
     enabling, for example, simultaneous multi-room operation.
     </p>
-    
-    <p>shairport-sync can additionally be compiled and configured to stream raw audio to a pipe or to stdout.</p>
-    
-    <p>Settings can be made using the configuration file (recommended for all new installations) or by using command-line options.</p>
- 
-	
 
-	
+    <p>shairport-sync can additionally be compiled and configured to stream raw audio to a pipe or to stdout.</p>
+
+    <p>Settings can be made using the configuration file (recommended for all new installations) or by using command-line options.</p>
+
+
+
+
 	<h2>Configuration File Settings</h2>
 
 	   <p>You should use the configuration file for setting up shairport-sync.
 	  This file is normally <em>/etc/shairport-sync.conf</em>.
 	  You may need to have root privileges to modify it.</p>
-	  
+
 	  <p>Settings are organised into groups, for example, there is a &quot;general&quot; group of
 	  standard settings, and there is an &quot;alsa&quot; group with settings that pertain to the ALSA
 	  back end. Here is an example of a typical configuration file:</p>
-	  
+
 	  <p><b>general = {</b></p>
     <p><p><b>name = &quot;Mike's Boombox&quot;;</b></p></p>
     <p><p><b>interpolation = &quot;soxr&quot;;</b></p></p>
@@ -82,12 +83,12 @@
     <p><p><b>output_device = &quot;hw:0&quot;;</b></p></p>
     <p><p><b>mixer_control_name = &quot;PCM&quot;;</b></p></p>
     <p><b>};</b></p>
-	  
+
 	  <p>Most settings have sensible default values, so -- as in the example above -- users generally only need to set (1) the service name, (2) a password (if desired) and
 	  (3) the output device. If the output device has a mixer that can be used for volume control, then (4) the volume control's name should be specificed. It is highly desirable to use the output device's mixer for volume control, if available -- response time is reduced to zero and the processor load is reduced. In the example above, &quot;soxr&quot; interpolation was also enabled.</p>
-	  
+
 	  <p>A sample configuration file with all possible settings, but with all of them commented out, is installed at <em>/etc/shairport-sync.conf.sample</em>.</p>
-	  
+
 	  <p>To retain backwards compatability with previous versions of shairport-sync
 	  you can use still use command line options, but any new features, etc. will
 	  be available only via configuration file settings.</p>
@@ -98,19 +99,19 @@
     <p><b>&quot;GENERAL&quot; SETTINGS</b></p>
     <p>These are the settings available within the <b>general</b> group:</p>
 
-    
+
 		<p><b>name=</b><em>&quot;service_name&quot;</em><b>;</b></p>
-		
+
 		Use this <em>service_name</em> to identify this player in iTunes, etc.
     The default name is &quot;Shairport Sync on &lt;hostname&gt;&quot;.
-    
-	  
-	  
-	  
+
+
+
+
     <p><b>password=</b><em>&quot;password&quot;</em><b>;</b></p>
     Require the password <em>password</em> to connect to the service. If you leave this setting commented out, no password is needed.
-    
-    
+
+
     <p><b>interpolation=</b><em>&quot;mode&quot;</em><b>;</b></p>
     Interpolate, or &quot;stuff&quot;, the audio stream using the <em>mode</em>.  Interpolation here refers to the
     process of adding or removing frames of audio  to  or  from  the
@@ -121,80 +122,80 @@
     requires much more processing power. For this mode, support for
     libsoxr, the SoX Resampler Library, must be selected when
     shairport-sync is compiled.
-		
-    
-    
-    
+
+
+
+
     <p><b>statistics=</b><em>&quot;setting&quot;</em><b>;</b></p>
     Use this <em>setting</em> to enable (&quot;yes&quot;) or disable (&quot;no&quot;) the output of some statistical information on the console or in the log. The default is to disable statistics.
-    
 
-    
+
+
     <p><b>mdns_backend=</b><em>&quot;backend&quot;</em><b>;</b></p>
     shairport-sync has a number of modules of code (&quot;backends&quot;) for interacting with the mDNS service to be used to advertise itself. Normally, the first mDNS backend that works is selected. This setting forces the selection of the specific mDNS <em>backend</em>. The default is &quot;avahi&quot;. Perform the command <b>shairport-sync -h</b> to get a list of available mDNS modules.
-    
-    
+
+
     <p><b>output_backend=</b><em>&quot;backend&quot;</em><b>;</b></p>
     shairport-sync has a number of modules of code (&quot;backends&quot;) through which audio is output. Normally, the first audio backend that works is selected. This setting forces the selection of the specific audio <em>backend</em>. The default is &quot;alsa&quot;. Perform the command <b>shairport-sync -h</b> to get a list of available audio backends. Only the alsa backend supports synchronisation.
-    
-    
+
+
     <p><b>port=</b><em>portnumber</em><b>;</b></p>
     Use this to specify the <em>portnumber</em> shairport-sync uses to listen for service requests from iTunes, etc. The default is port 5000.
-    
-    
+
+
     <p><b>udp_port_base=</b><em>portnumber</em><b>;</b></p>
     When shairport-sync starts to play audio, it establises three UDP connections to the audio source. Use this setting to specify the starting <em>portnumber</em> for these three ports. It will pick the first three unused ports starting from <em>portnumber</em>. The default is port 6001.
-    
-    
+
+
     <p><b>udp_port_range=</b><em>range</em><b>;</b></p>
     Use this in conjunction with the prevous setting to specify the <em>range</em> of ports that can be checked for availability. Only three ports are needed. The default is 100, thus 100 ports will be checked from port 6001 upwards until three are found.
-    
-    
+
+
     <p><b>drift=</b><em>frames</em><b>;</b></p>
     Allow playback to drift up to <em>frames</em> out of exact synchronization before attempting to correct it.
 		The default is 88 frames, i.e. 2 ms. The smaller the tolerance, the more likely it is that overcorrection will occur.
 		Overcorrection is when more corrections (insertions and deletions) are made than are strictly necessary to keep the stream in sync. Use the <b>statistics</b> setting to
 		monitor correction levels. Corrections should not greatly exceed net corrections.
-		
-    
-    
+
+
+
     <p><b>resync_threshold=</b><em>threshold</em><b>;</b></p>
     Resynchronise if timings differ by more than <em>threshold</em> frames.
     If the output timing differs from the source timing by more than
     the threshold, output will be muted and a full resynchronisation
     will occur. The default threshold is 2,205 frames, i.e. 50
     milliseconds. Specify 0 to disable resynchronisation.
-    
-    
+
+
     <p><b>log_verbosity=</b><em>0</em><b>;</b></p>
     Use this to specify how much debugging information should be output or logged. &quot;0&quot; means no debug information, &quot;3&quot; means most debug information. The default is &quot;0&quot;.
-    
-    
+
+
     <p><b>ignore_volume_control=</b><em>&quot;choice&quot;</em><b>;</b></p>
     Set this <em>choice</em> to &quot;yes&quot; if you want the volume to be at 100% no matter what the source's volume control is set to. This might be useful if you want to set the volume on the output device, independently of the setting at the source. The default is &quot;no&quot;.
-    
+
 
     <p><b>&quot;LATENCIES&quot; SETTINGS</b></p>
     <p>There are four default latency settings, chosen automatically. One latency matches the latency used by recent versions of iTunes when playing audio and another matches the latency used by so-called &quot;AirPlay&quot; devices, including iOS devices and iTunes and Quicktime Player when they are playing video. A third latency is used when the audio source is forked-daapd. The fourth latency is the default if no other latency is chosen and is used for older versions of iTunes.</p>
     <p>If you want to change latencies to compensate for a delay in the audio output device (which will have the same effect on all sources), instead of changing these individual latencies, consider using the <b>audio_backend_latency_offset</b> setting in the <b>alsa</b> group (or the appropriate other group if you're not outputing through the alsa backend).</p>
 
 
-    
+
     <p><b>itunes=</b><em>latency</em><b>;</b></p>
     This is the <em>latency</em>, in frames, used for iTunes 10 or later. Default is 99,400.
-    
-    
+
+
     <p><b>airplay=</b><em>latency</em><b>;</b></p>
    This is the <em>latency</em>, in frames, used for AirPlay devices, including iOS devices and iTunes and Quicktime Player when they are playing video. Default is 88,200.
-    
-    
+
+
     <p><b>forkedDaapd=</b><em>latency</em><b>;</b></p>
    This is the <em>latency</em>, in frames, used for forkedDaapd sources. Default is 99,400.
-   
-    
+
+
     <p><b>default=</b><em>latency</em><b>;</b></p>
    This is the <em>latency</em>, in frames, used when the source is unrecognised. Default is 88,200.
-   
+
 
     <p><b>&quot;METADATA&quot; SETTINGS</b></p>
     <p>shairport-sync can process metadata provided by the source, such as Track Number, Album Name, cover art, etc. and can provide additional metadata such as volume level,
@@ -204,93 +205,99 @@
     <p>The <b>metadata</b> group of settings allow you to enable metadata handling and to control certain aspects of it:</p>
 
 
-    
+
     <p><b>enabled=</b><em>&quot;choice&quot;</em><b>;</b></p>
     Set the <em>choice</em> to &quot;yes&quot; to enable shairport-sync to look for metadata from the audio source and to forward it,
     along with metadata generated by shairport-sync itself, to the metadata pipe. The default is &quot;no&quot;.
-    
-    
+
+
     <p><b>include_cover_art=</b><em>&quot;choice&quot;</em><b>;</b></p>
     Set the <em>choice</em> to &quot;yes&quot; to enable shairport-sync to look for cover art from the audio source and to include it in the feed to the metadata pipe.
     You must also enable metadata (see above).
     One reason for not including cover art is that the images can sometimes be very large and may delay transmission of subsequent metadata through the pipe.
     The default is &quot;no&quot;.
-    
-    
+
+
     <p><b>pipe_name=</b><em>&quot;filepathname&quot;</em><b>;</b></p>
     Specify the absolute path name of the pipe through which metadata should be sent The default is <em>/tmp/shairport-sync-metadata</em>&quot;.
-    
-    
+
+
     <p><b>&quot;SESSIONCONTROL&quot; SETTINGS</b></p>
-    <p>shairport-sync can run programs just before it starts to play an audio stream and just after it finishes.
-    You specify them using the settings <b>run_this_before_play_begins</b> and <b>run_this_after_play_ends</b>. </p>
-    
-    
+    <p>shairport-sync can run programs just before it starts to play an audio stream and just after it finishes or when the audio source changes it's volume.
+    You specify them using the settings <b>run_this_before_play_begins</b>, <b>run_this_after_play_ends</b> and <b>run_this_on_volume_change</b>. </p>
+
+
     <p><b>run_this_before_play_begins=</b><em>&quot;/path/to/application and args&quot;</em><b>;</b></p>
     Here you can specify a program and its arguments that will be run just before a play session begins. Be careful to include the full path to the application.
     The application must be marked as executable and, if it is a script, its first line must begin with the standard <em>#!/bin/...</em> as appropriate.
-    
-    
+
+
     <p><b>run_this_after_play_ends=</b><em>&quot;/path/to/application and args&quot;</em><b>;</b></p>
     Here you can specify a program and its arguments that will be run just after a play session ends. Be careful to include the full path to the application.
     The application must be marked as executable and, if it is a script, its first line must begin with the standard <em>#!/bin/...</em> as appropriate.
-    
-    
+
+
+		<p><b>run_this_on_volume_change=</b><em>&quot;/path/to/application&quot;</em><b>;</b></p>
+		Here you can specify a program that will be run when the audio source changes the volume. Be careful to include the full path to the application.
+		The application must be marked as executable and, if it is a script, its first line must begin with the standard <em>#!/bin/...</em> as appropriate.
+		There are no user specified arguments allowed for the program. Only the current volume will be passed as the first parameter to the program.
+
+
     <p><b>wait_for_completion=</b><em>&quot;choice&quot;</em><b>;</b></p>
-    Set <em>choice</em> to &quot;yes&quot; to make shairport-sync wait until the programs specified in the <b>run_this_before_play_begins</b>
-    and <b>run_this_after_play_ends</b> have completed execution before continuing. The default is &quot;no&quot;.
-    
-    
+    Set <em>choice</em> to &quot;yes&quot; to make shairport-sync wait until the programs specified in the <b>run_this_before_play_begins</b>, <b>run_this_after_play_ends</b>
+    and <b>run_this_on_volume_change</b> have completed execution before continuing. The default is &quot;no&quot;.
+
+
     <p><b>allow_session_interruption=</b><em>&quot;choice&quot;</em><b>;</b></p>
     If <b>choice</b> is set to &quot;yes&quot;, then another source will be able to interrupt an existing play session and start a new one.
     When set to &quot;no&quot; (the default), other devices attempting to interrupt a session will fail, receiving a busy signal.
-    
-    
+
+
     <p><b>session_timeout=</b><em>seconds</em><b>;</b></p>
     If a play session has been established and the source disappears without warning (such as a device going out of range of a network)
     then wait for <em>seconds</em> seconds before ending the session. Once the session has terminated, other devices can use it.
     The default is 120 seconds.
-    
-    
+
+
     <p><b>&quot;ALSA&quot; SETTINGS</b></p>
     <p>These settings are for the ALSA back end, used to communicate with audio output devices in the ALSA system.
     (By the way, you can use tools such as <b>alsamixer</b> or <b>aplay</b> to discover what devices are available.)
     Use these settings to select the output device and the mixer control to be used to control the output volume.
     You can additionally set the desired size of the output buffer and you can adjust overall latency. Here are the <b>alsa</b> group settings:</p>
 
-    
+
     <p><b>output_device=</b><em>&quot;output_device&quot;</em><b>;</b></p>
     Use the output device called <em>output_device</em>. The default is the device called &quot;default&quot;.
-    
-    
-    
+
+
+
     <p><b>mixer_control_name=</b><em>&quot;name&quot;</em><b>;</b></p>
     Specify the <em>name</em> of the mixer control to be used by shairport-sync to control the volume.
     The mixer control must be on the mixer device, which by default is the output device.
     If you do not specify a mixer control name, shairport-sync will adjust the volume in software.
-    
+
     <p><b>mixer_type=</b><em>&quot;mixer_type&quot;</em><b>;</b></p>
     This setting is deprecated and is ignored. For your information, its functionality has been automatically incorporated in the mixer_control_name setting
   -- if you specify a mixer name with the mixer_control_name setting, it is assumed that the mixer is implemented in hardware.
-    
-    
+
+
     <p><b>mixer_device=</b><em>&quot;mixer_device&quot;</em><b>;</b></p>
     By default, the mixer is assumed to be output_device. Use this setting to specify a device other than the output device.
-    
-    
+
+
     <p><b>audio_backend_latency_offset=</b><em>offset</em><b>;</b></p>
     Set this <em>offset</em>, in frames, to compensate for a fixed delay in the audio back end.
     For example, if the output device delays by 100 ms, set this to -4410.
-    
-    
+
+
     <p><b>audio_backend_buffer_desired_length=</b><em>length</em><b>;</b></p>
     Use this to set the desired number frames to be in the output device's hardware output buffer.
     The default is 6,615 frames, or 0.15 seconds. If set too small, buffer underflow may occur on low-powered machines.
     If too large, the response times when using software volume control (i.e. when not using a mixer control to control volume) become annoying,
     or it may exceed the hardware buffer size.
     It may need to be larger on low-powered machines that are also performing other tasks, such as processing metadata.
-    
-    
+
+
     <p><b>&quot;PIPE&quot; SETTINGS</b></p>
     <p>These settings are for the PIPE backend, used to route audio to a named unix pipe. The audio is in raw CD audio format: PCM 16 bit little endian, 44,100 samples per second,
     stereo.</p>
@@ -300,32 +307,32 @@
     and the <em>audio_backend_buffer_desired_length</em> setting affects the nominal output buffer size.</p>
     <p>These are the settings available within the <b>pipe</b> group:</p>
 
-    
+
     <p><b>name=</b><em>&quot;/path/to/pipe&quot;</em><b>;</b></p>
     Use this to specify the name and location of the pipe. The pipe will be created and opened when shairport-sync starts up and will be closed upon shutdown.
     Frames of audio will be sent to the pipe in packets of 352 frames and will be discarded if the pipe has not have a reader attached.
     The sender will wait for up to five seconds for a packet to be written before discarding it.
-    
 
-    
+
+
     <p><b>audio_backend_latency_offset=</b><em>offset_in_frames</em><b>;</b></p>
-    
+
     Packets of audio frames are written to the pipe synchronously -- that is, they are written to at exactly the time they should be played.
     You can offset the time of initial audio output relative to its nominal time using this setting.
     For example to send an audio stream to the pipe 100 milliseconds before it is due to be played, set this to -4410. Default setting is 0.
-    
-    
-    
+
+
+
     <p><b>audio_backend_buffer_desired_length=</b><em>buffer_length_in_frames</em><b>;</b></p>
-        
+
     Use this setting, in frames, to set the size of the output buffer. It works by determining how soon the second and subsequent packets of audio frames are sent to the pipe.
     For example, if you send the first packet of audio exactly when it is due and, using a <em>audio_backend_buffer_desired_length</em> setting of 44100,
     send subsequent packets of audio a second before they are due to be played, they will be buffered in the pipe reader's buffer, giving it a nominal buffer size of 44,100 frames.
     Note that if the pipe reader consumes audio packets faster or slower than they are supplied, the buffer will eventually empty or overflow --
     shairport-sync performs no stuffing or interpolation when writing to a pipe. Default setting is 44,100 frames.
-    
-    
-     
+
+
+
     <p><b>&quot;STDOUT&quot; SETTINGS</b></p>
     <p>These settings are for the STDOUT backend, used to route audio to standard output (&quot;stdout&quot;).
     The audio is in raw CD audio format: PCM 16 bit little endian, 44,100 samples per second, stereo.</p>
@@ -334,26 +341,26 @@
     and the <em>audio_backend_buffer_desired_length</em> setting affects the nominal output buffer size.</p>
     <p>These are the settings available within the <b>stdout</b> group:</p>
 
-    
+
     <p><b>audio_backend_latency_offset=</b><em>offset_in_frames</em><b>;</b></p>
-    
+
     Packets of audio frames are written to stdout synchronously -- that is, they are written at exactly the time they should be played.
     You can offset the time of initial audio output relative to its nominal time using this setting.
     For example to send an audio stream to stdout 100 milliseconds before it is due to be played, set this to -4410. Default setting is 0.
-    
-    
-    
+
+
+
     <p><b>audio_backend_buffer_desired_length=</b><em>buffer_length_in_frames</em><b>;</b></p>
-        
+
     Use this setting, in frames, to set the size of the output buffer. It works by determining how soon the second and subsequent packets of audio frames are sent to stdout.
     For example, if you send the first packet of audio exactly when it is due and, using a <em>audio_backend_buffer_desired_length</em> setting of 44100,
     send subsequent packets of audio a second before they are due to be played, they will be buffered in the stdout reader's buffer, giving it a nominal buffer size of 44,100 frames.
     Note that if the stdout reader consumes audio packets faster or slower than they are supplied, the buffer will eventually empty or overflow --
     shairport-sync performs no stuffing or interpolation when writing to stdout. Default setting is 44,100 frames.
-    
-    
-     
-	
+
+
+
+
 
 
 	<h2>Options</h2>
@@ -362,7 +369,7 @@
     <p>Note: if you are setting up shairport-sync for the first time or are updating an existing installation,
     you are encouraged to use the configuration file settings described above. Most of the options described below
     simply replicate the configuration settings and are retained to provide backward compatability with older installations of shairport-sync.</p>
-    
+
     <p>Many  of  the options take sensible default values, so you can normally
     ignore most of them. See the EXAMPLES section for typical usages.</p>
 
@@ -371,60 +378,60 @@
     Program options are
     always listed first, followed by any audio backend options, preceded by
     a <b>--</b> symbol.</p>
-    
+
   <h2>Program Options</h2>
 
   <p>These options are used by shairport-sync itself.</p>
-  
 
-  
-	  
+
+
+
 		<p><b>-a </b><em>service name</em><b> | --name=</b><em>service name</em></p>
 		<p>
 		Use this <em>service name</em> to identify this player in iTunes, etc.
     The default name is &quot;Shairport Sync on &lt;hostname&gt;&quot;.
     </p>
-	  
 
-	  
+
+
 		<p><b>-A | --AirPlayLatency=</b><em>latency</em></p>
 		<p>
 		Use this <em>latency</em>, in frames, for audio streamed from an AirPlay
     device. The default is 88,200 frames, where there are 44,100
     frames to the second.
     </p>
-	  
 
-	  
+
+
 		<p><b>-B </b><em>program</em><b> | --on-start=</b><em>program</em></p>
 		<p>
-		Execute <em>program</em> when playback is about to begin. Specify the 
+		Execute <em>program</em> when playback is about to begin. Specify the
 		full path to the program, e.g. <em>/usr/bin/logger</em>.
 		Executable scripts can be used, but they must have <em>#!/bin/sh</em> (or
 		whatever is appropriate) in the headline.</p>
-		
+
 		<p>If you want shairport-sync to wait until the command has
 		completed before starting to play, select the <b>-w</b> option as well.
 		</p>
-	  
 
-	  
+
+
 		<p><b>-c </b><em>filename</em><b> | --configfile=</b><em>filename</em></p>
 		<p>
 		Read configuration settings from <em>filename</em>. The default is to read them from <em>/etc/shairport-sync.conf</em>. For information about configuration settings, see the  &quot;Configuration File Settings&quot; section above.
     </p>
-	  
 
-	  
+
+
 		<p><b>-D | --disconnectFromOutput</b></p>
 		<p>
 		Disconnect the shairport-sync daemon from the output device and
     exit. (Requires that the daemon has written its PID to an agreed
     file -- see the <b>-d</b> option).
 		</p>
-	  
 
-	  
+
+
 		<p><b>-d | --daemon</b></p>
 		<p>
 		Instruct shairport-sync to demonise itself. It will write its
@@ -433,15 +440,15 @@
     <b>-k</b>, <b>-D</b> and <b>-R</b> options to locate
     the daemon at a later time.
 		</p>
-	  
 
-	  
+
+
 		<p><b>-E </b><em>program</em><b> | --on-stop=</b><em>program</em></p>
 		<p>
-		Execute <em>program</em> when playback has ended. Specify the 
+		Execute <em>program</em> when playback has ended. Specify the
 		full path to the program, e.g. <em>/usr/bin/logger</em>.
 		Executable scripts can be used, but they must have <em>#!/bin/sh</em> (or
-		whatever is appropriate) in the headline.</p>		
+		whatever is appropriate) in the headline.</p>
 		<p>If you want shairport-sync to wait until the command has
 		completed before continuing, select the <b>-w</b> option as well.
 		</p>
@@ -457,18 +464,18 @@
 		<p>If you want shairport-sync to wait until the command has
 		completed before continuing, select the <b>-w</b> option as well.
 		</p>
-	  
 
-	  
+
+
 		<p><b>--forkedDaapdLatency=</b><em>latency</em></p>
 		<p>
 		Use this <em>latency</em>, in frames, for audio streamed from a forked-daapd based
     source. The default is 99,400 frames, where there are 44,100
     frames to the second.
     </p>
-	  
-	  
-	  
+
+
+
 		<p><b>--get-coverart</b></p>
 		<p>
 		This option requires the <b>--meta-dir</b> option to be set, and enables
@@ -477,41 +484,41 @@
 		<p>Please note that cover art data may be very large, and may place too great a
 		burden on your network.
     </p>
-	  
 
-	  
+
+
 		<p><b>-h | --help</b></p>
 		<p>
 		Print brief help message and exit.
 		</p>
-	  
 
-	  
+
+
 		<p><b>-i | --iTunesLatency=</b><em>latency</em></p>
 		<p>
 		Use this <em>latency</em>, in frames, for audio streamed from an iTunes
     source, where iTunes is Version 10 or later. The default is 99,400 frames, where there are 44,100
     frames to the second. If the source is iTunes but is earler than Version 10, the <em>default latency</em> is used (see the <b>-L</b> option). Some third party programs masquerade as older versions of iTunes.
     </p>
-	  
 
-	  
+
+
 		<p><b>-k | --kill</b></p>
 		<p>
 		Kill the shairport-sync daemon and exit. (Requires that the daemon has
 		written its PID to an agreed file -- see the <b>-d</b> option).
 		</p>
-	  
 
-	  
+
+
 		<p><b>-L | --latency=</b><em>latency</em></p>
 		<p>
 		Use this to set the <em>default latency</em>, in frames, for audio coming from an unidentified source or from an iTunes Version 9 or earlier source. The standard value for the <em>default latency</em> is 88,200 frames, where there are 44,100
     frames to the second.
     </p>
-	  
 
-	  
+
+
 		<p><b>--meta-dir=</b><em>directory</em></p>
 		<p>
 		Listen for metadata coming from the source and send it, along with metadata from
@@ -520,42 +527,42 @@
 		cover art will be sent through the pipe too. See <a href = "https://github.com/mikebrady/shairport-sync-metadata-reader">https://github.com/mikebrady/shairport-sync-metadata-reader</a>
 		for a sample metadata reader.
 		</p>
-	  
 
-	  
+
+
 		<p><b>-m </b><em>mdnsbackend</em><b> | --mdns=</b><em>mdnsbackend</em></p>
 		<p>
 		Force the use of the specified mDNS backend to advertise the
     player on the network. The default is to try all mDNS backends until one
     works.
 		</p>
-	  
 
-	  
+
+
 		<p><b>-o </b><em>outputbackend</em><b> | --output=</b><em>outputbackend</em></p>
 		<p>
 		Force the use of the specified output backend to play the audio.
     The default is to try the first one. (This is not used at
     present.)
 		</p>
-	  
 
-	  
+
+
 		<p><b>-p </b><em>port</em><b> | --port=</b><em>port</em></p>
 		<p>
 		Listen for play requests on <em>port</em>. The default is to use port
     5000.
 		</p>
-	  
 
-	  
+
+
 		<p><b>--password=</b><em>secret</em></p>
 		<p>
 		Require the password <em>secret</em> to be able to connect and stream to the service.
 		</p>
-	  
 
-	  
+
+
 		<p><b>-R | --reconnectToOutput</b></p>
 		<p>
 		Reconnect the shairport-sync daemon to the output device and
@@ -563,9 +570,9 @@
     the daemon has written its PID to an agreed file -- see the <b>-d</b>
     option).
 		</p>
-	  
 
-	  
+
+
 		<p><b>-r </b><em>threshold</em><b> | --resync=</b><em>threshold</em></p>
 		<p>
 		Resynchronise if timings differ by more than <em>threshold</em> frames.
@@ -574,16 +581,16 @@
     will occur. The default threshold is 2,205 frames, i.e. 50
     milliseconds. Specify <b>0</b> to disable resynchronisation.
 		</p>
-	  
 
-	  
+
+
 		<p><b>--statistics</b></p>
 		<p>
 		Print some statistics in the standard output, or in the logfile if in daemon mode.
 		</p>
-	  
 
-	  
+
+
 		<p><b>-S </b><em>mode</em><b> | --stuffing=</b><em>mode</em></p>
 		<p>
 		Stuff the audio stream using the <em>mode</em>.  &quot;Stuffing&quot; refers to the
@@ -596,9 +603,9 @@
     libsoxr, the SoX Resampler Library, must be selected when
     shairport-sync is compiled.
 		</p>
-	  
 
-	  
+
+
 		<p><b>-t </b><em>timeout</em><b> | --timeout=</b><em>timeout</em></p>
 		<p>
 		Exit play mode if the stream disappears for  more  than  <em>timeout</em>
@@ -612,9 +619,9 @@
     it is busy and will not prevent other sources from &quot;barging in&quot;
     on an existing play session. The default value is 120 seconds.
 		</p>
-	  
 
-	  
+
+
 		<p><b>--tolerance=</b><em>frames</em></p>
 		<p>
 		Allow playback to be up to <em>frames</em> out of exact synchronization before attempting to correct it.
@@ -622,29 +629,29 @@
 		Overcorrection is when more corrections (insertions and deletions) are made than are strictly necessary to keep the stream in sync. Use the <b>--statistics</b> option to
 		monitor correction levels. Corrections should not greatly exceed net corrections.
 		</p>
-	  
 
-	  
+
+
 		<p><b>-V | --version</b></p>
 		<p>
 		Print version information and exit.
 		</p>
-	  
 
-	  
+
+
 		<p><b>-v | --verbose</b></p>
 		<p>
 		Print debug information. Repeat up to three times to get more detail.
 		</p>
-	  
 
-	  
+
+
 		<p><b>-w | --wait-cmd</b></p>
 		<p>
 		Wait for commands specified using <b>-B</b> or <b>-E</b>  to  complete  before
     continuing execution.
 		</p>
-	  
+
 
   <h2>Audio Backend Options</h2>
 
@@ -663,10 +670,10 @@
   (b) you must specify where the mixer is to be found using the <b>-m</b> option
   and finally (c) you must specify the name of the level control you are using
   with the <b>-c</b> option.</p>
-  
 
-  
-  
+
+
+
   <p><b>-c </b><em>controlname</em></p>
   <p>
   Use the level control called <em>controlname</em> on the hardware mixer for
@@ -674,9 +681,9 @@
   This is needed if the mixer type is specified, using the <b>-t</b> option,
   to be <b>hardware</b>. There is no default.
   </p>
-  
 
-  
+
+
   <p><b>-d </b><em>device</em></p>
   <p>
   Use the specified output <em>device</em>. You may specify a card, e.g. <b>hw:0</b>, in
@@ -684,9 +691,9 @@
   Alternatively, you can specify a specific device on a card, e.g. <b>hw:0,0</b>.
   The default is the device named <b>default</b>.
   </p>
-  
 
-  
+
+
   <p><b>-m </b><em>mixer</em></p>
   <p>
   Use the specified hardware <em>mixer</em> for volume control. Use this to specify where
@@ -697,17 +704,17 @@
   The default is the device named in the <b>-d</b> option,
   if given, or the device named <b>default</b>.
   </p>
-  
 
-  
+
+
   <p><b>-t </b><em>devicetype</em></p>
-  
+
   <p>
   This option is deprecated and is ignored. For your information, its functionality has been automatically incorporated in the -c option
   -- if you specify a mixer name with the -c option, it is assumed that the mixer is implemented in hardware.
   </p>
-  
-	
+
+
 
   <h2>Examples</h2>
 
@@ -718,7 +725,7 @@
       <b>--</b>
       <b>-d hw:1,0</b>
       <b>-m hw:1</b>
-      <b>-c PCM</b>      
+      <b>-c PCM</b>
       <br>
 
   <p>The program will run in daemon mode ( <b>-d</b> ), will be  visible  as
@@ -738,11 +745,11 @@
       <b>-S soxr</b>
       <b>--</b>
       <b>-d hw:1</b>
-      <b>-c PCM</b>      
+      <b>-c PCM</b>
       <br>
 
- 
-  
+
+
 
 
 	<h2>Credits</h2>
@@ -750,13 +757,13 @@
 	<p>Mike Brady developed shairport-sync from the original shairport by James Laird.</p>
 	<p>shairport-sync can be found at  <a href = "https://github.com/mikebrady/shairport-sync.">https://github.com/mikebrady/shairport-sync.</a></p>
   <p>shairport can be found at <a href = "https://github.com/abrasive/shairport.">https://github.com/abrasive/shairport.</a></p>
-	
+
 
 
 	<h2>Comments</h2>
 
 	  <p>This man page was written using <a href="http://masqmail.cx/xml2man/">xml2man</a> by Oliver Kurth.</p>
-	
+
 
 
   </td></tr></table></center>

--- a/man/shairport-sync.html
+++ b/man/shairport-sync.html
@@ -445,6 +445,18 @@
 		<p>If you want shairport-sync to wait until the command has
 		completed before continuing, select the <b>-w</b> option as well.
 		</p>
+
+
+
+		<p><b>-C </b><em>program</em><b> | --on-vol-change=</b><em>program</em></p>
+		<p>
+		Execute <em>program</em> when the volume of the audio source has changed.
+		Specify the full path to the program, e.g. <em>/usr/bin/logger</em>.
+		Executable scripts can be used, but they must have <em>#!/bin/sh</em> (or
+		whatever is appropriate) in the headline.</p>
+		<p>If you want shairport-sync to wait until the command has
+		completed before continuing, select the <b>-w</b> option as well.
+		</p>
 	  
 
 	  

--- a/player.c
+++ b/player.c
@@ -1229,6 +1229,7 @@ void player_volume(double f) {
   software_mixer_volume = linear_volume;
   fix_volume = 65536.0 * software_mixer_volume;
   pthread_mutex_unlock(&vol_mutex);
+  command_volChange(linear_volume);
 #ifdef CONFIG_METADATA
   char *dv = malloc(64); // will be freed in the metadata thread
   if (dv) {

--- a/player.c
+++ b/player.c
@@ -1203,7 +1203,7 @@ void player_volume(double f) {
   // it back to a number.
 
   double scaled_volume = vol2attn(f, 0, -4810);
-  double linear_volume = pow(10, scaled_volume / 1000);
+  double linear_volume = (f + 30.0)/30.0;
 
   if (f == -144.0)
     linear_volume = 0.0;

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -16,7 +16,7 @@ general =
 //	drift = 88; // allow this number of frames of drift away from exact synchronisation before attempting to correct it
 //	resync_threshold = 2205; // a synchronisation error greater than this will cause resynchronisation; 0 disables it
 //	log_verbosity = 0; // "0" means no debug verbosity, "3" is most verbose.
-//  ignore_volume_control = "no"; // set this to "yes" if you want the volume to be at 100% no matter what the source's volume control is set to.
+//	ignore_volume_control = "no"; // set this to "yes" if you want the volume to be at 100% no matter what the source's volume control is set to.
 };
 
 // Latencies for different sources. These have been estimated from listening tests.
@@ -42,6 +42,7 @@ sessioncontrol =
 {
 //	run_this_before_play_begins = "/full/path/to/application and args"; // make sure the application has executable permission. It it's a script, include the #!... stuff on the first line
 //	run_this_after_play_ends = "/full/path/to/application and args"; // make sure the application has executable permission. It it's a script, include the #!... stuff on the first line
+//	run_this_on_volume_change = "/full/path/to/application"; // make sure the application has executable permission. It it's a script, include the #!... stuff on the first line; the application is called with the current volume (0.0 - 1.0) as the first parameter; no other parameters allowed!
 //	wait_for_completion = "no"; // set to "yes" to get Shairport Sync to wait until the "run_this..." applications have terminated before continuing
 //	allow_session_interruption = "no"; // set to "yes" to allow another device to interrupt Shairport Sync while it's playing from an existing audio source
 //	session_timeout = 120; // wait for this number of seconds after a source disappears before terminating the session and becoming available again.

--- a/shairport.c
+++ b/shairport.c
@@ -188,6 +188,7 @@ void usage(char *progname) {
       "                            \"soxr\" option only available if built with soxr support.\n");
   printf("    -B, --on-start=PROGRAM  run PROGRAM when playback is about to begin.\n");
   printf("    -E, --on-stop=PROGRAM   run PROGRAM when playback has ended.\n");
+  printf("    -C, --on-vol-change=PROGRAM run PROGRAM when audio source volume changes.\n");
   printf("                            For -B and -E options, specify the full path to the program, "
          "e.g. /usr/bin/logger.\n");
   printf("                            Executable scripts work, but must have #!/bin/sh (or "
@@ -238,6 +239,7 @@ int parse_options(int argc, char **argv) {
       {"output", 'o', POPT_ARG_STRING, &config.output_name, 0, NULL},
       {"on-start", 'B', POPT_ARG_STRING, &config.cmd_start, 0, NULL},
       {"on-stop", 'E', POPT_ARG_STRING, &config.cmd_stop, 0, NULL},
+      {"on-vol-change", 'C', POPT_ARG_STRING, &config.cmd_volChange, 0, NULL},
       {"wait-cmd", 'w', POPT_ARG_NONE, &config.cmd_blocking, 0, NULL},
       {"mdns", 'm', POPT_ARG_STRING, &config.mdns_name, 0, NULL},
       {"latency", 'L', POPT_ARG_INT, &config.userSuppliedLatency, 0, NULL},
@@ -445,6 +447,10 @@ int parse_options(int argc, char **argv) {
 
       if (config_lookup_string(config.cfg, "sessioncontrol.run_this_after_play_ends", &str)) {
         config.cmd_stop = (char *)str;
+      }
+
+      if (config_lookup_string(config.cfg, "sessioncontrol.run_this_on_volume_change", &str)) {
+        config.cmd_volChange = (char *)str;
       }
 
       if (config_lookup_string(config.cfg, "sessioncontrol.wait_for_completion", &str)) {
@@ -832,6 +838,7 @@ int main(int argc, char **argv) {
   debug(2, "Audio Output name is \"%s\".", config.output_name);
   debug(2, "on-start action is \"%s\".", config.cmd_start);
   debug(2, "on-stop action is \"%s\".", config.cmd_stop);
+  debug(2, "on-vol-change action is \"%s\".", config.cmd_volChange);
   debug(2, "wait-cmd status is %d.", config.cmd_blocking);
   debug(2, "mdns backend \"%s\".", config.mdns_name);
   debug(2, "userSuppliedLatency is %d.", config.userSuppliedLatency);


### PR DESCRIPTION
I've added a new event when the audio source has changed the volume. It's similar to the start and stop events before and after the playback.

After the volume has changed a program (or script) can be executed. The program which should be started can be specified in the configuration file with the option `run_this_on_volume_change` in the `sessioncontrol` section. Another way to specify the executable program is to call shairport-sync with the `-C` or `--on-vol-change` argument.

The only limitation when launching the external program is that no user specific arguments can be passed (like it is possible with the start and stop events). Just the new volume value will be passed to the program. This is a double value between 0 and 1.
E.g.: A sample call of the program or script will look like this: `/path/to/program 0.21452`

I also changed the calculation of the `linear_volume` value in the `player_volume(double f)` method (`player.c`).
In my opinion the value wasn't linear calculated before. It was more exponentially (e.g. the value increased faster the higher the volume gets).
With my change the volume is now really linear calculated (at least what I understand under linear).