### PR TITLE
Fix git not ignoring generated files in man/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ install-sh
 missing
 stamp-h1
 .deps
+man/Makefile
+man/Makefile.in


### PR DESCRIPTION
The generated makefiles in the man/ subdirectory are not currently ignored by git. This upsets git buildpackage (yes, I am still working on this!!). 