### PR TITLE
Fix data allignment issue

### DIFF
--- a/rtsp.c
+++ b/rtsp.c
@@ -1085,13 +1085,16 @@ static void handle_set_parameter_metadata(rtsp_conn_info *conn, rtsp_message *re
 
   unsigned int off = 8;
 
+  uint32_t itag, vl;
   while (off < cl) {
     // pick up the metadata tag as an unsigned longint
-    uint32_t itag = ntohl(*(uint32_t *)(cp + off));
+    memcpy(&itag, (uint32_t *)(cp + off), sizeof(uint32_t)); /* can be misaligned, thus memcpy */
+    itag = ntohl(itag);
     off += sizeof(uint32_t);
 
     // pick up the length of the data
-    uint32_t vl = ntohl(*(uint32_t *)(cp + off));
+    memcpy(&vl, (uint32_t *)(cp + off), sizeof(uint32_t)); /* can be misaligned, thus memcpy */
+    vl = ntohl(vl);
     off += sizeof(uint32_t);
 
     // pass the data over


### PR DESCRIPTION
Different processor targets may have different word alignment restrictions. Typically, a two or four byte integer should start on a four-byte address in order to be fetched correctly over a bus. An access of a misaligned memory element may cause a bus error.

Therefore, we need to adjust the contents of a message by copying it into a new location, before interpreting it.

Reference:
http://www.csc.kth.se/utbildning/kth/kurser/DD2490/ipro1-10/homeworks/homework_4b_alignment.html

Fixes: https://github.com/mikebrady/shairport-sync/issues/174, https://github.com/mikebrady/shairport-sync/issues/171