### PR TITLE
User $PREFIX in the init file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ stamp-h1
 man/Makefile
 man/Makefile.in
 scripts/shairport-sync.service
+scripts/shairport-sync

--- a/configure.ac
+++ b/configure.ac
@@ -256,4 +256,5 @@ AC_FUNC_REALLOC
 AC_CHECK_FUNCS([atexit clock_gettime gethostname inet_ntoa memchr memmove memset mkfifo pow select socket stpcpy strcasecmp strchr strdup strerror strstr strtol strtoul])
 
 AC_CONFIG_FILES([Makefile man/Makefile scripts/shairport-sync.service])
+AC_CONFIG_FILES([scripts/shairport-sync],[chmod +x scripts/shairport-sync])
 AC_OUTPUT

--- a/scripts/shairport-sync.in
+++ b/scripts/shairport-sync.in
@@ -17,7 +17,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="AirPlay Synchronous Audio Service"
 NAME=shairport-sync
-DAEMON=/usr/local/bin/$NAME
+DAEMON=@prefix@/bin/$NAME
 
 # We don't use the DAEMON_ARGS variable here because some of the identifiers may have spaces in them, and so are
 # impossible to pass as arguments.


### PR DESCRIPTION
Simplifies building packages for older distros, my VCR is still running 12.04
PS. i'm also producing an ubuntu ppa for the development releases now https://launchpad.net/~dantheperson/+archive/ubuntu/shairport-sync-devel