### PR TITLE
Public ipv6

### DIFF
--- a/common.h
+++ b/common.h
@@ -2,7 +2,6 @@
 #define _COMMON_H
 
 #include <stdint.h>
-#include <endian.h>
 #include <sys/socket.h>
 #include <libconfig.h>
 
@@ -32,6 +31,12 @@
 #define SOCKADDR struct sockaddr
 #define SAFAMILY sa_family
 #endif
+
+enum endian_type {
+  SS_LITTLE_ENDIAN = 0,
+  SS_PDP_ENDIAN,
+  SS_BIG_ENDIAN,
+} endian_type;
 
 enum stuffing_type {
   ST_basic = 0,

--- a/rtp.c
+++ b/rtp.c
@@ -41,7 +41,7 @@
 #include "player.h"
 #include "rtp.h"
 
-#ifdef COMPILE_FOR_LINUX_AND_FREEBSD_AND_CYGWIN
+#if defined(__linux__)
 #include <linux/in6.h>
 #endif
 
@@ -529,7 +529,7 @@ static int bind_port(SOCKADDR *remote, int *sock) {
 
     *sock = socket(remote->SAFAMILY, SOCK_DGRAM, IPPROTO_UDP);
     
-    #ifdef COMPILE_FOR_LINUX_AND_FREEBSD_AND_CYGWIN
+    #if defined(__linux__)
     #ifdef AF_INET6
     // now, if we are on IPv6, prefer a public ipv6 address
     if (remote->SAFAMILY==AF_INET6) {

--- a/rtp.c
+++ b/rtp.c
@@ -41,6 +41,10 @@
 #include "player.h"
 #include "rtp.h"
 
+#ifdef COMPILE_FOR_LINUX_AND_FREEBSD_AND_CYGWIN
+#include <linux/in6.h>
+#endif
+
 typedef struct {
   uint32_t seconds;
   uint32_t fraction;
@@ -524,6 +528,19 @@ static int bind_port(SOCKADDR *remote, int *sock) {
       die("failed to get usable addrinfo?! %s.", gai_strerror(ret));
 
     *sock = socket(remote->SAFAMILY, SOCK_DGRAM, IPPROTO_UDP);
+    
+    #ifdef COMPILE_FOR_LINUX_AND_FREEBSD_AND_CYGWIN
+    #ifdef AF_INET6
+    // now, if we are on IPv6, prefer a public ipv6 address
+    if (remote->SAFAMILY==AF_INET6) {
+      int value = IPV6_PREFER_SRC_PUBLIC;
+      ret = setsockopt(*sock, IPPROTO_IPV6, IPV6_ADDR_PREFERENCES, &value, sizeof(value));
+      if (ret<0)
+        die("error: could not select a preference for public IPv6 address");
+    }
+    #endif
+    #endif
+
     ret = bind(*sock, info->ai_addr, info->ai_addrlen);
 
     freeaddrinfo(info);

--- a/shairport.c
+++ b/shairport.c
@@ -655,11 +655,11 @@ int main(int argc, char **argv) {
   xn.arr[3] = 0x11;     /* Highest-address byte */
   
   if (xn.u32==0x11223344)
-    endianness = __LITTLE_ENDIAN;
+    endianness = SS_LITTLE_ENDIAN;
   else if (xn.u32==0x33441122)
-    endianness = __PDP_ENDIAN;
+    endianness = SS_PDP_ENDIAN;
   else if (xn.u32==0x44332211)
-    endianness = __BIG_ENDIAN;
+    endianness = SS_BIG_ENDIAN;
   else die("Can not recognise the endianness of the processor.");
   
   strcpy(configuration_file_path, "/etc/");
@@ -854,13 +854,13 @@ int main(int argc, char **argv) {
   daemon_log(LOG_NOTICE, "startup");
   
   switch (endianness) {
-    case __LITTLE_ENDIAN:
+    case SS_LITTLE_ENDIAN:
       debug(2,"The processor is running little-endian.");
       break;
-    case __BIG_ENDIAN:
+    case SS_BIG_ENDIAN:
       debug(2,"The processor is running big-endian.");
       break;
-    case __PDP_ENDIAN:
+    case SS_PDP_ENDIAN:
       debug(2,"The processor is running pdp-endian.");
       break; 
   }


### PR DESCRIPTION
Add in a Linux-only ability to favour a "public" IPv6 source address when connecting to a distant IPv6 port. This is to help with systems that use IPv6 privacy extensions.

Also, restore the ability to compile in FreeBSD