### PR TITLE
Fix next track issue with iOS 9.2

### DIFF
--- a/rtsp.c
+++ b/rtsp.c
@@ -455,6 +455,7 @@ static enum rtsp_read_request_response rtsp_read_request(int fd, rtsp_message **
 
   while (msg_size < 0) {
     if (please_shutdown) {
+      please_shutdown = 0;
       debug(1, "RTSP shutdown requested.");
       reply = rtsp_read_request_response_shutdown_requested;
       goto shutdown;
@@ -1564,7 +1565,6 @@ static void *rtsp_conversation_thread_func(void *pconn) {
     rtp_shutdown();
     player_stop();
     pthread_mutex_unlock(&play_lock);
-    please_shutdown = 0;
     pthread_mutex_unlock(&playing_mutex);
   }
   if (auth_nonce)


### PR DESCRIPTION
With iOS 9.2 when skipping to the next track, a TEARDOWN is requested. Thereupon the teardown hander sets the `please_shutdown` flag and the current RTSP thread begins to shutdown.

If, in the meantime, a new RTSP connection is accepted and a new RTSP thread starts running before the shutting down RTSP thread has cleared the `please_shutdown` flag, the new RTSP thread will immediatetly shutdown and so the device disconnects from iOS.

Fix this by clearing `please_shutdown` immediately after evaluating the flag in `rtsp_read_request()`.

TODO: Is `please_shutdown` thread-safe? At least `rtsp_request_shutdown_stream()` is called from the player_thread.

TODO: Don't forget to merge bugfixes into the master branch :-)

Resolves: https://github.com/mikebrady/shairport-sync/issues/177