### PR TITLE
Prune locks

### DIFF
--- a/rtsp.h
+++ b/rtsp.h
@@ -2,7 +2,7 @@
 #define _RTSP_H
 
 void rtsp_listen_loop(void);
-void rtsp_shutdown_stream(void);
+// void rtsp_shutdown_stream(void);
 void rtsp_request_shutdown_stream(void);
 
 

--- a/shairport.c
+++ b/shairport.c
@@ -70,7 +70,7 @@ void shairport_shutdown() {
     return;
   shutting_down = 1;
   mdns_unregister();
-  rtsp_shutdown_stream();
+  rtsp_request_shutdown_stream();
   if (config.output)
     config.output->deinit();
 }


### PR DESCRIPTION
Reduce the number of mutex locks in play, and simplify how signalling occurs between threads.