### PR TITLE
Fix static linking with openssl and alsa

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,7 @@ AC_ARG_WITH(ssl, [ choose --with-ssl=openssl or --with-ssl=polarssl for encrypti
     AC_MSG_ERROR(choose either "openssl" or "polarssl" encryption)
   fi
   if test "x${with_ssl}" = xopenssl ; then
-    if  test "x${with_pkg_config}" = x1 ; then
+    if  test "x${with_pkg_config}" = xyes ; then
       PKG_CHECK_MODULES(
           [SSL], [libssl,libcrypto],
           [LIBS="${SSL_LIBS} ${LIBS}"
@@ -169,7 +169,7 @@ AC_ARG_WITH(alsa, [  --with-alsa = choose ALSA API support (GNU/Linux only)],
   HAS_ALSA=1
   AM_CONDITIONAL([USE_ALSA], [test 0])
   AC_DEFINE([CONFIG_ALSA], 1, [Needed by the compiler.])
-  if  test "x${with_pkg_config}" = x1 ; then
+  if  test "x${with_pkg_config}" = xyes ; then
     PKG_CHECK_MODULES(
       [ALSA], [alsa],
       [LIBS="${ALSA_LIBS} ${LIBS}"


### PR DESCRIPTION
Otherwise build fails for cross-compilation. See http://autobuild.buildroot.net/results/682/6821605cf12e1a5393c29b30baf00cb0f1e1a451/build-end.log