### PR TITLE
Modify delay check

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Download Shairport Sync:
 Next, `cd` into the shairport-sync directory and execute the following command:
 
 ```
-$ git checkout development
+$ git checkout modify_delay_check
 $ autoreconf -i -f
 ```
 (Note that the `autoreconf...` step may take some time on less powerful machines.)

--- a/audio.h
+++ b/audio.h
@@ -31,7 +31,8 @@ typedef struct {
   // returns the delay before the next frame to be sent to the device would actually be audible.
   // almost certainly wrong if the buffer is empty, so put silent buffers into it to make it busy.
   // will change dynamically, so keep watching it. Implemented in ALSA only.
-  uint32_t (*delay)();
+  // returns -1 if there's a problem
+  int32_t (*delay)();
 
   // may be NULL, in which case soft volume is applied
   void (*volume)(double vol);

--- a/audio.h
+++ b/audio.h
@@ -31,8 +31,8 @@ typedef struct {
   // returns the delay before the next frame to be sent to the device would actually be audible.
   // almost certainly wrong if the buffer is empty, so put silent buffers into it to make it busy.
   // will change dynamically, so keep watching it. Implemented in ALSA only.
-  // returns -1 if there's a problem
-  long (*delay)(); // snd_pcm_sframes_t is a signed long
+  // returns a negative error code if there's a problem
+  int (*delay)(long* the_delay); // snd_pcm_sframes_t is a signed long
 
   // may be NULL, in which case soft volume is applied
   void (*volume)(double vol);

--- a/audio.h
+++ b/audio.h
@@ -32,7 +32,7 @@ typedef struct {
   // almost certainly wrong if the buffer is empty, so put silent buffers into it to make it busy.
   // will change dynamically, so keep watching it. Implemented in ALSA only.
   // returns -1 if there's a problem
-  int32_t (*delay)();
+  long (*delay)(); // snd_pcm_sframes_t is a signed long
 
   // may be NULL, in which case soft volume is applied
   void (*volume)(double vol);

--- a/audio_alsa.c
+++ b/audio_alsa.c
@@ -427,9 +427,9 @@ static long delay() {
       derr = snd_pcm_delay(alsa_handle, &current_delay);
       // current_avail not used
       if (derr != 0) {
-        ignore = snd_pcm_recover(alsa_handle, derr, 0);
         debug(1, "Error %d in delay(): %s. Delay reported is %d frames.", derr,
               snd_strerror(derr), current_delay);
+        ignore = snd_pcm_recover(alsa_handle, derr, 0);
         current_delay = -1;
       }
     } else if (snd_pcm_state(alsa_handle) == SND_PCM_STATE_PREPARED) {

--- a/audio_alsa.c
+++ b/audio_alsa.c
@@ -411,7 +411,8 @@ static uint32_t delay() {
     snd_pcm_sframes_t current_avail, current_delay = 0;
     int derr, ignore;
     if (snd_pcm_state(alsa_handle) == SND_PCM_STATE_RUNNING) {
-      derr = snd_pcm_avail_delay(alsa_handle, &current_avail, &current_delay);
+//      derr = snd_pcm_avail_delay(alsa_handle, &current_avail, &current_delay);
+      derr = snd_pcm_delay(alsa_handle, &current_delay);
       // current_avail not used
       if (derr != 0) {
         ignore = snd_pcm_recover(alsa_handle, derr, 0);

--- a/audio_alsa.c
+++ b/audio_alsa.c
@@ -42,7 +42,7 @@ static void start(int sample_rate);
 static void play(short buf[], int samples);
 static void stop(void);
 static void flush(void);
-static int32_t delay(void);
+static long delay(void);
 static void volume(double vol);
 static void linear_volume(double vol);
 static void parameters(audio_parameters *info);
@@ -413,13 +413,14 @@ static void start(int sample_rate) {
   desired_sample_rate = sample_rate; // must be a variable
 }
 
-static int32_t delay() {
+static long delay() {
   // debug(3,"audio_alsa delay called.");
   if (alsa_handle == NULL) {
     return 0;
   } else {
     pthread_mutex_lock(&alsa_mutex);
     snd_pcm_sframes_t current_avail, current_delay = 0;
+    //snd_pcm_sframes_t is a signed long -- hence the return of a "long"
     int derr, ignore;
     if (snd_pcm_state(alsa_handle) == SND_PCM_STATE_RUNNING) {
 //      derr = snd_pcm_avail_delay(alsa_handle, &current_avail, &current_delay);

--- a/common.c
+++ b/common.c
@@ -478,7 +478,7 @@ uint64_t get_absolute_time_in_fp() {
   struct timespec tn;
   // can't use CLOCK_MONOTONIC_RAW as it's not implemented in OpenWrt
   clock_gettime(CLOCK_MONOTONIC, &tn);
-  time_now_fp = ((uint64_t)tn.tv_sec << 32) + ((uint64_t)tn.tv_nsec << 32) / 1000000000;
+  time_now_fp = ((uint64_t)tn.tv_sec << 32) + ((uint64_t)tn.tv_nsec << 32) / 1000000000; // types okay
 #endif
 #ifdef COMPILE_FOR_OSX
   uint64_t time_now_mach;

--- a/common.h
+++ b/common.h
@@ -57,6 +57,7 @@ typedef struct {
   int udp_port_base;
   int udp_port_range;
   int ignore_volume_control;
+  int no_sync; // disable synchronisation, even if it's available
   int resyncthreshold; // if it get's out of whack my more than this, resync. Zero means never
                        // resync.
   int allow_session_interruption;

--- a/common.h
+++ b/common.h
@@ -85,9 +85,9 @@ typedef struct {
   char *logfile;
   char *errfile;
   char *configfile;
-  int32_t audio_backend_buffer_desired_length; // this will be the desired number of frames in the
+  long audio_backend_buffer_desired_length; // this will be the desired number of frames in the
                                             // audio backend buffer -- the DAC buffer for ALSA
-  int32_t audio_backend_latency_offset; // this will be the offset to compensate for any fixed latency
+  long audio_backend_latency_offset; // this will be the offset to compensate for any fixed latency
   uint32_t volume_range_db; // the range, in dB, from max dB to min dB. Zero means use the mixer's native range.
                                      // there might be in the audio
 } shairport_cfg;

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.50])
-AC_INIT([shairport-sync], [2.9.5], [mikebrady@eircom.net])
+AC_INIT([shairport-sync], [2.9.5.1], [mikebrady@eircom.net])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([shairport.c])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.50])
-AC_INIT([shairport-sync], [2.9.5.3], [mikebrady@eircom.net])
+AC_INIT([shairport-sync], [2.9.5.4], [mikebrady@eircom.net])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([shairport.c])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.50])
-AC_INIT([shairport-sync], [2.9.5.2], [mikebrady@eircom.net])
+AC_INIT([shairport-sync], [2.9.5.3], [mikebrady@eircom.net])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([shairport.c])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.50])
-AC_INIT([shairport-sync], [2.9.4], [mikebrady@eircom.net])
+AC_INIT([shairport-sync], [2.9.5], [mikebrady@eircom.net])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([shairport.c])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.50])
-AC_INIT([shairport-sync], [2.9.5.1], [mikebrady@eircom.net])
+AC_INIT([shairport-sync], [2.9.5.2], [mikebrady@eircom.net])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([shairport.c])
 AC_CONFIG_HEADERS([config.h])

--- a/player.c
+++ b/player.c
@@ -776,6 +776,7 @@ static abuf_t *buffer_get_frame(void) {
     }
   }
 
+
   if (!curframe->ready) {
     // debug(1, "Supplying a silent frame for frame %u", read);
     missing_packets++;
@@ -1039,8 +1040,8 @@ static void *player_thread_func(void *arg) {
             if (inframe->sequence_number != last_seqno_read) { //seq_t, ei.e. uint16_t and int32_t, so okay
               debug(
                   1,
-                  "Player: packets out of sequence: expected: %d, got: %d, sync error: %d frames.",
-                  last_seqno_read, inframe->sequence_number, sync_error);
+                  "Player: packets out of sequence: expected: %u, got: %u, with ab_read: %u and ab_write: %u.",
+                  last_seqno_read, inframe->sequence_number,ab_read,ab_write);
               last_seqno_read = inframe->sequence_number; // reset warning...
             }
           }

--- a/player.c
+++ b/player.c
@@ -104,7 +104,7 @@ static pthread_mutex_t vol_mutex = PTHREAD_MUTEX_INITIALIZER;
 #define MAX_PACKET 2048
 
 // DAC buffer occupancy stuff
-#define DAC_BUFFER_QUEUE_MINIMUM_LENGTH 5000
+#define DAC_BUFFER_QUEUE_MINIMUM_LENGTH 2000
 
 typedef struct audio_buffer_entry { // decoded audio packets
   int ready;

--- a/rtp.c
+++ b/rtp.c
@@ -513,10 +513,10 @@ void *rtp_timing_receiver(void *arg) {
        source_drift_usec = 0;
      source_drift_usec = (source_drift_usec*1000000)>>32; // turn it to microseconds
       
-     int64_t current_delay = 0;
-     if (config.output->delay) {
-            current_delay = config.output->delay();
-     }
+     //long current_delay = 0;
+     //if (config.output->delay) {
+     //       config.output->delay(&current_delay);
+     //}
      //  Useful for troubleshooting:
      //    clock_drift between source and local clock -- +ve means source is faster
      //    session_corrections -- the amount of correction done, in microseconds. +ve means frames added
@@ -524,7 +524,7 @@ void *rtp_timing_receiver(void *arg) {
      //    source_drift_usec = how much faster (+ve) or slower the source DAC is running relative to the source clock
      //    buffer_occupancy = the number of buffers occupied. Crude, but should show no long term trend if source and device are in sync.
      //    return_time = the time from soliciting a timing packet to getting it back. It should be short ( < 5 ms) and pretty consistent.
-     // debug(1, "%lld\t%lld\t%lld\t%lld\t%u\t%llu", clock_drift_in_usec,(session_corrections*1000000)/44100,current_delay,source_drift_usec,buffer_occupancy,(return_time*1000000)>>32);
+     // debug(1, "%lld\t%lld\t%ld\t%lld\t%u\t%llu", clock_drift_in_usec,(session_corrections*1000000)/44100,current_delay,source_drift_usec,buffer_occupancy,(return_time*1000000)>>32);
       
     } else {
       debug(1, "Timing port -- Unknown RTP packet of type 0x%02X length %d.", packet[1], nread);

--- a/rtp.c
+++ b/rtp.c
@@ -124,7 +124,7 @@ void *rtp_audio_receiver(void *arg) {
       stat_mean += stat_delta/stat_n;
       stat_M2 += stat_delta*(time_interval_us - stat_mean);
       if (stat_n % 2500 == 0) {
-        debug(1,"Packet reception intervals: mean, standard deviation and max for the last 2,500 packets in microseconds: %10.1f, %10.1f, %10.1f.",stat_mean, sqrtf(stat_M2 / (stat_n-1)),longest_packet_time_interval_us);
+        debug(2,"Packet reception interval stats: mean, standard deviation and max for the last 2,500 packets in microseconds: %10.1f, %10.1f, %10.1f.",stat_mean, sqrtf(stat_M2 / (stat_n-1)),longest_packet_time_interval_us);
         stat_n = 0;
         stat_mean = 0.0;
         stat_M2 = 0.0;

--- a/rtp.c
+++ b/rtp.c
@@ -700,6 +700,7 @@ void rtp_setup(SOCKADDR *remote, int cport, int tport, uint32_t active_remote, i
 }
 
 void get_reference_timestamp_stuff(uint32_t *timestamp, uint64_t *timestamp_time, uint64_t *remote_timestamp_time) {
+  // types okay
   pthread_mutex_lock(&reference_time_mutex);
   *timestamp = reference_timestamp;
   *timestamp_time = reference_timestamp_time;

--- a/rtp.c
+++ b/rtp.c
@@ -124,7 +124,7 @@ void *rtp_audio_receiver(void *arg) {
       stat_mean += stat_delta/stat_n;
       stat_M2 += stat_delta*(time_interval_us - stat_mean);
       if (stat_n % 2500 == 0) {
-        debug(3,"Packet reception intervals: mean, standard deviation and max for the last 2,500 packets in microseconds: %10.1f, %10.1f, %10.1f.",stat_mean, sqrtf(stat_M2 / (stat_n-1)),longest_packet_time_interval_us);
+        debug(1,"Packet reception intervals: mean, standard deviation and max for the last 2,500 packets in microseconds: %10.1f, %10.1f, %10.1f.",stat_mean, sqrtf(stat_M2 / (stat_n-1)),longest_packet_time_interval_us);
         stat_n = 0;
         stat_mean = 0.0;
         stat_M2 = 0.0;

--- a/rtsp.c
+++ b/rtsp.c
@@ -293,7 +293,7 @@ static void cleanup_threads(void) {
     if (conns[i]->running == 0) {
       pthread_join(conns[i]->thread, &retval);
       free(conns[i]);
-      debug(2, "one thread joined...");
+      debug(3, "one thread joined...");
       nconns--;
       if (nconns)
         conns[i] = conns[nconns];

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -48,6 +48,7 @@ alsa =
 //  mixer_device = "default"; // the mixer_device default is whatever the output_device is. Normally you wouldn't have to use this.
 //  audio_backend_latency_offset = 0; // Set this offset to compensate for a fixed delay in the audio back end. E.g. if the output device delays by 100 ms, set this to -4410.
 //  audio_backend_buffer_desired_length = 6615; // If set too small, buffer underflow occurs on low-powered machines. Too long and the response times with software mixer become annoying.
+//  disable_synchronization = "no"; // Set to "yes" to disable synchronization. Default is "no".
 };
 
 // These are parameters for the "pipe" audio back end, a back end that directs raw CD-style audio output to a pipe. No interpolation is done.

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -49,6 +49,8 @@ alsa =
 //  audio_backend_latency_offset = 0; // Set this offset to compensate for a fixed delay in the audio back end. E.g. if the output device delays by 100 ms, set this to -4410.
 //  audio_backend_buffer_desired_length = 6615; // If set too small, buffer underflow occurs on low-powered machines. Too long and the response times with software mixer become annoying.
 //  disable_synchronization = "no"; // Set to "yes" to disable synchronization. Default is "no".
+//  period_size = <number>; // Use this optional advanced setting to set the alsa period size near to this value
+//  buffer_size = <number>; // Use this optional advanced setting to set the alsa buffer size near to this value
 };
 
 // These are parameters for the "pipe" audio back end, a back end that directs raw CD-style audio output to a pipe. No interpolation is done.

--- a/shairport.c
+++ b/shairport.c
@@ -79,7 +79,7 @@ static void sig_ignore(int foo, siginfo_t *bar, void *baz) {}
 static void sig_shutdown(int foo, siginfo_t *bar, void *baz) {
   debug(1, "shutdown requested...");
   shairport_shutdown();
-  daemon_log(LOG_NOTICE, "exit...");
+//  daemon_log(LOG_NOTICE, "exit...");
   daemon_retval_send(255);
   daemon_pid_file_remove();
   exit(0);
@@ -104,52 +104,64 @@ static void sig_connect_audio_output(int foo, siginfo_t *bar, void *baz) {
   set_requested_connection_state_to_output(1);
 }
 
+char* get_version_string() {
+  char* version_string = malloc(200);
+  if (version_string) {
+    strcpy(version_string, PACKAGE_VERSION);
+  #ifdef HAVE_LIBPOLARSSL
+    strcat(version_string, "-polarssl");
+  #endif
+  #ifdef HAVE_LIBSSL
+    strcat(version_string, "-openssl");
+  #endif
+  #ifdef CONFIG_TINYSVCMDNS
+    strcat(version_string, "-tinysvcmdns");
+  #endif
+  #ifdef CONFIG_AVAHI
+    strcat(version_string, "-Avahi");
+  #endif
+  #ifdef CONFIG_DNS_SD
+    strcat(version_string, "-dns_sd");
+  #endif
+  #ifdef CONFIG_ALSA
+    strcat(version_string, "-ALSA");
+  #endif
+  #ifdef CONFIG_SNDIO
+    strcat(version_string, "-sndio");
+  #endif
+  #ifdef CONFIG_AO
+    strcat(version_string, "-ao");
+  #endif
+  #ifdef CONFIG_PULSE
+    strcat(version_string, "-pulse");
+  #endif
+  #ifdef CONFIG_DUMMY
+    strcat(version_string, "-dummy");
+  #endif
+  #ifdef CONFIG_STDOUT
+    strcat(version_string, "-stdout");
+  #endif
+  #ifdef CONFIG_PIPE
+    strcat(version_string, "-pipe");
+  #endif
+  #ifdef HAVE_LIBSOXR
+    strcat(version_string, "-soxr");
+  #endif
+  #ifdef CONFIG_METADATA
+    strcat(version_string, "-metadata");
+  #endif
+  }
+  return version_string;
+}
+
 void print_version(void) {
-  char version_string[200];
-  strcpy(version_string, PACKAGE_VERSION);
-#ifdef HAVE_LIBPOLARSSL
-  strcat(version_string, "-polarssl");
-#endif
-#ifdef HAVE_LIBSSL
-  strcat(version_string, "-openssl");
-#endif
-#ifdef CONFIG_TINYSVCMDNS
-  strcat(version_string, "-tinysvcmdns");
-#endif
-#ifdef CONFIG_AVAHI
-  strcat(version_string, "-Avahi");
-#endif
-#ifdef CONFIG_DNS_SD
-  strcat(version_string, "-dns_sd");
-#endif
-#ifdef CONFIG_ALSA
-  strcat(version_string, "-ALSA");
-#endif
-#ifdef CONFIG_SNDIO
-  strcat(version_string, "-sndio");
-#endif
-#ifdef CONFIG_AO
-  strcat(version_string, "-ao");
-#endif
-#ifdef CONFIG_PULSE
-  strcat(version_string, "-pulse");
-#endif
-#ifdef CONFIG_DUMMY
-  strcat(version_string, "-dummy");
-#endif
-#ifdef CONFIG_STDOUT
-  strcat(version_string, "-stdout");
-#endif
-#ifdef CONFIG_PIPE
-  strcat(version_string, "-pipe");
-#endif
-#ifdef HAVE_LIBSOXR
-  strcat(version_string, "-soxr");
-#endif
-#ifdef CONFIG_METADATA
-  strcat(version_string, "-metadata");
-#endif
-  printf("%s\n", version_string);
+  char* version_string = get_version_string();
+  if (version_string) {
+    printf("%s\n", version_string);
+    free(version_string);
+  } else {
+    debug(1,"Can't print version string!");
+  }
 }
 
 void usage(char *progname) {
@@ -851,7 +863,7 @@ int main(int argc, char **argv) {
   }
   config.output->init(argc - audio_arg, argv + audio_arg);
 
-  daemon_log(LOG_NOTICE, "startup");
+  // daemon_log(LOG_NOTICE, "startup");
   
   switch (endianness) {
     case SS_LITTLE_ENDIAN:
@@ -907,47 +919,57 @@ int main(int argc, char **argv) {
     inform("Please remove this setting and use the relevant audio_backend_latency_offset setting, if necessary, to compensate for delays elsewhere.");
   }
   
+  /* print out version */
   
+  char* version_dbs = get_version_string();
+  if (version_dbs) {
+    debug(1,"Version: \"%s\"",version_dbs);
+    free(version_dbs);
+  } else {
+    debug(1,"Can't print the version information!");
+  }
+
   /* Print out options */
 
-  debug(2, "statistics_requester status is %d.", config.statistics_requested);
-  debug(2, "daemon status is %d.", config.daemonise);
-  debug(2, "rtsp listening port is %d.", config.port);
-  debug(2, "udp base port is %d.", config.udp_port_base);
-  debug(2, "udp port range is %d.", config.udp_port_range);
-  debug(2, "Shairport Sync player name is \"%s\".", config.apname);
-  debug(2, "Audio Output name is \"%s\".", config.output_name);
-  debug(2, "on-start action is \"%s\".", config.cmd_start);
-  debug(2, "on-stop action is \"%s\".", config.cmd_stop);
-  debug(2, "wait-cmd status is %d.", config.cmd_blocking);
-  debug(2, "mdns backend \"%s\".", config.mdns_name);
+  debug(1, "statistics_requester status is %d.", config.statistics_requested);
+  debug(1, "daemon status is %d.", config.daemonise);
+  debug(1, "rtsp listening port is %d.", config.port);
+  debug(1, "udp base port is %d.", config.udp_port_base);
+  debug(1, "udp port range is %d.", config.udp_port_range);
+  debug(1, "Shairport Sync player name is \"%s\".", config.apname);
+  debug(1, "Audio Output name is \"%s\".", config.output_name);
+  debug(1, "on-start action is \"%s\".", config.cmd_start);
+  debug(1, "on-stop action is \"%s\".", config.cmd_stop);
+  debug(1, "wait-cmd status is %d.", config.cmd_blocking);
+  debug(1, "mdns backend \"%s\".", config.mdns_name);
   debug(2, "userSuppliedLatency is %d.", config.userSuppliedLatency);
   debug(2, "AirPlayLatency is %d.", config.AirPlayLatency);
   debug(2, "iTunesLatency is %d.", config.iTunesLatency);
   debug(2, "forkedDaapdLatency is %d.", config.ForkedDaapdLatency);
-  debug(2, "stuffing option is \"%d\".", config.packet_stuffing);
-  debug(2, "resync time is %d.", config.resyncthreshold);
-  debug(2, "allow a session to be interrupted: %d.", config.allow_session_interruption);
-  debug(2, "busy timeout time is %d.", config.timeout);
-  debug(2, "tolerance is %d frames.", config.tolerance);
-  debug(2, "password is \"%s\".", config.password);
-  debug(2, "ignore_volume_control is %d.", config.ignore_volume_control);
-  debug(2, "audio backend desired buffer length is %d.",
+  debug(1, "stuffing option is \"%d\".", config.packet_stuffing);
+  debug(1, "resync time is %d.", config.resyncthreshold);
+  debug(1, "allow a session to be interrupted: %d.", config.allow_session_interruption);
+  debug(1, "busy timeout time is %d.", config.timeout);
+  debug(1, "drift tolerance is %d frames.", config.tolerance);
+  debug(1, "password is \"%s\".", config.password);
+  debug(1, "ignore_volume_control is %d.", config.ignore_volume_control);
+  debug(1, "disable_synchronization is %d.", config.no_sync);
+  debug(1, "audio backend desired buffer length is %d.",
         config.audio_backend_buffer_desired_length);
-  debug(2, "audio backend latency offset is %d.", config.audio_backend_latency_offset);
-  debug(2, "volume range in dB (zero means use the range specified by the mixer): %u.", config.volume_range_db);
+  debug(1, "audio backend latency offset is %d.", config.audio_backend_latency_offset);
+  debug(1, "volume range in dB (zero means use the range specified by the mixer): %u.", config.volume_range_db);
   
   char *realConfigPath = realpath(config.configfile,NULL);
   if (realConfigPath) {
-    debug(2, "configuration file name \"%s\" resolves to \"%s\".", config.configfile,realConfigPath);
+    debug(1, "configuration file name \"%s\" resolves to \"%s\".", config.configfile,realConfigPath);
     free(realConfigPath);
   } else {
-     debug(2, "configuration file name \"%s\" can not be resolved.", config.configfile);
+     debug(1, "configuration file name \"%s\" can not be resolved.", config.configfile);
   }   
 #ifdef CONFIG_METADATA
-  debug(2, "metdata enabled is %d.", config.metadata_enabled);
-  debug(2, "metadata pipename is \"%s\".", config.metadata_pipename);
-  debug(2, "get-coverart is %d.", config.get_coverart);
+  debug(1, "metdata enabled is %d.", config.metadata_enabled);
+  debug(1, "metadata pipename is \"%s\".", config.metadata_pipename);
+  debug(1, "get-coverart is %d.", config.get_coverart);
 #endif
 
   uint8_t ap_md5[16];


### PR DESCRIPTION
Detect and handle when the packet buffers are exhausted. (!)
Modify the way `audio_alsa` gets delay information from the `alsa` subsystem.
Gracefully handle occasions when the delay information is unavailable or the delay returns a negative result.
Add an option to turn off synchronisation (this is probably temporary).
Add two options for setting `alsa` period size and `alsa` buffer size – advanced usage only.
Start to tidy up arithmetic errors due to sloppy observance of type mixing and promotion rules.
Add some `alsa` information to debug info.
Tidy up some debug messages; drop the priority of some and raise others.