### PR TITLE
Add support for mono output

### DIFF
--- a/common.h
+++ b/common.h
@@ -77,6 +77,7 @@ typedef struct {
   int32_t ForkedDaapdLatency; // supplied with --ForkedDaapdLatency option
   int daemonise;
   int statistics_requested,use_negotiated_latencies;
+  int mono;
   char *cmd_start, *cmd_stop;
   int cmd_blocking;
   int tolerance; // allow this much drift before attempting to correct it

--- a/player.c
+++ b/player.c
@@ -378,6 +378,24 @@ void player_put_packet(seq_t seqno, uint32_t timestamp, uint8_t *data, int len) 
 					abuf->ready = 1;
 					abuf->timestamp = timestamp;
 					abuf->sequence_number = seqno;
+
+          if (config.mono) {
+            signed short *v = abuf->data;
+            int i;
+            int both;
+            for (i=frame_size;i;i--) {
+              int both = *v + *(v+1);
+              if (both > INT16_MAX) {
+                both = INT16_MAX;
+              } else if (both < INT16_MIN) {
+                both = INT16_MIN;
+              }
+              short sboth = (short)both;
+              *v++ = sboth;
+              *v++ = sboth;
+            }
+          }
+
         } else {
         	debug(1,"Bad audio packet detected and discarded.");
 					abuf->ready = 0;

--- a/shairport.c
+++ b/shairport.c
@@ -420,7 +420,7 @@ int parse_options(int argc, char **argv) {
         else if (strcasecmp(str, "yes") == 0)
           config.mono = 1;
         else
-          die("Invalid general enabled option choice \"%s\". It should be \"yes\" or \"no\"");
+          die("Invalid mono option choice \"%s\". It should be \"yes\" or \"no\"");
       }
 
       /* Get the regtype -- the service type and protocol, separated by a dot. Default is "_raop._tcp" */

--- a/shairport.c
+++ b/shairport.c
@@ -207,6 +207,7 @@ void usage(char *progname) {
   printf("                            Executable scripts work, but must have #!/bin/sh (or "
          "whatever) in the headline.\n");
   printf("    -w, --wait-cmd          wait until the -B or -E programs finish before continuing.\n");
+  printf("    --mono                   convert all outgoing audio to mono.\n");
   printf("    -o, --output=BACKEND    select audio output method.\n");
   printf("    -m, --mdns=BACKEND      force the use of BACKEND to advertize the service.\n");
   printf("                            if no mdns provider is specified,\n");
@@ -253,6 +254,7 @@ int parse_options(int argc, char **argv) {
       {"on-start", 'B', POPT_ARG_STRING, &config.cmd_start, 0, NULL},
       {"on-stop", 'E', POPT_ARG_STRING, &config.cmd_stop, 0, NULL},
       {"wait-cmd", 'w', POPT_ARG_NONE, &config.cmd_blocking, 0, NULL},
+      {"mono", 0, POPT_ARG_NONE, &config.mono, 0, NULL},
       {"mdns", 'm', POPT_ARG_STRING, &config.mdns_name, 0, NULL},
       {"latency", 'L', POPT_ARG_INT, &config.userSuppliedLatency, 0, NULL},
       {"AirPlayLatency", 'A', POPT_ARG_INT, &config.AirPlayLatency, 0, NULL},
@@ -409,6 +411,16 @@ int parse_options(int argc, char **argv) {
           config.ignore_volume_control = 1;
         else
           die("Invalid ignore_volume_control option choice \"%s\". It should be \"yes\" or \"no\"");
+      }
+
+      /* Get the mono setting */
+      if (config_lookup_string(config.cfg, "general.mono", &str)) {
+        if (strcasecmp(str, "no") == 0)
+          config.mono = 0;
+        else if (strcasecmp(str, "yes") == 0)
+          config.mono = 1;
+        else
+          die("Invalid general enabled option choice \"%s\". It should be \"yes\" or \"no\"");
       }
 
       /* Get the regtype -- the service type and protocol, separated by a dot. Default is "_raop._tcp" */
@@ -960,6 +972,7 @@ int main(int argc, char **argv) {
   debug(1, "drift tolerance is %d frames.", config.tolerance);
   debug(1, "password is \"%s\".", config.password);
   debug(1, "ignore_volume_control is %d.", config.ignore_volume_control);
+  debug(1, "mono is %d.", config.mono);
   debug(1, "disable_synchronization is %d.", config.no_sync);
   debug(1, "audio backend desired buffer length is %d.",
         config.audio_backend_buffer_desired_length);


### PR DESCRIPTION
Hi Mike

I've added a "mono" flag to merge the left and right channels into mono for output. This seems to come up every now and again (on the wider internet, not in the issues list), usually because someone has a faulty speaker or similar. Their typical solution is to switch ALSA over to mono output.

My use-case is I have a stereo amp running four speakers, two front at the front and two at the back. I want all four speakers to have the same output, but to be able to adjust the volume of each pair (front or back) individually. I couldn't do this by reducing ALSA to mono, but with this patch I can: by converting shairport output to mono then adjusting the left/right volume individually.

It's a pretty simple patch as you can see and should be safe to merge - I've been running it for some time without problems. For the record there are two methods of merging stereo to mono, you can add the samples, or you can add them and divide by two (i.e. average them). The first option gives introduces the possibility of clipping, the second option will never clip but will reduce the apparent volume. I've decided clipping was preferable, and haven't noticed any distortion so far.

Thanks for picking up up the torch from the original abrasive release and continuing to maintain it. Hope you find this one useful. And please excuse my very rusty C.