### PR TITLE
Metadata over UDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ What else?
 * Hardware Mute — Shairport Sync will mute properly if the hardware supports it.
 * Fast Response — With hardware volume control, response is instantaneous; otherwise the response time is 0.15 seconds.
 * Non-Interruptible — Shairport Sync sends back a "busy" signal if it's already playing audio from another source, so other sources can't disrupt an existing Shairport Sync session. (If a source disappears without warning, the session automatically terminates after two minutes and the device becomes available again.)
-* Metadata — Shairport Sync can deliver metadata supplied by the source, such as Album Name, Artist Name, Cover Art, etc. through a pipe to a recipient application program — see https://github.com/mikebrady/shairport-sync-metadata-reader for a sample recipient. Sources that supply metadata include iTunes and the Music app in iOS.
+* Metadata — Shairport Sync can deliver metadata supplied by the source, such as Album Name, Artist Name, Cover Art, etc. through a pipe or UDP socket to a recipient application program — see https://github.com/mikebrady/shairport-sync-metadata-reader for a sample recipient. Sources that supply metadata include iTunes and the Music app in iOS.
 * Raw Audio — Shairport Sync can deliver raw PCM audio to standard output or to a pipe. This output is delivered synchronously with the source after the appropriate latency and is not interpolated or "stuffed" on its way through Shairport Sync.
 * Autotools and Libtool Support — the Shairport Sync build process uses GNU `autotools` and `libtool` to examine and configure the build environment — important for portability and for cross compilation. Previous versions of Shairport looked at the current system to determine which packages were available, instead of looking at the target system for what packages were available.
 
@@ -341,6 +341,14 @@ alsa = {
   mixer_control_name = "Speaker";
 };
 ```
+
+Metadata broadcasting over UDP
+------------------------------
+As an alternative to sending metadata to a pipe, the `socket_address` and `socket_port` tags may be set in the metadata group to cause Shairport Sync to broadcast UDP packets containing the track metadata.
+
+The advantage of UDP is that packets can be sent to a single listener or, if a multicast address is used, to multiple listeners. It also allows metadata to be routed to a different host. However UDP has a maximum packet size of about 65000 bytes; while large enough for most data, Cover Art will often exceed this value. Any metadata exceeding this limit will not be sent over the socket interface. The maximum packet size may be set with the `socket_msglength` tag to any value between 500 and 65000 to control this - lower values may be used to ensure that each UDP packet is sent in a single network frame. The default is 500. Other than this restriction, metadata sent over the socket interface is identical to metadata sent over the pipe interface.
+
+The UDP metadata format is very simple - the first four bytes are the metadata *type*, and the next four bytes are the metadata *code* (both are sent in network byte order - see https://github.com/mikebrady/shairport-sync-metadata-reader for a definition of those terms). The remaining bytes of the packet, if any, make up the raw value of the metadata.
 
 Latency
 -------

--- a/common.h
+++ b/common.h
@@ -50,6 +50,9 @@ typedef struct {
 #ifdef CONFIG_METADATA
   int metadata_enabled;
   char *metadata_pipename;
+  char *metadata_sockaddr;
+  int metadata_sockport;
+  int metadata_sockmsglength;
   int get_coverart;
 #endif
   uint8_t hw_addr[6];

--- a/mdns_tinysvcmdns.c
+++ b/mdns_tinysvcmdns.c
@@ -125,6 +125,9 @@ static int mdns_tinysvcmdns_register(char *apname, int port) {
 
     txt = txtwithoutmetadata;
   
+  if (config.regtype == NULL)
+    die("tinysvcmdns: regtype is null");
+
   char* extendedregtype = malloc(strlen(config.regtype)+strlen(".local")+1);
 
   if (extendedregtype==NULL)

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -27,6 +27,9 @@ metadata =
 //	enabled = "no"; // et to yes to get Shairport Sync to solicit metadata from the source and to pass it on via a pipe
 //	include_cover_art = "no"; // set to "yes" to get Shairport Sync to solicit cover art from the source and pass it via the pipe. You must also set "enabled" to "yes".
 //	pipe_name = "/tmp/shairport-sync-metadata";
+//      socket_address = "226.0.0.1"; // if set to a host name or IP address, UDP packets containing metadata will be sent to this address. May be a multicast address. "socket-port" must be non-zero and "enabled" must be set to yes"
+//      socket_port = "5555"; // if socket_address is set, the port to send UDP packets to
+//      socket_msglength = "65000"; // the maximum packet size for any UDP metadata. This will be clipped to be between 500 or 65000. The default is 500.
 };
 
 // Advanced parameters for controlling how a Shairport Sync runs

--- a/shairport.c
+++ b/shairport.c
@@ -477,6 +477,17 @@ int parse_options(int argc, char **argv) {
       if (config_lookup_string(config.cfg, "metadata.pipe_name", &str)) {
         config.metadata_pipename = (char *)str;
       }
+
+      if (config_lookup_string(config.cfg, "metadata.socket_address", &str)) {
+        config.metadata_sockaddr = (char *)str;
+      }
+      if (config_lookup_int(config.cfg, "metadata.socket_port", &value)) {
+        config.metadata_sockport = value;
+      }
+      config.metadata_sockmsglength = 500;
+      if (config_lookup_int(config.cfg, "metadata.socket_msglength", &value)) {
+        config.metadata_sockmsglength = value < 500 ? 500 : value > 65000 ? 65000 : value;
+      }
   #endif
 
       if (config_lookup_string(config.cfg, "sessioncontrol.run_this_before_play_begins", &str)) {
@@ -991,6 +1002,8 @@ int main(int argc, char **argv) {
 #ifdef CONFIG_METADATA
   debug(1, "metdata enabled is %d.", config.metadata_enabled);
   debug(1, "metadata pipename is \"%s\".", config.metadata_pipename);
+  debug(1, "metadata socket address is \"%s\" port %d.", config.metadata_sockaddr, config.metadata_sockport);
+  debug(1, "metadata socket packet size is \"%d\".", config.metadata_sockmsglength);
   debug(1, "get-coverart is %d.", config.get_coverart);
 #endif
 


### PR DESCRIPTION
Hi Mike - got another pull request for you.

I have never managed to get the "metadata over pipe" working reliably: if my client doesn't connect at the right time, or if it drops the connection, I don't seem to get anything and have no way to recover. Worse, connecting to a named FIFO when shairport-sync is not running will block, which is a problem in environments like Java: it will hang the current thread, with no way to recover cleanly.

So this pull request adds an option to broadcast metadata to a UDP socket address.

The advantages here are the listeners to this socket can come and go without any need to coordinate with the server. Also, you can use a multicast address to broadcast metadata to multiple cilents (tested the theory successfully), or a remote address to send metadata over the network.

Only disadvantage is most cover art will be too large, so will not be sent, which is documented.