### PR TITLE
Make statistics output more parsable

### DIFF
--- a/player.c
+++ b/player.c
@@ -1026,6 +1026,42 @@ static void *player_thread_func(void *arg) {
                            // as a null operand, so we'll use it like that too
   int sync_error_out_of_bounds = 0; // number of times in a row that there's been a serious sync error
 
+  if (config.statistics_requested) {
+    if ((config.output->delay)) {
+      if (config.no_sync==0) {
+        inform("sync error in frames, "
+               "net correction in ppm, "
+               "corrections in ppm, "
+               "total packets, "
+               "missing packets, "
+               "late packets, "
+               "too late packets, "
+               "resend requests, "
+               "min DAC queue size, "
+               "min buffer occupancy, "
+               "max buffer occupancy");
+      } else {
+        inform("sync error in frames, "
+               "total packets, "
+               "missing packets, "
+               "late packets, "
+               "too late packets, "
+               "resend requests, "
+               "min DAC queue size, "
+               "min buffer occupancy, "
+               "max buffer occupancy");
+      }
+    } else {
+      inform("total packets, "
+             "missing packets, "
+             "late packets, "
+             "too late packets, "
+             "resend requests, "
+             "min buffer occupancy, "
+             "max buffer occupancy");
+    }
+  }
+
   uint64_t tens_of_seconds = 0;
   while (!please_stop) {
     abuf_t *inframe = buffer_get_frame();
@@ -1354,31 +1390,66 @@ static void *player_thread_func(void *arg) {
             if (at_least_one_frame_seen) {
             	if ((config.output->delay)) {
                 if (config.no_sync==0) {
-                  inform("Sync error: %.1f (frames); net correction: %.1f (ppm); corrections: %.1f "
-                         "(ppm); total packets %d; missing packets %llu; late packets %llu; too late packets %llu; "
-                         "resend requests %llu; min DAC queue size %lli, min and max buffer occupancy "
-                         "%d and %d.",
-                         moving_average_sync_error, moving_average_correction * 1000000 / 352,
-                         moving_average_insertions_plus_deletions * 1000000 / 352, play_number, missing_packets,
-                         late_packets, too_late_packets, resend_requests, minimum_dac_queue_size,
-                         minimum_buffer_occupancy, maximum_buffer_occupancy);
+                  inform("%*.1f,"  /* Sync error inf frames */
+                         "%*.1f,"  /* net correction in ppm */
+                         "%*.1f,"  /* corrections in ppm */
+                         "%*d,"    /* total packets */
+                         "%*llu,"  /* missing packets */
+                         "%*llu,"  /* late packets */
+                         "%*llu,"  /* too late packets */
+                         "%*llu,"  /* resend requests */
+                         "%*lli,"  /* min DAC queue size */
+                         "%*d,"    /* min buffer occupancy */
+                         "%*d",    /* max buffer occupancy */
+                         10, moving_average_sync_error,
+                         10, moving_average_correction * 1000000 / 352,
+                         10, moving_average_insertions_plus_deletions * 1000000 / 352,
+                         12, play_number,
+                         7, missing_packets,
+                         7, late_packets,
+                         7, too_late_packets,
+                         7, resend_requests,
+                         7, minimum_dac_queue_size,
+                         5, minimum_buffer_occupancy,
+                         5, maximum_buffer_occupancy);
                 } else {
-                  inform("Synchronisation disabled. Sync error: %.1f (frames); total packets %d; "
-                         "missing packets %llu; late packets %llu; too late packets %llu; "
-                         "resend requests %llu; min DAC queue size %lli, min and max buffer occupancy "
-                         "%d and %d.",
-                         moving_average_sync_error, play_number, missing_packets,
-                         late_packets, too_late_packets, resend_requests, minimum_dac_queue_size,
-                         minimum_buffer_occupancy, maximum_buffer_occupancy);
+                  inform("%*.1f,"  /* Sync error inf frames */
+                         "%*d,"    /* total packets */
+                         "%*llu,"  /* missing packets */
+                         "%*llu,"  /* late packets */
+                         "%*llu,"  /* too late packets */
+                         "%*llu,"  /* resend requests */
+                         "%*lli,"  /* min DAC queue size */
+                         "%*d,"    /* min buffer occupancy */
+                         "%*d",    /* max buffer occupancy */
+                         10, moving_average_sync_error,
+                         12, play_number,
+                         7, missing_packets,
+                         7, late_packets,
+                         7, too_late_packets,
+                         7, resend_requests,
+                         7, minimum_dac_queue_size,
+                         5, minimum_buffer_occupancy,
+                         5, maximum_buffer_occupancy);
                 } 
               } else {
-								inform("Synchronisation disabled. Total packets %d; missing packets %llu; late packets %llu; too late packets %llu; "
-										 "resend requests %llu; min and max buffer occupancy "
-										 "%d and %d.",
-										 play_number, missing_packets,
-										 late_packets, too_late_packets, resend_requests,
-										 minimum_buffer_occupancy, maximum_buffer_occupancy);
-							}            
+                inform("%*.1f,"  /* Sync error inf frames */
+                       "%*d,"    /* total packets */
+                       "%*llu,"  /* missing packets */
+                       "%*llu,"  /* late packets */
+                       "%*llu,"  /* too late packets */
+                       "%*llu,"  /* resend requests */
+                       "%*d,"    /* min buffer occupancy */
+                       "%*d",    /* max buffer occupancy */
+                       10, moving_average_sync_error,
+                       12, play_number,
+                       7, missing_packets,
+                       7, late_packets,
+                       7, too_late_packets,
+                       7, resend_requests,
+                       5, minimum_buffer_occupancy,
+                       5, maximum_buffer_occupancy);
+              }
             } else {
               inform("No frames received in the last sampling interval.");
             }


### PR DESCRIPTION
Example output with synchronization enabled:

```
sync error in frames,net correction in ppm,corrections in ppm,total packets,missing packets,late packets,too late packets,resend requests,min DAC queue size,min buffer occupancy,max buffer occupancy
28.1,0.0,0.0,3758,0,1,0,1,4350,207,238
30.0,0.0,0.0,7516,0,2,0,2,5646,210,235
36.0,0.0,0.0,11274,0,4,0,4,5702,200,235
159.9,0.0,0.0,15032,0,7,0,7,5770,207,235
167.8,0.0,0.0,18790,0,8,0,8,5930,203,234
79.4,0.0,0.0,22548,0,9,0,9,5818,206,235
82.8,0.0,0.0,26306,0,10,0,10,5726,206,235
53.0,0.0,0.0,30064,0,13,0,13,5482,208,235
203.6,0.0,0.0,33822,0,16,0,16,5874,205,235
133.4,0.0,0.0,37580,0,19,0,19,5758,219,235
151.4,0.0,0.0,41338,0,23,0,23,5818,211,235
262.5,0.0,0.0,45096,0,24,0,24,5946,217,235
176.5,0.0,0.0,48854,0,28,0,28,5978,215,235
171.3,0.0,0.0,52612,0,28,0,28,5754,222,235
-99.5,0.0,0.0,56370,0,28,0,28,5222,220,235
```

One step closer to https://github.com/mikebrady/shairport-sync/issues/235.

Closes: https://github.com/mikebrady/shairport-sync/issues/295