### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Many Linux distributions have Avahi and OpenSSL already in place, so normally it
 
 Debian, Ubuntu and Raspbian users can get the basics with:
 
-- `apt-get install build-essential git` – these may already be installed.
+- `apt-get install build-essential git xmltoman` – these may already be installed.
 - `apt-get install autoconf automake libtool libdaemon-dev libasound2-dev libpopt-dev libconfig-dev`
 - `apt-get install avahi-daemon libavahi-client-dev` if you want to use Avahi (recommended).
 - `apt-get install libssl-dev` if you want to use OpenSSL and libcrypto, or use PolarSSL otherwise.


### PR DESCRIPTION
If `xmltoman` is not installed, `./configure` complains:
```
checking for xmltoman... no
configure: WARNING: >>xmltoman not found - not rebuilding man pages
```
After `xmltoman` is installed, no more complains:

`checking for xmltoman... xmltoman`

Afterwards when launching `make`, the man pages are processed ok:

`xmltoman shairport-sync.7.xml > shairport-sync.7`