### PR TITLE
Update shairport-sync.spec

### DIFF
--- a/shairport-sync.spec
+++ b/shairport-sync.spec
@@ -1,29 +1,29 @@
-Name:		shairport-sync
-Version:	2.8.2
-Release:	1%{?dist}
-Summary:	AirTunes emulator. Shairport Sync adds multi-room capability with Audio Synchronisation
+Name:           shairport-sync
+Version:        2.8.3
+Release:        1
+Summary:        AirTunes emulator. Shairport Sync adds multi-room capability with Audio Synchronisation.
 
-Group:		Applications/Multimedia
-License:	GPL
-URL:		https://github.com/mikebrady/shairport-sync
-Source0:	https://github.com/mikebrady/%{name}/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Group:          Applications/Multimedia
+License:        GPL
+URL:            https://github.com/mikebrady/shairport-sync
+Source0:        https://github.com/mikebrady/%{name}/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
-BuildRequires:	autoconf
-BuildRequires:	automake
-BuildRequires:	libconfig-devel
-BuildRequires:	popt-devel
-BuildRequires:	openssl-devel
-BuildRequires:	libdaemon-devel
-BuildRequires:	avahi-devel
-BuildRequires:	alsa-lib-devel
-BuildRequires:	systemd-units
-BuildRequires:	soxr-devel
-Requires:	popt
-Requires:	openssl
-Requires:	avahi
-Requires:	libdaemon
-Requires:	alsa-lib
-Requires:	soxr
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  libconfig-devel
+BuildRequires:  popt-devel
+BuildRequires:  openssl-devel
+BuildRequires:  libdaemon-devel
+BuildRequires:  avahi-devel
+BuildRequires:  alsa-lib-devel
+BuildRequires:  systemd-units
+BuildRequires:  soxr-devel
+Requires:       libpopt-dev
+Requires:       openssl
+Requires:       avahi
+Requires:       libdaemon
+Requires:       alsa-lib
+Requires:       soxr
 
 %description
 Shairport Sync emulates an AirPort Express for the purpose of streaming audio from iTunes, iPods, iPhones, iPads and AppleTVs. Audio played by a Shairport Sync-powered device stays synchronised with the source and hence with similar devices playing the same source. Thus, for example, synchronised multi-room audio is possible without difficulty. (Hence the name Shairport Sync, BTW.)
@@ -45,8 +45,8 @@ rm %{buildroot}/etc/shairport-sync.conf.sample
 %pre
 getent group %{name} &>/dev/null || groupadd --system %{name} >/dev/null
 getent passwd %{name} &> /dev/null || useradd --system -c "%{name} User" \
-	-d %{_localstatedir}/%{name} -m -g %{name} -s /sbin/nologin \
-	-G audio %{name} >/dev/null
+        -d %{_localstatedir}/%{name} -m -g %{name} -s /sbin/nologin \
+        -G audio %{name} >/dev/null
 
 %files
 %config /etc/shairport-sync.conf


### PR DESCRIPTION
- Fixed Version: from `2.8.2` to `2.8.3`.
- Fixed Release: special characters were reported as non-compliant by `checkinstall`.
- Replaced all occurrences of character Horizontal Tab, ASCII Dec #9, that was used everywhere between a colon and tag value. Replaced with a Blank Space ASCII Dec #32. Horizontal Tab caused problems when creating a .deb package, tag values were reported as non-compliant by `checkinstall`.
- Fixed `Requires: popt`

If a .deb package was created with `Requires: popt`, the .deb package could not be installed due to a missing Package popt, even though libpopt-dev was installed previously:
```
venca@cubox-i:~/shairport-sync$ sudo dpkg -i shairport-sync_2.8.3-1_armhf.deb
Selecting previously unselected package shairport-sync.
(Reading database ... 52746 files and directories currently installed.)
Preparing to unpack shairport-sync_2.8.3-1_armhf.deb ...
Unpacking shairport-sync (2.8.3-1) ...
dpkg: dependency problems prevent configuration of shairport-sync:
 shairport-sync depends on popt; however:
  Package popt is not installed.

dpkg: error processing package shairport-sync (--install):
 dependency problems - leaving unconfigured
Processing triggers for man-db (2.7.0.2-5) ...
Errors were encountered while processing:
 shairport-sync
```
After `Requires: popt` was changed to `Requires: libpopt-dev` and a new .deb package was created using `checkinstall`, the new package could be installed without any problem (tested under Debian Jessie).