### PR TITLE
Fix build without metadata support

### DIFF
--- a/common.c
+++ b/common.c
@@ -513,6 +513,7 @@ uint64_t get_absolute_time_in_fp() {
   return time_now_fp;
 }
 
+#ifdef CONFIG_METADATA
 ssize_t non_blocking_write(int fd, const void *buf, size_t count) {
 	void *ibuf = (void *)buf;
 	size_t bytes_remaining = count;
@@ -547,6 +548,7 @@ ssize_t non_blocking_write(int fd, const void *buf, size_t count) {
 		return rc;
   //  return write(fd,buf,count);
 }
+#endif
 
 /* from http://coding.debuntu.org/c-implementing-str_replace-replace-all-occurrences-substring#comment-722 */
 

--- a/shairport.c
+++ b/shairport.c
@@ -763,7 +763,9 @@ int main(int argc, char **argv) {
   //snprintf(config.service_name, 20 + 100, "Shairport Sync on %s", hostname);
   set_requested_connection_state_to_output(1); // we expect to be able to connect to the output device
   config.audio_backend_buffer_desired_length = 6615; // 0.15 seconds.
+#ifdef CONFIG_METADATA
   config.metadata_pipe_timeout = 5000; //milliseconds
+#endif
   config.udp_port_base = 6001;
   config.udp_port_range = 100;
 


### PR DESCRIPTION
Commit f36352dc4ece27fda24ef736183b8ff5729b8c96 introduced the parameter `pipe_timeout` for the metadata config. If shairport-sync is now configured without metadata support, the build fails with:

```
shairport.c: In function ‘main’:
shairport.c:766:9: error: ‘shairport_cfg {aka struct <anonymous>}’ has no member named ‘metadata_pipe_timeout’
   config.metadata_pipe_timeout = 5000; //milliseconds

common.c: In function ‘non_blocking_write’:
common.c:525:30: error: ‘shairport_cfg {aka struct <anonymous>}’ has no member named ‘metadata_pipe_timeout’
     rc = poll(ufds, 1, config.metadata_pipe_timeout);

```

Fix this by guarding the affected code by `CONFIG_METADATA`.