### PR TITLE
In config file, metadata socket_port needs to be a number, not a string

### DIFF
--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -36,7 +36,7 @@ metadata =
 //	pipe_name = "/tmp/shairport-sync-metadata";
 //	pipe_timeout = 5000; // wait for this number of milliseconds for a blocked pipe to unblock before giving up
 //      socket_address = "226.0.0.1"; // if set to a host name or IP address, UDP packets containing metadata will be sent to this address. May be a multicast address. "socket-port" must be non-zero and "enabled" must be set to yes"
-//      socket_port = "5555"; // if socket_address is set, the port to send UDP packets to
+//      socket_port = 5555; // if socket_address is set, the port to send UDP packets to
 //      socket_msglength = "65000"; // the maximum packet size for any UDP metadata. This will be clipped to be between 500 or 65000. The default is 500.
 };
 


### PR DESCRIPTION
Just a nit, but I tried using UDP metadata and it didn't work - kept getting port 0.  I tracked it down to the example config file using a string, but the code requires a number.

So, this changes the sample config file to reflect that.