### PR TITLE
use alsa mmap feature if supported

### DIFF
--- a/audio_alsa.c
+++ b/audio_alsa.c
@@ -85,6 +85,8 @@ static int alsa_mix_index = 0;
 static int hardware_mixer = 0;
 static int has_softvol = 0;
 
+static snd_pcm_sframes_t (*alsa_pcm_write)(snd_pcm_t *, const void *, snd_pcm_uframes_t) = snd_pcm_writei;
+
 static int play_number;
 static int64_t accumulated_delay, accumulated_da_delay;
 int alsa_characteristics_already_listed = 0;
@@ -373,6 +375,7 @@ int open_alsa_device(void) {
   unsigned int my_sample_rate = desired_sample_rate;
   // snd_pcm_uframes_t frames = 441 * 10;
   snd_pcm_uframes_t buffer_size, actual_buffer_length;
+  snd_pcm_access_t access;
 
   ret = snd_pcm_open(&alsa_handle, alsa_out_dev, SND_PCM_STREAM_PLAYBACK, 0);
   if (ret < 0)
@@ -389,8 +392,15 @@ int open_alsa_device(void) {
         alsa_out_dev);
   }
 
-  ret = snd_pcm_hw_params_set_access(alsa_handle, alsa_params,
-                                     SND_PCM_ACCESS_RW_INTERLEAVED);
+  if (snd_pcm_hw_params_set_access(alsa_handle, alsa_params, SND_PCM_ACCESS_MMAP_INTERLEAVED) >= 0) {
+    access = SND_PCM_ACCESS_MMAP_INTERLEAVED;
+    alsa_pcm_write = snd_pcm_mmap_writei;
+  } else {
+    access = SND_PCM_ACCESS_RW_INTERLEAVED;
+    alsa_pcm_write = snd_pcm_writei;
+  }
+
+  ret = snd_pcm_hw_params_set_access(alsa_handle, alsa_params, access);
   if (ret < 0) {
     die("audio_alsa: Access type not available for device \"%s\": %s",
         alsa_out_dev, snd_strerror(ret));
@@ -684,7 +694,7 @@ static void play(short buf[], int samples) {
       if (samples==0)
       	debug(1,"empty buffer being passed to pcm_writei -- skipping it");
       if ((samples!=0) && (buf!=NULL)) {
-				err = snd_pcm_writei(alsa_handle, (char *)buf, samples);
+				err = alsa_pcm_write(alsa_handle, (char *)buf, samples);
 				if (err < 0) {
 					debug(1, "Error %d writing %d samples in play(): \"%s\".", err, samples,
 								snd_strerror(err));


### PR DESCRIPTION
Use alsa direct access (mmap) feature to improve performance if mmap is supported.
For some embedded systems such as LinkIt 7688 running OpenWrt, alsa always underruns without  mmap.