### PR TITLE
Ensure scope_id is set correctly for ipv6 timing and control sockets

### DIFF
--- a/rtp.c
+++ b/rtp.c
@@ -666,9 +666,12 @@ void rtp_setup(SOCKADDR *local, SOCKADDR *remote, int cport, int tport, uint32_t
     die("Can't get address of client's control port");
 
 #ifdef AF_INET6
-  if (servinfo->ai_family == AF_INET6)
+  if (servinfo->ai_family == AF_INET6) {
     memcpy(&rtp_client_control_socket, servinfo->ai_addr, sizeof(struct sockaddr_in6));
-  else
+    // ensure the scope id matches that of remote. this is needed for link-local addresses.
+    struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)&rtp_client_control_socket;
+    sa6->sin6_scope_id = self_scope_id;
+  } else
 #endif
     memcpy(&rtp_client_control_socket, servinfo->ai_addr, sizeof(struct sockaddr_in));
   freeaddrinfo(servinfo);
@@ -682,9 +685,12 @@ void rtp_setup(SOCKADDR *local, SOCKADDR *remote, int cport, int tport, uint32_t
   if (getaddrinfo(client_ip_string, portstr, &hints, &servinfo) != 0)
     die("Can't get address of client's timing port");
 #ifdef AF_INET6
-  if (servinfo->ai_family == AF_INET6)
+  if (servinfo->ai_family == AF_INET6) {
     memcpy(&rtp_client_timing_socket, servinfo->ai_addr, sizeof(struct sockaddr_in6));
-  else
+    // ensure the scope id matches that of remote. this is needed for link-local addresses.
+    struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)&rtp_client_timing_socket;
+    sa6->sin6_scope_id = self_scope_id;
+  } else
 #endif
     memcpy(&rtp_client_timing_socket, servinfo->ai_addr, sizeof(struct sockaddr_in));
   freeaddrinfo(servinfo);


### PR DESCRIPTION
On OS X `getaddrinfo` does not set the scope_id for ipv6 link-local addresses so we set it manually instead.

This fixes errors such as `Error sendto-ing to timing socket: No route to host` on OS X.