### PR TITLE
Fix RTSP status code "Unauthorized"

### DIFF
--- a/rtsp.c
+++ b/rtsp.c
@@ -1499,12 +1499,12 @@ static void handle_announce(rtsp_conn_info *conn, rtsp_message *req,
     }
     resp->respcode = 200;
   } else {
-    resp->respcode = 453;
+    resp->respcode = 401;
     debug(1, "Already playing.");
   }
 
 out:
-  if (resp->respcode != 200 && resp->respcode != 453) {
+  if (resp->respcode != 200 && resp->respcode != 401) {
     pthread_mutex_unlock(&play_lock);
   }
 }


### PR DESCRIPTION
Following [RFC2326](https://tools.ietf.org/html/rfc2326#page-24) the status code for "Unauthorized" is 401 whereas 453 means "Not Enough Bandwidth".