### PR TITLE
Add avahi client error handling

### DIFF
--- a/mdns_avahi.c
+++ b/mdns_avahi.c
@@ -273,7 +273,7 @@ static int avahi_register(char *srvname, int srvport) {
     return -1;
   }
   if (!(client =
-            avahi_client_new(avahi_threaded_poll_get(tpoll), 0, client_callback, NULL, &err))) {
+            avahi_client_new(avahi_threaded_poll_get(tpoll), AVAHI_CLIENT_NO_FAIL, client_callback, NULL, &err))) {
     warn("couldn't create avahi client: %s!", avahi_strerror(err));
     return -1;
   }


### PR DESCRIPTION
If the avahi daemon is not up when shairport-sync is started or the avahi daemon restarts while shairport-sync is running makes shairport-sync to fail. Improve this by:

1. Add an option to the avahi client to not fail if the daemon is not up yet.
2. Add an avahi client error handler which tries to reconnect to the avahi daemon.