### PR TITLE
Rewrite and unbreak sndio backend

### DIFF
--- a/common.c
+++ b/common.c
@@ -648,7 +648,7 @@ ssize_t non_blocking_write(int fd, const void *buf, size_t count) {
     } else if (rc == 0) {
       // warn("non-blocking write timeout waiting for pipe to become ready for writing");
       rc = -1;
-      errno = -ETIME;
+      errno = -ETIMEDOUT;
     } else { // rc > 0, implying it might be ready
       ssize_t bytes_written = write(fd, ibuf, bytes_remaining);
       if (bytes_written == -1) {

--- a/configure.ac
+++ b/configure.ac
@@ -206,8 +206,8 @@ AC_ARG_WITH(alsa, [  --with-alsa = choose ALSA API support (GNU/Linux only)],
 AM_CONDITIONAL([USE_ALSA], [test "x$HAS_ALSA" = "x1"])
 
 # Look for SNDIO flag
-AC_ARG_WITH(sndio, [  --with-sndio = choose SNDIO API support (FreeBSD) -- probably broken], [
-  AC_MSG_RESULT(>>Including a SNDIO back end -- N.B. this is probably broken!)
+AC_ARG_WITH(sndio, [  --with-sndio = choose SNDIO API support], [
+  AC_MSG_RESULT(>>Including a SNDIO back end)
   HAS_SNDIO=1
   AC_DEFINE([CONFIG_SNDIO], 1, [Needed by the compiler.])
   AC_CHECK_LIB([sndio], [sio_open], , AC_MSG_ERROR(SNDIO support requires the sndio library!))], )

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -127,6 +127,16 @@ ao =
 //  audio_backend_buffer_desired_length = 1.0;  // Having started to send audio at the right time, send all subsequent audio this much ahead of time, creating a buffer this length.
 };
 
+// These are parameters for the "sndio" audio back end. All are optional.
+sndio =
+{
+//  device = "snd/0"; // the name of the output device
+//  rate = 44100; // can be 44100, 88200, 176400 or 352800, but the device must have the capability.
+//  format = "s16le"; // set output format. can be "u8", "s8", "s16le", "s24le", "s24le3", "s24be3", "s32"
+//  round = <number>; // set the period size near to this value
+//  bufsz = <number>; // set the buffer size near to this value
+};
+
 // Static latency settings are deprecated and the settings have been removed. 
 
 


### PR DESCRIPTION
The title says it all :wink:. I'm hoping this can be merged.  Seems to work well together with my lowly iPad 1.

The development branch doesn't currently build on FreeBSD, so this includes a small fix:  FreeBSD doesn't have `ETIME` so I replaced it with `ETIMEDOUT`. Nothing checks for `ETIME` so I hope this is fine.

Thank you!