### PR TITLE
read stdout from the on-start command to choose ALSA output device

### DIFF
--- a/audio_alsa.c
+++ b/audio_alsa.c
@@ -109,6 +109,10 @@ static void help(void) {
          "    *) default option\n");
 }
 
+void set_alsa_out_dev(char *dev) {
+  alsa_out_dev = dev;
+}
+
 int open_mixer() {
   if (hardware_mixer) {
     debug(2, "Open Mixer");

--- a/common.h
+++ b/common.h
@@ -116,7 +116,7 @@ typedef struct {
   int statistics_requested, use_negotiated_latencies;
   enum playback_mode_type playback_mode;
   char *cmd_start, *cmd_stop, *cmd_set_volume;
-  int cmd_blocking;
+  int cmd_blocking, cmd_start_returns_output;
   double tolerance; // allow this much drift before attempting to correct it
   enum stuffing_type packet_stuffing;
   int decoders_supported;

--- a/shairport.c
+++ b/shairport.c
@@ -694,6 +694,16 @@ int parse_options(int argc, char **argv) {
               "\"yes\" or \"no\"");
       }
 
+      if (config_lookup_string(config.cfg, "sessioncontrol.before_play_begins_returns_output", &str)) {
+        if (strcasecmp(str, "no") == 0)
+          config.cmd_start_returns_output = 0;
+        else if (strcasecmp(str, "yes") == 0)
+          config.cmd_start_returns_output = 1;
+        else
+          die("Invalid session control before_play_begins_returns_output option choice \"%s\". It should be "
+              "\"yes\" or \"no\"");
+      }
+
       if (config_lookup_string(config.cfg, "sessioncontrol.allow_session_interruption", &str)) {
         config.dont_check_timeout = 0; // this is for legacy -- only set by -t 0
         if (strcasecmp(str, "no") == 0)
@@ -1276,6 +1286,7 @@ int main(int argc, char **argv) {
   debug(1, "on-start action is \"%s\".", config.cmd_start);
   debug(1, "on-stop action is \"%s\".", config.cmd_stop);
   debug(1, "wait-cmd status is %d.", config.cmd_blocking);
+  debug(1, "on-start returns output is %d.", config.cmd_start_returns_output);
   debug(1, "mdns backend \"%s\".", config.mdns_name);
   debug(2, "userSuppliedLatency is %d.", config.userSuppliedLatency);
   debug(2, "AirPlayLatency is %d.", config.AirPlayLatency);


### PR DESCRIPTION
refs GH-452

this will enable me to multiplex a small number of USB audio cards (say 2 or 3) into a much larger matrix, and still have AirPlay advertise each zone individually (as well as virtual airplay zones activating multiple physical zones, if I desire)