### PR TITLE
clean up dynamic output device a bit

### DIFF
--- a/audio.h
+++ b/audio.h
@@ -43,6 +43,8 @@ typedef struct {
   // may be NULL, in which case software muting is used.
   void (*mute)(int do_mute);
 
+  // may be NULL, in which case changing out device on-the-fly is not supported
+  void (*change_output_device)(char *device);
 } audio_output;
 
 audio_output *audio_get_output(char *name);

--- a/audio_ao.c
+++ b/audio_ao.c
@@ -187,4 +187,5 @@ audio_output audio_ao = {.name = "ao",
                          .play = &play,
                          .volume = NULL,
                          .parameters = NULL,
-                         .mute = NULL};
+                         .mute = NULL,
+                         .change_output_device = NULL};

--- a/audio_dummy.c
+++ b/audio_dummy.c
@@ -65,4 +65,5 @@ audio_output audio_dummy = {.name = "dummy",
                             .play = &play,
                             .volume = NULL,
                             .parameters = NULL,
-                            .mute = NULL};
+                            .mute = NULL,
+                            .change_output_device = NULL};

--- a/audio_pa.c
+++ b/audio_pa.c
@@ -238,7 +238,8 @@ audio_output audio_pa = {.name = "pa",
                          .play = &play,
                          .volume = NULL,
                          .parameters = NULL,
-                         .mute = NULL};
+                         .mute = NULL,
+                         .change_output_device = NULL};
 
 void context_state_cb(pa_context *context, void *mainloop) {
   pa_threaded_mainloop_signal(mainloop, 0);

--- a/audio_pipe.c
+++ b/audio_pipe.c
@@ -187,4 +187,5 @@ audio_output audio_pipe = {.name = "pipe",
                            .play = &play,
                            .volume = NULL,
                            .parameters = NULL,
-                           .mute = NULL};
+                           .mute = NULL,
+                           .change_output_device = NULL};

--- a/audio_pulse.c
+++ b/audio_pulse.c
@@ -140,4 +140,5 @@ audio_output audio_pulse = {.name = "pulse",
                             .play = &play,
                             .volume = NULL,
                             .parameters = NULL,
-                            .mute = NULL};
+                            .mute = NULL,
+                            .change_output_device = NULL};

--- a/audio_sndio.c
+++ b/audio_sndio.c
@@ -50,7 +50,8 @@ audio_output audio_sndio = {.name = "sndio",
                             .play = &play,
                             .volume = NULL,
                             .parameters = NULL,
-                            .mute = NULL};
+                            .mute = NULL,
+                            .change_output_device = NULL};
 
 static pthread_mutex_t sndio_mutex = PTHREAD_MUTEX_INITIALIZER;
 static struct sio_hdl *hdl;

--- a/audio_soundio.c
+++ b/audio_soundio.c
@@ -212,4 +212,5 @@ audio_output audio_soundio = {.name = "soundio",
                               .play = &play,
                               .volume = NULL,
                               .parameters = &parameters,
-                              .mute = NULL};
+                              .mute = NULL,
+                              .change_output_device = NULL};

--- a/audio_stdout.c
+++ b/audio_stdout.c
@@ -140,4 +140,5 @@ audio_output audio_stdout = {.name = "stdout",
                              .play = &play,
                              .volume = NULL,
                              .parameters = NULL,
-                             .mute = NULL};
+                             .mute = NULL,
+                             .change_output_device = NULL};

--- a/common.c
+++ b/common.c
@@ -80,10 +80,6 @@
 
 #include <libdaemon/dlog.h>
 
-#ifdef CONFIG_ALSA
-void set_alsa_out_dev(char *);
-#endif
-
 // true if Shairport Sync is supposed to be sending output to the output device, false otherwise
 
 static volatile int requested_connection_state_to_output = 1;
@@ -553,7 +549,7 @@ void command_start(void) {
           debug(1, "on-start command %s finished with error %d", config.cmd_start, errno);
         }
         if (config.cmd_start_returns_output) {
-          static char buffer[256];
+          char buffer[256];
           int len;
           close(pipes[1]);
           len = read(pipes[0], buffer, 255);
@@ -562,9 +558,8 @@ void command_start(void) {
           if (buffer[len - 1] == '\n')
             buffer[len - 1] = '\0'; // strip trailing newlines
           debug(1, "received '%s' as the device to use from the on-start command", buffer);
-#ifdef CONFIG_ALSA
-          set_alsa_out_dev(buffer);
-#endif
+          if (config.output->change_output_device)
+            config.output->change_output_device(buffer);
         }
       }
       // debug(1,"Continue after on-start command");

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -86,6 +86,7 @@ sessioncontrol =
 //	run_this_before_play_begins = "/full/path/to/application and args"; // make sure the application has executable permission. It it's a script, include the #!... stuff on the first line
 //	run_this_after_play_ends = "/full/path/to/application and args"; // make sure the application has executable permission. It it's a script, include the #!... stuff on the first line
 //	wait_for_completion = "no"; // set to "yes" to get Shairport Sync to wait until the "run_this..." applications have terminated before continuing
+//	before_play_begins_returns_output = "no"; // set to "yes", and Shairport Sync will choose the output device based on what is written to stdout by the before play script. ALSA only.
 //	allow_session_interruption = "no"; // set to "yes" to allow another device to interrupt Shairport Sync while it's playing from an existing audio source
 //	session_timeout = 120; // wait for this number of seconds after a source disappears before terminating the session and becoming available again.
 };


### PR DESCRIPTION
still ALSA specific, but should be easy to add to others. and no, I won't be offended if you rip this out in the future for a more robust implementation (say something that you could specify a different config section instead of just the device name, including completely different backends).