### PR TITLE
Fixed race condition when stopping other threads with SIGUSR1

### DIFF
--- a/common.c
+++ b/common.c
@@ -92,6 +92,8 @@ shairport_cfg config;
 
 int debuglev = 0;
 
+sigset_t pselect_sigset;
+
 int get_requested_connection_state_to_output() { return requested_connection_state_to_output; }
 
 void set_requested_connection_state_to_output(int v) { requested_connection_state_to_output = v; }

--- a/common.h
+++ b/common.h
@@ -4,6 +4,7 @@
 #include <libconfig.h>
 #include <stdint.h>
 #include <sys/socket.h>
+#include <signal.h>
 
 #include "audio.h"
 #include "config.h"
@@ -218,5 +219,7 @@ void command_set_volume(double volume);
 
 void shairport_shutdown();
 // void shairport_startup_complete(void);
+
+extern sigset_t pselect_sigset;
 
 #endif // _COMMON_H

--- a/mdns_external.c
+++ b/mdns_external.c
@@ -28,7 +28,6 @@
 #include "common.h"
 #include <errno.h>
 #include <fcntl.h>
-#include <signal.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>

--- a/player.c
+++ b/player.c
@@ -35,7 +35,6 @@
 #include <limits.h>
 #include <math.h>
 #include <pthread.h>
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdlib.h>

--- a/shairport.c
+++ b/shairport.c
@@ -33,7 +33,6 @@
 #include <memory.h>
 #include <net/if.h>
 #include <popt.h>
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
@@ -986,6 +985,10 @@ void signal_setup(void) {
   sigdelset(&set, SIGCHLD);
   sigdelset(&set, SIGUSR2);
   pthread_sigmask(SIG_BLOCK, &set, NULL);
+
+  // SIGUSR1 is used to interrupt a thread if blocked in pselect
+  pthread_sigmask(SIG_SETMASK, NULL, &pselect_sigset);
+  sigdelset(&pselect_sigset, SIGUSR1);
 
   // setting this to SIG_IGN would prevent signalling any threads.
   struct sigaction sa;


### PR DESCRIPTION
I've got one other issue besides those in pull request #611, but this one is more complicated and more debatable, so I think it's better to open a separate pull request for it.

Many threads have got a main loop that checks some exit variable in the loop condition, e.g. `conn->please_stop`, `conn->timing_sender_stop` or `conn->stop`. To stop a thread, another thread sets that exit variable, sends a SIGUSR1 to that thread to get it out of blocking calls like `read()`, `write()` or `select()`, and finally joins it.

There is a hidden race condition though, a lost signal condition, which actually hit me several times: The signal wakes up the target thread only if it is actually blocked right now. If the target thread is currently executing some code outside the above mentioned system calls, it has got no effect. This is still fine if the thread is going to check the exit condition before the next blocking system call, but it fails if the signal arrives just after the check in the loop exit condition, but before the call to `read()` or similar. The section _Blocking Signals_ in http://www.linuxprogrammingblog.com/all-about-linux-signals has helped me to understand this issue better.

The only solution I know is to block SIGUSR1 until the blocking system call. Blocking a signal means that the signal is not delivered immediately, but postponed to the moment when you unblock it again. To be really thread-safe, unblocking the signal and blocking on a socket must be an atomic unit, so you can't do it yourself. You need a system call that provides this atomic unit, and AFAIK the only system in the Posix standard that provides this is `pselect()`. Therefore I propose a fix where every call to `read()`, `recv()`, `write()` and `sendto()` is prepended by a call to `pselect()` in a loop that checks the exit condition.

Unfortunately, this blows up the code and makes it less readable. And it requires that every function calling `read()`, `recv()`, `write()` or `sendto()` knows which exit variable it must check. Above all, I'm not convinced that I've corrected every such call. I actually left out some concerning metadata or the start and stop shell commands, because I was unsure what to do. So if you decide to merge this pull request, please double-check it first. Maybe you have got an idea how to solve that problem more elegantly?
