### PR TITLE
Fix CVE-2017-12087 in bundled tinysvcmdns (development branch)

### DIFF
--- a/tinysvcmdns.c
+++ b/tinysvcmdns.c
@@ -123,20 +123,32 @@ uint8_t *join_nlabel(const uint8_t *n1, const uint8_t *n2) {
 char *nlabel_to_str(const uint8_t *name) {
   char *label, *labelp;
   const uint8_t *p;
+  size_t buf_len = 256;
 
   assert(name != NULL);
 
-  label = labelp = malloc(256);
+  label = labelp = malloc(buf_len);
 
   if (label) {
     for (p = name; *p; p++) {
-      strncpy(labelp, (char *)p + 1, *p);
-      labelp += *p;
+      uint8_t label_len = *p;
+      if (buf_len <= label_len)
+        break;
+
+      strncpy(labelp, (char *)p + 1, label_len);
+      labelp += label_len;
+
       *labelp = '.';
       labelp++;
 
-      p += *p;
+      buf_len -= label_len + 1;
+
+      p += label_len;
     }
+
+    // avoid writing NULL past end of buffer
+    if (buf_len == 0)
+      labelp--;
 
     *labelp = '\0';
   } else {


### PR DESCRIPTION
This patch incorporates upstream's fixes for a remotely exploitable buffer overflow bug in the bundled `tinysvcmdns` library. The following upstream commits are included:

https://bitbucket.org/geekman/tinysvcmdns/commits/48c73fbb36b7a5584b00538d89c89dd8b15ab2a7
https://bitbucket.org/geekman/tinysvcmdns/commits/29ea1b9fca94dc42d16109e050d2967231b1e341

The changes have been incorporated preserving local changes such as the check for `malloc()` returning `NULL`.

Reported against `shairport-sync` in Ubuntu Launchpad:
https://bugs.launchpad.net/ubuntu/+source/shairport-sync/+bug/1729668

This commit closes GitHub issue #619.