### PR TITLE
Fix detecting soxr in static builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,12 +176,18 @@ AC_ARG_WITH(ssl, [ choose --with-ssl=openssl, --with-ssl=mbedtls or --with-ssl=p
 # Look for soxr flag
 AC_ARG_WITH(soxr, [  --with-soxr = choose libsoxr for high-quality interpolation], [
   AC_MSG_RESULT(>>Including support for soxr-based interpolation)
-  AC_CHECK_LIB([avutil],[av_get_cpu_flags])
-  if  test "x${ac_cv_lib_avutil_av_get_cpu_flags}" = xyes ; then
-    # soxr may link against libavutil, depending on the architecture, but for the sake of simplicity link with it if it is found
-    AC_CHECK_LIB([soxr],[soxr_create], , AC_MSG_ERROR(soxr support requested but libsoxr not found!), [-lavutil])
+  if  test "x${with_pkg_config}" = xyes ; then
+    PKG_CHECK_MODULES(
+        [SOXR], [soxr],
+        [LIBS="${SOXR_LIBS} ${LIBS}"])
   else
-    AC_CHECK_LIB([soxr],[soxr_create], , AC_MSG_ERROR(soxr support requested but libsoxr not found!))
+    AC_CHECK_LIB([avutil],[av_get_cpu_flags])
+    if  test "x${ac_cv_lib_avutil_av_get_cpu_flags}" = xyes ; then
+      # soxr may link against libavutil, depending on the architecture, but for the sake of simplicity link with it if it is found
+      AC_CHECK_LIB([soxr],[soxr_create], , AC_MSG_ERROR(soxr support requested but libsoxr not found!), [-lavutil])
+    else
+      AC_CHECK_LIB([soxr],[soxr_create], , AC_MSG_ERROR(soxr support requested but libsoxr not found!))
+    fi
   fi
 ], )
 

--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,14 @@ AC_ARG_WITH(ssl, [ choose --with-ssl=openssl, --with-ssl=mbedtls or --with-ssl=p
 # Look for soxr flag
 AC_ARG_WITH(soxr, [  --with-soxr = choose libsoxr for high-quality interpolation], [
   AC_MSG_RESULT(>>Including support for soxr-based interpolation)
-  AC_CHECK_LIB([soxr],[soxr_create], , AC_MSG_ERROR(soxr support requested but libsoxr not found!))], )
+  AC_CHECK_LIB([avutil],[av_get_cpu_flags])
+  if  test "x${ac_cv_lib_avutil_av_get_cpu_flags}" = xyes ; then
+    # soxr may link against libavutil, depending on the architecture, but for the sake of simplicity link with it if it is found
+    AC_CHECK_LIB([soxr],[soxr_create], , AC_MSG_ERROR(soxr support requested but libsoxr not found!), [-lavutil])
+  else
+    AC_CHECK_LIB([soxr],[soxr_create], , AC_MSG_ERROR(soxr support requested but libsoxr not found!))
+  fi
+], )
 
 # Look for metadata flag -- set flag for conditional compilation
 AC_ARG_WITH(metadata, [  --with-metadata = include support for a metadata feed], [


### PR DESCRIPTION
The Buildroot autobuilder detected a build [issue](http://autobuild.buildroot.org/results/53d/53d21686780aa2485745b59e812b6280dd39f1c5//shairport-sync-3.2.1/config.log) when building shairport-sync statically:

```
arm-buildroot-linux-uclibcgnueabi/sysroot/usr//lib/libsoxr.a(soxr.c.o): In function `soxr_create':
soxr.c:(.text+0xd4c): undefined reference to `av_get_cpu_flags'
collect2: error: ld returned 1 exit status
```

A quick look at the soxr source code shows that `soxr_create()` might use `av_get_cpu_flags()` under certain circumstances.

Therefore, `-lavutil` should be added to `[other-libraries]`. Even better, as soxr provides a pkg-config file, this should be prefered.