### PR TITLE
Add another example on Bluetooth speaker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,9 +477,13 @@ alsa =
 ```
 
 To prevent stuttering with AAC or aptX, set `audio_backend_buffer_desired_length_in_seconds` to a value big enough.
+
 To make bluetooth device sync with other devices, manually adjust `audio_backend_latency_offset_in_seconds`.
+
 Here `output_device` is the one defined in `asound.conf`, for example, `pcm.headset`.
+
 To enable volume control of Airplay, it is also required to set mixer device for bluetooth. You can use command `amixer scontrols -D bluealsa` to acquire name of your mixer device. Example output: `Simple mixer control 'Speaker - A2DP',0`
+
 If your bluetooth device isn't connected when shairport-sync starts, shairport-sync may fail to start. Therefore you should also add some delay for startup.
 
 Metadata

--- a/README.md
+++ b/README.md
@@ -462,6 +462,25 @@ general = {
 
 ```
 
+And another example if you want to send audio to Bluetooth speakers with alsa backend:
+```
+general = {
+  audio_backend_latency_offset_in_seconds = -0.23;
+  audio_backend_buffer_desired_length_in_seconds = 1.0;
+}
+alsa =
+{
+  output_device = "headset";
+  mixer_control_name = "Speaker - A2DP";
+  mixer_device = "bluealsa";
+};
+```
+
+To prevent stuttering with AAC or aptX, set `audio_backend_buffer_desired_length_in_seconds` to a value big enough.
+To make bluetooth device sync with other devices, manually adjust `audio_backend_latency_offset_in_seconds`.
+Here `output_device` is the one defined in `asound.conf`, for example, `pcm.headset`.
+To enable volume control of Airplay, it is also required to set mixer device for bluetooth. You can use command `amixer scontrols -D bluealsa` to acquire name of your mixer device. Example output: `Simple mixer control 'Speaker - A2DP',0`
+If your bluetooth device isn't connected when shairport-sync starts, shairport-sync may fail to start. Therefore you should also add some delay for startup.
 
 Metadata
 --------


### PR DESCRIPTION
Hello,
Recently I'm trying setting up Airplay on one of my bluetooth speakers. I've met with many difficulties such as stuttering sound. Finally I succeeded in delivering sound (AAC / aptX) to my speakers with `bluealsa` and enabling volume control on my Raspberry Pi, and I'd like to share my configuration with other users, which may fix (possibly) #559 and #200 . Is it possible to add this example in README.md? Thank you for reading my PR.