### PR TITLE
Add configuration option to specify PulseAudio output sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,15 @@ alsa =
 };
 ```
 
-The `pa` group is used to specify settings relevant to the PulseAudio backend. You can set the "Application Name" that will appear in the "Sound" control panel.
+The `pa` group is used to specify settings relevant to the PulseAudio backend. You can set the "Application Name" that will appear in the "Sound" control panel. You can also set the sink name that audio will be pushed to. Here's an example `pa` group configuration:
+
+```
+pa = 
+{
+  application_name = "Shairport Sync - Bedroom";
+  sink = "server_bedroom"; // Sink name or ID. If not specified, the default sink will be used.
+};
+```
 
 Shairport Sync can run programs just before it starts to play an audio stream and just after it finishes. You specify them using the `sessioncontrol` group settings `run_this_before_play_begins` and `run_this_after_play_ends`. This is to facilitate situations where something has to be done before and after playing, e.g. switching on an amplifier beforehand and switching it off afterwards. Set the `wait_for_completion` value to `"yes"` for Shairport Sync to wait until the respective commands have been completed before continuing.
 

--- a/common.h
+++ b/common.h
@@ -84,7 +84,9 @@ typedef struct {
 #ifdef CONFIG_PA
   char *pa_application_name; // the name under which Shairport Sync shows up as an "Application" in
                              // the Sound Preferences in most desktop Linuxes.
-// Defaults to "Shairport Sync". Shairport Sync must be playing to see it.
+                             // Defaults to "Shairport Sync". Shairport Sync must be playing to see it.
+
+  char *pa_sink;    // the name (or id) of the sink that Shairport Sync will play on.
 #endif
 #ifdef CONFIG_METADATA
   int metadata_enabled;


### PR DESCRIPTION
I believe the title explains the contribution quite well. 

I recently wanted to switch from using Shairport Sync on all Raspberries around my house to using it on one server and distributing the audio using PulseAudio's sinks and server-client connections. To be able to do that, I had to add a configuration option to Shairport Sync that would allow me to specify a sink that I want to push audio to. 