### PR TITLE
normalize whitespaces in scripts/shairport-sync.conf

### DIFF
--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -29,9 +29,9 @@ general =
 //	volume_control_profile = "standard" ; // use this advanced setting to specify how the airplay volume is transferred to the mixer volume.
 //		"standard" makes the volume change more quickly at lower volumes and slower at higher volumes.
 //		"flat" makes the volume change at the same rate at all volumes.
-//  run_this_when_volume_is_set = "/full/path/to/application/and/args"; //  Run the specified application whenever the volume control is set or changed.
-//    The desired AirPlay volume is appended to the end of the command line – leave a space if you want it treated as an extra argument.
-//    AirPlay volume goes from 0 to -30 and -144 means "mute".
+//	run_this_when_volume_is_set = "/full/path/to/application/and/args"; //	Run the specified application whenever the volume control is set or changed.
+//		The desired AirPlay volume is appended to the end of the command line – leave a space if you want it treated as an extra argument.
+//		AirPlay volume goes from 0 to -30 and -144 means "mute".
 
 //	regtype = "_raop._tcp"; // Use this advanced setting to set the service type and transport to be advertised by Zeroconf/Bonjour. Default is "_raop._tcp".
 //	playback_mode = "stereo"; // This can be "stereo", "mono", "reverse stereo", "both left" or "both right". Default is "stereo".
@@ -39,17 +39,17 @@ general =
 //		the original Shairport decoder by David Hammerton or the Apple Lossless Audio Codec (ALAC) decoder written by Apple.
 //	interface = "name"; // Use this advanced setting to specify the interface on which Shairport Sync should provide its service. Leave it commented out to get the default, which is to select the interface(s) automatically.
 
-//  audio_backend_latency_offset_in_seconds = 0.0; // Set this offset to compensate for a fixed delay in the audio back end. E.g. if the output device delays by 100 ms, set this to -0.1.
-//  audio_backend_buffer_desired_length_in_seconds = 0.15; // If set too small, buffer underflow occurs on low-powered machines. Too long and the response time to volume changes becomes annoying. Default is 0.15 seconds in the alsa backend, 0.35 seconds in the pa backend and 1.0 seconds otherwise.
-//  audio_backend_silent_lead_in_time = 2.0; // This optional advanced setting, from 0.0 and 4.0 seconds, sets the length of the period of silence that precedes the start of the audio. The default is the latency, usually 2.0 seconds. Values greater than the latency are ignored. Values that are too low will affect initial synchronisation.
-//  dbus_service_bus = "system"; // The Shairport Sync dbus interface, if selected at compilation, will appear
-//    as "org.gnome.ShairportSync" on the whichever bus you specify here: "system" (default) or "session".
-//  mpris_service_bus = "system"; // The Shairport Sync mpris interface, if selected at compilation, will appear
-//    as "org.gnome.ShairportSync" on the whichever bus you specify here: "system" (default) or "session".
+//	audio_backend_latency_offset_in_seconds = 0.0; // Set this offset to compensate for a fixed delay in the audio back end. E.g. if the output device delays by 100 ms, set this to -0.1.
+//	audio_backend_buffer_desired_length_in_seconds = 0.15; // If set too small, buffer underflow occurs on low-powered machines. Too long and the response time to volume changes becomes annoying. Default is 0.15 seconds in the alsa backend, 0.35 seconds in the pa backend and 1.0 seconds otherwise.
+//	audio_backend_silent_lead_in_time = 2.0; // This optional advanced setting, from 0.0 and 4.0 seconds, sets the length of the period of silence that precedes the start of the audio. The default is the latency, usually 2.0 seconds. Values greater than the latency are ignored. Values that are too low will affect initial synchronisation.
+//	dbus_service_bus = "system"; // The Shairport Sync dbus interface, if selected at compilation, will appear
+//		as "org.gnome.ShairportSync" on the whichever bus you specify here: "system" (default) or "session".
+//	mpris_service_bus = "system"; // The Shairport Sync mpris interface, if selected at compilation, will appear
+//		as "org.gnome.ShairportSync" on the whichever bus you specify here: "system" (default) or "session".
 };
 
 // Advanced parameters for controlling how Shairport Sync runs a play session
-sessioncontrol = 
+sessioncontrol =
 {
 //	run_this_before_play_begins = "/full/path/to/application and args"; // make sure the application has executable permission. If it's a script, include the shebang (#!/bin/...) on the first line
 //	run_this_after_play_ends = "/full/path/to/application and args"; // make sure the application has executable permission. If it's a script, include the shebang (#!/bin/...) on the first line
@@ -63,72 +63,72 @@ sessioncontrol =
 // These are parameters for the "alsa" audio back end.
 alsa =
 {
-//  output_device = "default"; // the name of the alsa output device. Use "alsamixer" or "aplay" to find out the names of devices, mixers, etc.
-//  mixer_control_name = "PCM"; // the name of the mixer to use to adjust output volume. If not specified, volume in adjusted in software.
-//  mixer_device = "default"; // the mixer_device default is whatever the output_device is. Normally you wouldn't have to use this.
-//  output_rate = 44100; // can be 44100, 88200, 176400 or 352800, but the device must have the capability.
-//  output_format = "S16"; // can be "U8", "S8", "S16", "S24", "S24_3LE", "S24_3BE" or "S32", but the device must have the capability. Except where stated using (*LE or *BE), endianness matches that of the processor.
-//  disable_synchronization = "no"; // Set to "yes" to disable synchronization. Default is "no".
-//  period_size = <number>; // Use this optional advanced setting to set the alsa period size near to this value
-//  buffer_size = <number>; // Use this optional advanced setting to set the alsa buffer size near to this value
-//  use_mmap_if_available = "yes"; // Use this optional advanced setting to control whether MMAP-based output is used to communicate  with the DAC. Default is "yes"
-//  use_hardware_mute_if_available = "no"; // Use this optional advanced setting to control whether the hardware in the DAC is used for muting. Default is "no", for compatibility with other audio players.
+//	output_device = "default"; // the name of the alsa output device. Use "alsamixer" or "aplay" to find out the names of devices, mixers, etc.
+//	mixer_control_name = "PCM"; // the name of the mixer to use to adjust output volume. If not specified, volume in adjusted in software.
+//	mixer_device = "default"; // the mixer_device default is whatever the output_device is. Normally you wouldn't have to use this.
+//	output_rate = 44100; // can be 44100, 88200, 176400 or 352800, but the device must have the capability.
+//	output_format = "S16"; // can be "U8", "S8", "S16", "S24", "S24_3LE", "S24_3BE" or "S32", but the device must have the capability. Except where stated using (*LE or *BE), endianness matches that of the processor.
+//	disable_synchronization = "no"; // Set to "yes" to disable synchronization. Default is "no".
+//	period_size = <number>; // Use this optional advanced setting to set the alsa period size near to this value
+//	buffer_size = <number>; // Use this optional advanced setting to set the alsa buffer size near to this value
+//	use_mmap_if_available = "yes"; // Use this optional advanced setting to control whether MMAP-based output is used to communicate  with the DAC. Default is "yes"
+//	use_hardware_mute_if_available = "no"; // Use this optional advanced setting to control whether the hardware in the DAC is used for muting. Default is "no", for compatibility with other audio players.
 };
 
 // Parameters for the "sndio" audio back end. All are optional.
 sndio =
 {
-//  device = "snd/0"; // optional setting to set the name of the output device. Default is the sndio system default.
-//  rate = 44100; // optional setting  which can be 44100, 88200, 176400 or 352800, but the device must have the capability. Default is 44100.
-//  format = "S16"; // optional setting  which can be "U8", "S8", "S16", "S24", "S24_3LE", "S24_3BE" or "S32", but the device must have the capability. Except where stated using (*LE or *BE), endianness matches that of the processor.
-//  round = <number>; // advanced optional setting to set the period size near to this value
-//  bufsz = <number>; // advanced optional setting to set the buffer size near to this value
+//	device = "snd/0"; // optional setting to set the name of the output device. Default is the sndio system default.
+//	rate = 44100; // optional setting  which can be 44100, 88200, 176400 or 352800, but the device must have the capability. Default is 44100.
+//	format = "S16"; // optional setting  which can be "U8", "S8", "S16", "S24", "S24_3LE", "S24_3BE" or "S32", but the device must have the capability. Except where stated using (*LE or *BE), endianness matches that of the processor.
+//	round = <number>; // advanced optional setting to set the period size near to this value
+//	bufsz = <number>; // advanced optional setting to set the buffer size near to this value
 };
 
 // Parameters for the "pa" PulseAudio  backend.
 pa =
 {
-//  application_name = "Shairport Sync"; //Set this to the name that should appear in the Sounds "Applications" tab when Shairport Sync is active.
+//	application_name = "Shairport Sync"; //Set this to the name that should appear in the Sounds "Applications" tab when Shairport Sync is active.
 };
 
 // Parameters for the "pipe" audio back end, a back end that directs raw CD-style audio output to a pipe. No interpolation is done.
 pipe =
 {
-//  name = "/path/to/pipe"; // there is no default pipe name for the output
+//	name = "/path/to/pipe"; // there is no default pipe name for the output
 };
 
 // These are no configuration file parameters for the "stdout" audio back end. No interpolation is done.
 
 // These are no configuration file  parameters for the "ao" audio back end. No interpolation is done.
 
-// Static latency settings are deprecated and the settings have been removed. 
+// Static latency settings are deprecated and the settings have been removed.
 
 dsp =
 {
 
 //////////////////////////////////////////
-//  This convolution filter can be used to apply almost any correction to the audio signal, like frequency and phase correction.
-//  For example you could measure (with a good microphone and a sweep-sine) the frequency response of your speakers + room,
-//  and apply a correction to get a flat response curve.
+// This convolution filter can be used to apply almost any correction to the audio signal, like frequency and phase correction.
+// For example you could measure (with a good microphone and a sweep-sine) the frequency response of your speakers + room,
+// and apply a correction to get a flat response curve.
 //////////////////////////////////////////
 //
-//  convolution = "yes";                  // Activate the convolution filter.
-//  convolution_ir_file = "impulse.wav";  // Impulse Response file to be convolved to the audio stream
-//  convolution_gain = -4.0;              // Static gain applied to prevent clipping during the convolution process
-//  convolution_max_length = 44100;       // Truncate the input file to this length in order to save CPU.
+//	convolution = "yes";                  // Activate the convolution filter.
+//	convolution_ir_file = "impulse.wav";  // Impulse Response file to be convolved to the audio stream
+//	convolution_gain = -4.0;              // Static gain applied to prevent clipping during the convolution process
+//	convolution_max_length = 44100;       // Truncate the input file to this length in order to save CPU.
 
 
 //////////////////////////////////////////
-//  This loudness filter is used to compensate for human ear non linearity.
-//  When the volume decreases, our ears loose more sentisitivity in the low range frequencies than in the mid range ones.
-//  This filter aims at compensating for this loss, applying a variable gain to low frequencies depending on the volume.
-//  More info can be found here: https://en.wikipedia.org/wiki/Equal-loudness_contour
-//  For this filter to work properly, you should disable (or set to a fix value) all other volume control and only let shairport-sync control your volume.
-//  The setting "loudness_reference_volume_db" should be set at the volume reported by shairport-sync when listening to music at a normal listening volume.
+// This loudness filter is used to compensate for human ear non linearity.
+// When the volume decreases, our ears loose more sentisitivity in the low range frequencies than in the mid range ones.
+// This filter aims at compensating for this loss, applying a variable gain to low frequencies depending on the volume.
+// More info can be found here: https://en.wikipedia.org/wiki/Equal-loudness_contour
+// For this filter to work properly, you should disable (or set to a fix value) all other volume control and only let shairport-sync control your volume.
+// The setting "loudness_reference_volume_db" should be set at the volume reported by shairport-sync when listening to music at a normal listening volume.
 //////////////////////////////////////////
 //
-//  loudness = "yes";                     // Activate the filter
-//  loudness_reference_volume_db = -20.0; // Above this level the filter will have no effect anymore. Below this level it will gradually boost the low frequencies.
+//	loudness = "yes";                     // Activate the filter
+//	loudness_reference_volume_db = -20.0; // Above this level the filter will have no effect anymore. Below this level it will gradually boost the low frequencies.
 
 };
 


### PR DESCRIPTION
This inconsistency int tab/spaces was pretty annoying while editing shairport-sync.conf :)
Or is there a reason behind it?