### PR TITLE
Revamped timestamp calculation

### DIFF
--- a/audio_alsa.c
+++ b/audio_alsa.c
@@ -899,13 +899,13 @@ int delay(long *the_delay) {
       measurement_data_is_valid = 0;
 
       if (dac_state == SND_PCM_STATE_PREPARED) {
-        debug(1, "delay not available -- state is SND_PCM_STATE_PREPARED");
+        debug(2, "delay not available -- state is SND_PCM_STATE_PREPARED");
       } else {
         if (dac_state == SND_PCM_STATE_XRUN) {
-          debug(1, "delay not available -- state is SND_PCM_STATE_XRUN");
+          debug(2, "delay not available -- state is SND_PCM_STATE_XRUN");
         } else {
 
-          debug(1, "Error -- ALSA delay(): bad state: %d.", dac_state);
+          debug(2, "Error -- ALSA delay(): bad state: %d.", dac_state);
         }
         if ((derr = snd_pcm_prepare(alsa_handle))) {
           snd_pcm_recover(alsa_handle, derr, 1);

--- a/audio_alsa.c
+++ b/audio_alsa.c
@@ -894,15 +894,15 @@ int delay(long *the_delay) {
         }
       }
     } else {
-      reply = -EIO; // shomething is wrong
+      reply = -EIO;    // shomething is wrong
       frame_index = 0; // we'll be starting over...
       measurement_data_is_valid = 0;
 
       if (dac_state == SND_PCM_STATE_PREPARED) {
-        debug(1,"delay not available -- state is SND_PCM_STATE_PREPARED");
+        debug(1, "delay not available -- state is SND_PCM_STATE_PREPARED");
       } else {
         if (dac_state == SND_PCM_STATE_XRUN) {
-          debug(1,"delay not available -- state is SND_PCM_STATE_XRUN"); 
+          debug(1, "delay not available -- state is SND_PCM_STATE_XRUN");
         } else {
 
           debug(1, "Error -- ALSA delay(): bad state: %d.", dac_state);

--- a/audio_pa.c
+++ b/audio_pa.c
@@ -187,12 +187,14 @@ static void start(__attribute__((unused)) int sample_rate,
 
   if (config.pa_sink) {
     // Connect stream to the sink specified in the config
-    connect_result = pa_stream_connect_playback(stream, config.pa_sink, &buffer_attr, stream_flags, NULL, NULL);
+    connect_result =
+        pa_stream_connect_playback(stream, config.pa_sink, &buffer_attr, stream_flags, NULL, NULL);
   } else {
     // Connect stream to the default audio output sink
-    connect_result = pa_stream_connect_playback(stream, NULL, &buffer_attr, stream_flags, NULL, NULL);
+    connect_result =
+        pa_stream_connect_playback(stream, NULL, &buffer_attr, stream_flags, NULL, NULL);
   }
-  
+
   if (connect_result != 0)
     die("could not connect to the pulseaudio playback stream -- the error message is \"%s\".",
         pa_strerror(pa_context_errno(context)));

--- a/common.h
+++ b/common.h
@@ -84,9 +84,9 @@ typedef struct {
 #ifdef CONFIG_PA
   char *pa_application_name; // the name under which Shairport Sync shows up as an "Application" in
                              // the Sound Preferences in most desktop Linuxes.
-                             // Defaults to "Shairport Sync". Shairport Sync must be playing to see it.
+  // Defaults to "Shairport Sync". Shairport Sync must be playing to see it.
 
-  char *pa_sink;    // the name (or id) of the sink that Shairport Sync will play on.
+  char *pa_sink; // the name (or id) of the sink that Shairport Sync will play on.
 #endif
 #ifdef CONFIG_METADATA
   int metadata_enabled;
@@ -136,7 +136,7 @@ typedef struct {
   int buffer_start_fill;
   uint32_t userSuppliedLatency; // overrides all other latencies -- use with caution
   uint32_t fixedLatencyOffset;  // add this to all automatic latencies supplied to get the actual
-                               // total latency
+                                // total latency
   // the total latency will be limited to the min and max-latency values, if supplied
   int daemonise;
   int daemonise_store_pid; // don't try to save a PID file

--- a/common.h
+++ b/common.h
@@ -134,8 +134,8 @@ typedef struct {
   char *mdns_name;
   mdns_backend *mdns;
   int buffer_start_fill;
-  int64_t userSuppliedLatency; // overrides all other latencies -- use with caution
-  int64_t fixedLatencyOffset;  // add this to all automatic latencies supplied to get the actual
+  uint32_t userSuppliedLatency; // overrides all other latencies -- use with caution
+  uint32_t fixedLatencyOffset;  // add this to all automatic latencies supplied to get the actual
                                // total latency
   // the total latency will be limited to the min and max-latency values, if supplied
   int daemonise;

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.50])
-AC_INIT([shairport-sync], [3.3d16], [mikebrady@eircom.net])
+AC_INIT([shairport-sync], [3.3d17], [mikebrady@eircom.net])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([shairport.c])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.50])
-AC_INIT([shairport-sync], [3.3d17], [mikebrady@eircom.net])
+AC_INIT([shairport-sync], [3.3d18], [mikebrady@eircom.net])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([shairport.c])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.50])
-AC_INIT([shairport-sync], [3.3d18], [mikebrady@eircom.net])
+AC_INIT([shairport-sync], [3.3d19], [mikebrady@eircom.net])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([shairport.c])
 AC_CONFIG_HEADERS([config.h])

--- a/player.c
+++ b/player.c
@@ -1136,7 +1136,7 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
                     int64_t frame_gap = (lead_time * config.output_rate) >> 32;
                     // debug(1,"%d frames needed.",frame_gap);
                     while (frame_gap > 0) {
-                      size_t fs = config.output_rate / 10;
+                      ssize_t fs = config.output_rate / 10;
                       if (fs > frame_gap)
                         fs = frame_gap;
 

--- a/player.c
+++ b/player.c
@@ -2085,7 +2085,7 @@ void *player_thread_func(void *arg) {
               //        sync_error_out_of_bounds, sync_error);
               sync_error_out_of_bounds = 0;
 
-              int64_t filler_length = (int64_t)config.resyncthreshold * config.output_rate; // number of samples
+              int64_t filler_length = (int64_t)(config.resyncthreshold * config.output_rate); // number of samples
               if ((sync_error > 0) && (sync_error > filler_length)) {
                 debug(1, "Large positive sync error: %" PRId64 ".", sync_error);
                 frames_to_drop = sync_error / conn->output_sample_ratio;
@@ -2098,6 +2098,7 @@ void *player_thread_func(void *arg) {
                 char *long_silence = malloc(conn->output_bytes_per_frame * silence_length_sized);
                 if (long_silence) {
                   memset(long_silence, 0, conn->output_bytes_per_frame * silence_length_sized);
+                  debug(1,"Play a silence of %d frames.",silence_length_sized);
                   config.output->play(long_silence, silence_length_sized);
                   free(long_silence);
                 } else {

--- a/player.c
+++ b/player.c
@@ -2114,7 +2114,7 @@ void *player_thread_func(void *arg) {
                 char *long_silence = malloc(conn->output_bytes_per_frame * silence_length_sized);
                 if (long_silence) {
                   memset(long_silence, 0, conn->output_bytes_per_frame * silence_length_sized);
-                  debug(1,"Play a silence of %d frames.",silence_length_sized);
+                  debug(2,"Play a silence of %d frames.",silence_length_sized);
                   config.output->play(long_silence, silence_length_sized);
                   free(long_silence);
                 } else {

--- a/player.c
+++ b/player.c
@@ -1610,7 +1610,7 @@ void *player_thread_func(void *arg) {
   signed short *inbuf;
   int inbuflength;
 
-  int output_bit_depth = 16; // default;
+  unsigned int output_bit_depth = 16; // default;
 
   switch (config.output_format) {
   case SPS_FORMAT_S8:

--- a/player.c
+++ b/player.c
@@ -602,6 +602,7 @@ void player_put_packet(seq_t seqno, uint32_t actual_timestamp, uint8_t *data,
                    j)) { // prevent multiple requests from the same level of lookback
                 check_buf->resend_level = j;
                 if (config.disable_resend_requests == 0) {
+                	debug_mutex_unlock(&conn->ab_mutex, 3);
                   rtp_request_resend(next, 1, conn);
                   conn->resend_requests++;
                   debug_mutex_lock(&conn->ab_mutex, 20000, 1);

--- a/player.c
+++ b/player.c
@@ -100,10 +100,10 @@
 #define BUFIDX(seqno) ((seq_t)(seqno) % BUFFER_FRAMES)
 
 uint32_t rtp_frame_offset(uint32_t from, uint32_t to) {
-	if (from <= to)
-		return to - from;
-	else
-		return UINT32_MAX - from + to + 1;
+  if (from <= to)
+    return to - from;
+  else
+    return UINT32_MAX - from + to + 1;
 }
 
 void do_flush(uint32_t timestamp, rtsp_conn_info *conn);
@@ -120,33 +120,34 @@ static void ab_resync(rtsp_conn_info *conn) {
   conn->ab_buffering = 1;
 }
 
-// given starting and ending points as unsigned 32-bit integers running modulo 2^32, returns the position of x in the interval in *pos
+// given starting and ending points as unsigned 32-bit integers running modulo 2^32, returns the
+// position of x in the interval in *pos
 // returns true if x is actually within the buffer
 
-int position_in_modulo_uint32_t_buffer(uint32_t x, uint32_t start, uint32_t end, uint32_t *pos ) {
-	int response = 0; // not in the buffer
-	if (start <= end ) {
-		if (x < start) {
-			if (pos)
-				*pos = UINT32_MAX - start + 1 + x;
-		} else {
-			if (pos)
-				*pos = x - start;
-			if (x < end) 
-				response = 1;
-		}
-	} else if ((x >= start) && (x <= UINT32_MAX)) {
-		response = 1;
-		if (pos)
-			*pos = x - start;
-	} else {
-		if (pos)
-			*pos = UINT32_MAX - start + 1 + x;
-		if (x < end) {
-			response = 1;
-		}
-	}
-	return response;
+int position_in_modulo_uint32_t_buffer(uint32_t x, uint32_t start, uint32_t end, uint32_t *pos) {
+  int response = 0; // not in the buffer
+  if (start <= end) {
+    if (x < start) {
+      if (pos)
+        *pos = UINT32_MAX - start + 1 + x;
+    } else {
+      if (pos)
+        *pos = x - start;
+      if (x < end)
+        response = 1;
+    }
+  } else if ((x >= start) && (x <= UINT32_MAX)) {
+    response = 1;
+    if (pos)
+      *pos = x - start;
+  } else {
+    if (pos)
+      *pos = UINT32_MAX - start + 1 + x;
+    if (x < end) {
+      response = 1;
+    }
+  }
+  return response;
 }
 
 // this is used.
@@ -441,8 +442,8 @@ static void free_audio_buffers(rtsp_conn_info *conn) {
     free(conn->audio_buffer[i].data);
 }
 
-void player_put_packet(seq_t seqno, uint32_t actual_timestamp, uint8_t *data,
-                       int len, rtsp_conn_info *conn) {
+void player_put_packet(seq_t seqno, uint32_t actual_timestamp, uint8_t *data, int len,
+                       rtsp_conn_info *conn) {
 
   // ignore a request to flush that has been made before the first packet...
   if (conn->packet_count == 0) {
@@ -460,26 +461,31 @@ void player_put_packet(seq_t seqno, uint32_t actual_timestamp, uint8_t *data,
 
     //    if (flush_rtp_timestamp != 0)
     //    	debug(1,"Flush_rtp_timestamp is %u",flush_rtp_timestamp);
-    
-    // now, if a flush_rtp_timestamp has been defined and the incoming timestamp is "before" it, drop it…
-    
-    if ((conn->flush_rtp_timestamp != 0) && (rtp_frame_offset(actual_timestamp,conn->flush_rtp_timestamp) < 8820)) {// if it's less than 0.2 seconds
-				debug(2, "Dropping flushed packet in player_put_packet, seqno %u, timestamp %" PRIu32
-					 ", flushing to "
-					 "timestamp: %" PRIu32 ".",
-				seqno, actual_timestamp, conn->flush_rtp_timestamp);
-				conn->initial_reference_time = 0;
-				conn->initial_reference_timestamp = 0;
+
+    // now, if a flush_rtp_timestamp has been defined and the incoming timestamp is "before" it,
+    // drop it…
+
+    if ((conn->flush_rtp_timestamp != 0) &&
+        (rtp_frame_offset(actual_timestamp, conn->flush_rtp_timestamp) <
+         8820)) { // if it's less than 0.2 seconds
+      debug(2, "Dropping flushed packet in player_put_packet, seqno %u, timestamp %" PRIu32
+               ", flushing to "
+               "timestamp: %" PRIu32 ".",
+            seqno, actual_timestamp, conn->flush_rtp_timestamp);
+      conn->initial_reference_time = 0;
+      conn->initial_reference_timestamp = 0;
     } else {
-      if ((conn->flush_rtp_timestamp != 0) && (rtp_frame_offset(conn->flush_rtp_timestamp,actual_timestamp) > 8820) && (rtp_frame_offset(conn->flush_rtp_timestamp,actual_timestamp) < 44100)) {
-      	debug(2,"Dropping flush request");
+      if ((conn->flush_rtp_timestamp != 0) &&
+          (rtp_frame_offset(conn->flush_rtp_timestamp, actual_timestamp) > 8820) &&
+          (rtp_frame_offset(conn->flush_rtp_timestamp, actual_timestamp) < 44100)) {
+        debug(2, "Dropping flush request");
         conn->flush_rtp_timestamp = 0;
       }
 
       abuf_t *abuf = 0;
 
       if (!conn->ab_synced) {
-      	// if this is the first packet…
+        // if this is the first packet…
         debug(3, "syncing to seqno %u.", seqno);
         conn->ab_write = seqno;
         conn->ab_read = seqno;
@@ -500,7 +506,8 @@ void player_put_packet(seq_t seqno, uint32_t actual_timestamp, uint8_t *data,
         conn->resend_interval = resend_interval;
       }
 
-      if (conn->ab_write == seqno) { // if this is the expected packet (which could be the first packet…)
+      if (conn->ab_write ==
+          seqno) { // if this is the expected packet (which could be the first packet…)
         uint64_t reception_time = get_absolute_time_in_fp();
         if (conn->input_frame_rate_starting_point_is_valid == 0) {
           if ((conn->packet_count_since_flush >= 500) && (conn->packet_count_since_flush <= 510)) {
@@ -602,7 +609,7 @@ void player_put_packet(seq_t seqno, uint32_t actual_timestamp, uint8_t *data,
                    j)) { // prevent multiple requests from the same level of lookback
                 check_buf->resend_level = j;
                 if (config.disable_resend_requests == 0) {
-                	debug_mutex_unlock(&conn->ab_mutex, 3);
+                  debug_mutex_unlock(&conn->ab_mutex, 3);
                   rtp_request_resend(next, 1, conn);
                   conn->resend_requests++;
                   debug_mutex_lock(&conn->ab_mutex, 20000, 1);
@@ -853,12 +860,14 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
               debug(1, "Inconsistent sequence numbers detected");
             }
           }
-          
-					if ((conn->flush_rtp_timestamp != 0) && (rtp_frame_offset(curframe->given_timestamp,conn->flush_rtp_timestamp) < 8820)) {// if it's less than 0.2 seconds
-						debug(2, "Dropping flushed packet in buffer_get_frame, seqno %u, timestamp %" PRIu32
-							 ", flushing to "
-							 "timestamp: %" PRIu32 ".",
-						curframe->sequence_number, curframe->given_timestamp, conn->flush_rtp_timestamp);
+
+          if ((conn->flush_rtp_timestamp != 0) &&
+              (rtp_frame_offset(curframe->given_timestamp, conn->flush_rtp_timestamp) <
+               8820)) { // if it's less than 0.2 seconds
+            debug(2, "Dropping flushed packet in buffer_get_frame, seqno %u, timestamp %" PRIu32
+                     ", flushing to "
+                     "timestamp: %" PRIu32 ".",
+                  curframe->sequence_number, curframe->given_timestamp, conn->flush_rtp_timestamp);
             curframe->ready = 0;
             curframe->resend_level = 0;
             flush_limit += curframe->length;
@@ -866,10 +875,12 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
             conn->initial_reference_time = 0;
             conn->initial_reference_timestamp = 0;
           }
-					if ((conn->flush_rtp_timestamp != 0) && (rtp_frame_offset(conn->flush_rtp_timestamp,curframe->given_timestamp) > 8820) && (rtp_frame_offset(conn->flush_rtp_timestamp,curframe->given_timestamp) < 44100)) {
-						debug(2,"Dropping flush request");
-						conn->flush_rtp_timestamp = 0;
-					}
+          if ((conn->flush_rtp_timestamp != 0) &&
+              (rtp_frame_offset(conn->flush_rtp_timestamp, curframe->given_timestamp) > 8820) &&
+              (rtp_frame_offset(conn->flush_rtp_timestamp, curframe->given_timestamp) < 44100)) {
+            debug(2, "Dropping flush request");
+            conn->flush_rtp_timestamp = 0;
+          }
         }
       } while ((conn->flush_rtp_timestamp != 0) && (flush_limit <= 8820) && (curframe->ready == 0));
 
@@ -901,7 +912,7 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
               // debug(1,"First frame seen with timestamp...");
               conn->first_packet_timestamp =
                   curframe->given_timestamp; // we will keep buffering until we are
-                                       // supposed to start playing this
+                                             // supposed to start playing this
               have_sent_prefiller_silence = 0;
               conn->packet_stream_established = 1;
 
@@ -943,10 +954,11 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
               // frame should be played"
 
               uint64_t should_be_time;
-              frame_to_local_time(
-                  conn->first_packet_timestamp + conn->latency +
-                      (uint32_t)(config.audio_backend_latency_offset * conn->input_rate), // this will go modulo 2^32
-                  &should_be_time, conn);
+              frame_to_local_time(conn->first_packet_timestamp + conn->latency +
+                                      (uint32_t)(config.audio_backend_latency_offset *
+                                                 conn->input_rate), // this will go modulo 2^32
+                                  &should_be_time,
+                                  conn);
 
               conn->first_packet_time_to_play = should_be_time;
 
@@ -964,10 +976,11 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
             // recalculate conn->first_packet_time_to_play -- the latency might change
 
             uint64_t should_be_time;
-            frame_to_local_time(
-                conn->first_packet_timestamp + conn->latency +
-                    (uint32_t)(config.audio_backend_latency_offset * conn->input_rate), // this should go modulo 2^32
-                &should_be_time, conn);
+            frame_to_local_time(conn->first_packet_timestamp + conn->latency +
+                                    (uint32_t)(config.audio_backend_latency_offset *
+                                               conn->input_rate), // this should go modulo 2^32
+                                &should_be_time,
+                                conn);
 
             conn->first_packet_time_to_play = should_be_time;
 
@@ -979,9 +992,9 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
 
             int64_t max_dac_delay = config.output_rate / 10; // so the lead-in time must be greater
                                                              // than this, say 0.2 sec, to allow for
-                                                             // dynamic adjustment            
+                                                             // dynamic adjustment
             int64_t filler_size = max_dac_delay;
-            
+
             if (local_time_now >= conn->first_packet_time_to_play) {
               // debug(1,"Gone past starting time");
               have_sent_prefiller_silence = 1;
@@ -1006,34 +1019,38 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
               int64_t lead_time = conn->first_packet_time_to_play - local_time_now;
               // an audio_backend_silent_lead_in_time of less than zero means start filling ASAP
               int64_t lead_in_time = -1;
-              if (config.audio_backend_silent_lead_in_time>=0)
+              if (config.audio_backend_silent_lead_in_time >= 0)
                 lead_in_time =
-                  (int64_t)(config.audio_backend_silent_lead_in_time * (int64_t)0x100000000);
+                    (int64_t)(config.audio_backend_silent_lead_in_time * (int64_t)0x100000000);
               // debug(1,"Lead time is %llx at fpttp
               // %llx.",lead_time,conn->first_packet_time_to_play);
               if ((lead_in_time < 0) || (lead_time <= lead_in_time)) {
-              // debug(1,"Lead time is %" PRIx64 ", lead-in time is %" PRIx64 " at fpttp %llx.",lead_time,conn->first_packet_time_to_play);
+                // debug(1,"Lead time is %" PRIx64 ", lead-in time is %" PRIx64 " at fpttp
+                // %llx.",lead_time,conn->first_packet_time_to_play);
 
                 // debug(1,"Checking");
                 if (config.output->delay) {
                   // conn->first_packet_time_to_play is definitely later than local_time_now
                   int resp = 0;
                   dac_delay = 0;
-                  if (have_sent_prefiller_silence != 0) 
+                  if (have_sent_prefiller_silence != 0)
                     resp = config.output->delay(&dac_delay);
                   if (resp == 0) {
                     int64_t gross_frame_gap =
                         ((conn->first_packet_time_to_play - local_time_now) * config.output_rate) >>
                         32;
                     int64_t exact_frame_gap = gross_frame_gap - dac_delay;
-                    // debug(1,"Exact and gross frame gaps are %" PRId64 " and %" PRId64 " frames, and the dac delay is %ld.", exact_frame_gap, gross_frame_gap, dac_delay);
+                    // debug(1,"Exact and gross frame gaps are %" PRId64 " and %" PRId64 " frames,
+                    // and the dac delay is %ld.", exact_frame_gap, gross_frame_gap, dac_delay);
                     if (exact_frame_gap < 0) {
                       // we've gone past the time...
                       // debug(1,"Run past time.");
-                      
-                      // this might happen if a big clock adjustment was made at just the wrong time.
-                      
-                      debug(1,"Run a bit past the exact start time by %" PRId64 " frames.",-exact_frame_gap);
+
+                      // this might happen if a big clock adjustment was made at just the wrong
+                      // time.
+
+                      debug(1, "Run a bit past the exact start time by %" PRId64 " frames.",
+                            -exact_frame_gap);
                       if (config.output->flush)
                         config.output->flush();
                       ab_resync(conn);
@@ -1044,7 +1061,9 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
                       if (fs > (max_dac_delay - dac_delay))
                         fs = max_dac_delay - dac_delay;
                       if (fs < 0) {
-                        // this could happen if the dac delay mysteriously grows between samples, which could happen in a transition between having no interpolation and having interpolated buffer numbers.
+                        // this could happen if the dac delay mysteriously grows between samples,
+                        // which could happen in a transition between having no interpolation and
+                        // having interpolated buffer numbers.
                         debug(2,
                               "frame size (fs) < 0 with max_dac_delay of %lld and dac_delay of %ld",
                               max_dac_delay, dac_delay);
@@ -1062,7 +1081,8 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
                       }
                       void *silence;
                       // if (fs==0)
-                      //  debug(2,"Zero length silence buffer needed with gross_frame_gap of %lld and
+                      //  debug(2,"Zero length silence buffer needed with gross_frame_gap of %lld
+                      //  and
                       //  dac_delay of %lld.",gross_frame_gap,dac_delay);
                       // the fs (number of frames of silence to play) can be zero in the DAC doesn't
                       // start
@@ -1162,11 +1182,12 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
       if (have_timestamp_timing_information(conn)) { // if we have a reference time
 
         uint64_t time_to_play;
-        frame_to_local_time(
-            curframe->given_timestamp + conn->latency +
-                (uint32_t)(config.audio_backend_latency_offset * conn->input_rate) -
-                (uint32_t)(config.audio_backend_buffer_desired_length * conn->input_rate), // this will go modulo 2^32
-            &time_to_play, conn);
+        frame_to_local_time(curframe->given_timestamp + conn->latency +
+                                (uint32_t)(config.audio_backend_latency_offset * conn->input_rate) -
+                                (uint32_t)(config.audio_backend_buffer_desired_length *
+                                           conn->input_rate), // this will go modulo 2^32
+                            &time_to_play,
+                            conn);
 
         if (local_time_now >= time_to_play) {
           do_wait = 0;
@@ -1909,8 +1930,8 @@ void *player_thread_func(void *arg) {
           get_reference_timestamp_stuff(&reference_timestamp, &reference_timestamp_time,
                                         &remote_reference_timestamp_time, conn); // types okay
           int64_t rt, nt;
-          rt = reference_timestamp; // uint32_t to int64_t
-          nt = inframe->given_timestamp;  // uint32_t to int64_t
+          rt = reference_timestamp;      // uint32_t to int64_t
+          nt = inframe->given_timestamp; // uint32_t to int64_t
           rt *= conn->output_sample_ratio;
           nt *= conn->output_sample_ratio;
 
@@ -2041,11 +2062,12 @@ void *player_thread_func(void *arg) {
                 (config.resyncthreshold > 0.0) &&
                 (abs_sync_error > config.resyncthreshold * config.output_rate)) {
               if (abs_sync_error > 3 * config.output_rate) {
-              
+
                 warn("Very large sync error: %" PRId64 " frames, with should_be_frame: %" PRId64
-                     ",  nt: %" PRId64
-                     ", current_delay: %" PRId64 ", given timestamp %" PRIX32 ", reference timestamp %" PRIX32 ", should_be_frame %" PRIX32 ".",
-                     sync_error, should_be_frame, nt, current_delay, inframe->given_timestamp, reference_timestamp, should_be_frame_32);
+                     ",  nt: %" PRId64 ", current_delay: %" PRId64 ", given timestamp %" PRIX32
+                     ", reference timestamp %" PRIX32 ", should_be_frame %" PRIX32 ".",
+                     sync_error, should_be_frame, nt, current_delay, inframe->given_timestamp,
+                     reference_timestamp, should_be_frame_32);
               }
               sync_error_out_of_bounds++;
             } else {

--- a/player.h
+++ b/player.h
@@ -242,6 +242,8 @@ typedef struct {
   void *dapo_private_storage;  // this is used for compatibility, if dacp stuff isn't enabled.
 } rtsp_conn_info;
 
+uint32_t rtp_frame_offset(uint32_t from, uint32_t to);
+
 int player_play(rtsp_conn_info *conn);
 int player_stop(rtsp_conn_info *conn);
 

--- a/player.h
+++ b/player.h
@@ -68,14 +68,14 @@ typedef struct {
 } stream_cfg;
 
 typedef struct {
-  int connection_number;   // for debug ID purposes, nothing else...
-  int resend_interval;     // this is really just for debugging
-  int AirPlayVersion;      // zero if not an AirPlay session. Used to help calculate latency
+  int connection_number;    // for debug ID purposes, nothing else...
+  int resend_interval;      // this is really just for debugging
+  int AirPlayVersion;       // zero if not an AirPlay session. Used to help calculate latency
   uint32_t latency;         // the actual latency used for this play session
   uint32_t minimum_latency; // set if an a=min-latency: line appears in the ANNOUNCE message; zero
-                           // otherwise
+                            // otherwise
   uint32_t maximum_latency; // set if an a=max-latency: line appears in the ANNOUNCE message; zero
-                           // otherwise
+                            // otherwise
 
   int fd;
   int authorized;   // set if a password is required and has been supplied
@@ -250,8 +250,8 @@ int player_stop(rtsp_conn_info *conn);
 void player_volume(double f, rtsp_conn_info *conn);
 void player_volume_without_notification(double f, rtsp_conn_info *conn);
 void player_flush(uint32_t timestamp, rtsp_conn_info *conn);
-void player_put_packet(seq_t seqno, uint32_t actual_timestamp, uint8_t *data,
-                       int len, rtsp_conn_info *conn);
+void player_put_packet(seq_t seqno, uint32_t actual_timestamp, uint8_t *data, int len,
+                       rtsp_conn_info *conn);
 int64_t monotonic_timestamp(uint32_t timestamp,
                             rtsp_conn_info *conn); // add an epoch to the timestamp. The monotonic
 // timestamp guaranteed to start between 2^32 2^33

--- a/player.h
+++ b/player.h
@@ -111,7 +111,7 @@ typedef struct {
   // other stuff...
   pthread_t *player_thread;
   abuf_t audio_buffer[BUFFER_FRAMES];
-  int max_frames_per_packet, input_num_channels, input_bit_depth, input_rate;
+  unsigned int max_frames_per_packet, input_num_channels, input_bit_depth, input_rate;
   int input_bytes_per_frame, output_bytes_per_frame, output_sample_ratio;
   int max_frame_size_change;
   int64_t previous_random_number;

--- a/player.h
+++ b/player.h
@@ -218,7 +218,8 @@ typedef struct {
                                         // slightly above or  below.
   int local_to_remote_time_gradient_sample_count; // the number of samples used to calculate the
                                                   // gradient
-  uint64_t local_to_remote_time_difference;       // used to switch between local and remote clocks
+  // add the following to the local time to get the remote time modulo 2^64
+  uint64_t local_to_remote_time_difference; // used to switch between local and remote clocks
   uint64_t local_to_remote_time_difference_measurement_time; // when the above was calculated
 
   int last_stuff_request;
@@ -242,7 +243,8 @@ typedef struct {
   void *dapo_private_storage;  // this is used for compatibility, if dacp stuff isn't enabled.
 } rtsp_conn_info;
 
-uint32_t rtp_frame_offset(uint32_t from, uint32_t to);
+uint32_t modulo_32_offset(uint32_t from, uint32_t to);
+uint64_t modulo_64_offset(uint64_t from, uint64_t to);
 
 int player_play(rtsp_conn_info *conn);
 int player_stop(rtsp_conn_info *conn);

--- a/player.h
+++ b/player.h
@@ -40,7 +40,7 @@ typedef uint16_t seq_t;
 typedef struct audio_buffer_entry { // decoded audio packets
   int ready;
   int resend_level;
-  int64_t timestamp;
+  // int64_t timestamp;
   seq_t sequence_number;
   uint32_t given_timestamp; // for debugging and checking
   signed short *data;
@@ -71,10 +71,10 @@ typedef struct {
   int connection_number;   // for debug ID purposes, nothing else...
   int resend_interval;     // this is really just for debugging
   int AirPlayVersion;      // zero if not an AirPlay session. Used to help calculate latency
-  int64_t latency;         // the actual latency used for this play session
-  int64_t minimum_latency; // set if an a=min-latency: line appears in the ANNOUNCE message; zero
+  uint32_t latency;         // the actual latency used for this play session
+  uint32_t minimum_latency; // set if an a=min-latency: line appears in the ANNOUNCE message; zero
                            // otherwise
-  int64_t maximum_latency; // set if an a=max-latency: line appears in the ANNOUNCE message; zero
+  uint32_t maximum_latency; // set if an a=max-latency: line appears in the ANNOUNCE message; zero
                            // otherwise
 
   int fd;
@@ -103,10 +103,10 @@ typedef struct {
   int input_frame_rate_starting_point_is_valid;
 
   uint64_t frames_inward_measurement_start_time;
-  uint64_t frames_inward_frames_received_at_measurement_start_time;
+  uint32_t frames_inward_frames_received_at_measurement_start_time;
 
   uint64_t frames_inward_measurement_time;
-  uint64_t frames_inward_frames_received_at_measurement_time;
+  uint32_t frames_inward_frames_received_at_measurement_time;
 
   // other stuff...
   pthread_t *player_thread;
@@ -136,7 +136,7 @@ typedef struct {
   int ab_buffering, ab_synced;
   int64_t first_packet_timestamp;
   int flush_requested;
-  int64_t flush_rtp_timestamp;
+  uint32_t flush_rtp_timestamp;
   uint64_t time_of_last_audio_packet;
   seq_t ab_read, ab_write;
 
@@ -187,7 +187,7 @@ typedef struct {
 
   // this is what connects an rtp timestamp to the remote time
 
-  int64_t reference_timestamp;
+  uint32_t reference_timestamp;
   uint64_t remote_reference_timestamp_time;
 
   int packet_stream_established; // true if a stream of packets is flowing, made true by a first
@@ -195,7 +195,7 @@ typedef struct {
 
   // used as the initials values for calculating the rate at which the source thinks it's sending
   // frames
-  int64_t initial_reference_timestamp;
+  uint32_t initial_reference_timestamp;
   uint64_t initial_reference_time;
   double remote_frame_rate;
 
@@ -247,8 +247,8 @@ int player_stop(rtsp_conn_info *conn);
 
 void player_volume(double f, rtsp_conn_info *conn);
 void player_volume_without_notification(double f, rtsp_conn_info *conn);
-void player_flush(int64_t timestamp, rtsp_conn_info *conn);
-void player_put_packet(seq_t seqno, uint32_t actual_timestamp, int64_t timestamp, uint8_t *data,
+void player_flush(uint32_t timestamp, rtsp_conn_info *conn);
+void player_put_packet(seq_t seqno, uint32_t actual_timestamp, uint8_t *data,
                        int len, rtsp_conn_info *conn);
 int64_t monotonic_timestamp(uint32_t timestamp,
                             rtsp_conn_info *conn); // add an epoch to the timestamp. The monotonic

--- a/rtp.c
+++ b/rtp.c
@@ -1074,7 +1074,7 @@ int frame_to_local_time(uint32_t timestamp, uint64_t *time, rtsp_conn_info *conn
   uint64_t timestamp_interval_time;
   uint64_t remote_time_of_timestamp;
   uint32_t timestamp_interval = rtp_frame_offset(conn->reference_timestamp,timestamp);
-  if (timestamp_interval <= 44100*10) { // i.e. timestamp was really after the reference timestamp
+  if (timestamp_interval <= conn->input_rate*10) { // i.e. timestamp was really after the reference timestamp
     timestamp_interval_time =
         (timestamp_interval * time_difference) /
         (frame_difference);                             // this is the nominal time, based on the

--- a/rtp.c
+++ b/rtp.c
@@ -329,10 +329,14 @@ void *rtp_control_receiver(void *arg) {
               // Sigh, it would be nice to have a published protocol...
 
               uint16_t flags = nctohs(&packet[2]);
-              uint32_t la = sync_rtp_timestamp - rtp_timestamp_less_latency; // note, this might loop around in modulo. Not sure if you'll get an error!
+              uint32_t la = sync_rtp_timestamp - rtp_timestamp_less_latency; // note, this might
+                                                                             // loop around in
+                                                                             // modulo. Not sure if
+                                                                             // you'll get an error!
               // debug(3, "Latency derived just from the sync packet is %" PRIu32 " frames.", la);
-              
-              if ((flags == 7) || ((conn->AirPlayVersion > 0) && (conn->AirPlayVersion <= 353)) || ((conn->AirPlayVersion > 0) && (conn->AirPlayVersion >= 371))) {
+
+              if ((flags == 7) || ((conn->AirPlayVersion > 0) && (conn->AirPlayVersion <= 353)) ||
+                  ((conn->AirPlayVersion > 0) && (conn->AirPlayVersion >= 371))) {
                 la += config.fixedLatencyOffset;
                 // debug(3, "A fixed latency offset of %d frames has been added, giving a latency of
                 // "
@@ -350,7 +354,8 @@ void *rtp_control_receiver(void *arg) {
 
               if (la > max_frames) {
                 warn("An out-of-range latency request of %" PRIu32
-                     " frames was ignored. Must be %" PRIu32 " frames or less (44,100 frames per second). "
+                     " frames was ignored. Must be %" PRIu32
+                     " frames or less (44,100 frames per second). "
                      "Latency remains at %" PRIu32 " frames.",
                      la, max_frames, conn->latency);
               } else {
@@ -379,7 +384,8 @@ void *rtp_control_receiver(void *arg) {
                 if (remote_frame_time_interval) {
                   conn->remote_frame_rate =
                       (1.0 * (conn->reference_timestamp - conn->initial_reference_timestamp)) /
-                      remote_frame_time_interval; // an IEEE double calculation with a 32-bit numerator and 64-bit denominator
+                      remote_frame_time_interval; // an IEEE double calculation with a 32-bit
+                                                  // numerator and 64-bit denominator
                                                   // integers
                   conn->remote_frame_rate = conn->remote_frame_rate *
                                             (uint64_t)0x100000000; // this should just change the
@@ -1040,8 +1046,9 @@ int sanitised_source_rate_information(uint32_t *frames, uint64_t *time, rtsp_con
   *time = (uint64_t)(0x100000000); // one second in fp form
   if ((conn->packet_stream_established) && (conn->initial_reference_time) &&
       (conn->initial_reference_timestamp)) {
-//    uint32_t local_frames = conn->reference_timestamp - conn->initial_reference_timestamp;
-    uint32_t local_frames = rtp_frame_offset(conn->initial_reference_timestamp, conn->reference_timestamp);
+    //    uint32_t local_frames = conn->reference_timestamp - conn->initial_reference_timestamp;
+    uint32_t local_frames =
+        rtp_frame_offset(conn->initial_reference_timestamp, conn->reference_timestamp);
     uint64_t local_time = conn->remote_reference_timestamp_time - conn->initial_reference_time;
     if ((local_frames == 0) || (local_time == 0) || (use_nominal_rate)) {
       result = 1;
@@ -1073,24 +1080,24 @@ int frame_to_local_time(uint32_t timestamp, uint64_t *time, rtsp_conn_info *conn
 
   uint64_t timestamp_interval_time;
   uint64_t remote_time_of_timestamp;
-  uint32_t timestamp_interval = rtp_frame_offset(conn->reference_timestamp,timestamp);
-  if (timestamp_interval <= conn->input_rate*10) { // i.e. timestamp was really after the reference timestamp
-    timestamp_interval_time =
-        (timestamp_interval * time_difference) /
-        (frame_difference);                             // this is the nominal time, based on the
-                                                        // fps specified between current and
-                                                        // previous sync frame.
+  uint32_t timestamp_interval = rtp_frame_offset(conn->reference_timestamp, timestamp);
+  if (timestamp_interval <=
+      conn->input_rate * 10) { // i.e. timestamp was really after the reference timestamp
+    timestamp_interval_time = (timestamp_interval * time_difference) /
+                              (frame_difference); // this is the nominal time, based on the
+                                                  // fps specified between current and
+                                                  // previous sync frame.
     remote_time_of_timestamp = conn->remote_reference_timestamp_time +
                                timestamp_interval_time; // based on the reference timestamp time
                                                         // plus the time interval calculated based
                                                         // on the specified fps.
   } else { // i.e. timestamp was actually after the reference timestamp
-    timestamp_interval = rtp_frame_offset(timestamp,conn->reference_timestamp); // fix the calculation
-    timestamp_interval_time =
-        (timestamp_interval * time_difference) /
-        (frame_difference);                             // this is the nominal time, based on the
-                                                        // fps specified between current and
-                                                        // previous sync frame.
+    timestamp_interval =
+        rtp_frame_offset(timestamp, conn->reference_timestamp); // fix the calculation
+    timestamp_interval_time = (timestamp_interval * time_difference) /
+                              (frame_difference); // this is the nominal time, based on the
+                                                  // fps specified between current and
+                                                  // previous sync frame.
     remote_time_of_timestamp = conn->remote_reference_timestamp_time -
                                timestamp_interval_time; // based on the reference timestamp time
                                                         // plus the time interval calculated based

--- a/rtp.h
+++ b/rtp.h
@@ -17,7 +17,7 @@ void rtp_setup(SOCKADDR *local, SOCKADDR *remote, uint16_t controlport, uint16_t
 void rtp_request_resend(seq_t first, uint32_t count, rtsp_conn_info *conn);
 void rtp_request_client_pause(rtsp_conn_info *conn); // ask the client to pause
 
-void get_reference_timestamp_stuff(int64_t *timestamp, uint64_t *timestamp_time,
+void get_reference_timestamp_stuff(uint32_t *timestamp, uint64_t *timestamp_time,
                                    uint64_t *remote_timestamp_time, rtsp_conn_info *conn);
 void clear_reference_timestamp(rtsp_conn_info *conn);
 

--- a/rtp.h
+++ b/rtp.h
@@ -25,9 +25,9 @@ int have_timestamp_timing_information(rtsp_conn_info *conn);
 
 int get_frame_play_time(int64_t timestamp, int sample_ratio, uint64_t *time_to_play);
 
-int frame_to_local_time(int64_t timestamp, uint64_t *time, rtsp_conn_info *conn);
-int local_time_to_frame(uint64_t time, int64_t *frame, rtsp_conn_info *conn);
+int frame_to_local_time(uint32_t timestamp, uint64_t *time, rtsp_conn_info *conn);
+int local_time_to_frame(uint64_t time, uint32_t *frame, rtsp_conn_info *conn);
 
-int sanitised_source_rate_information(int64_t *frames, uint64_t *time, rtsp_conn_info *conn);
+int sanitised_source_rate_information(uint32_t *frames, uint64_t *time, rtsp_conn_info *conn);
 
 #endif // _RTP_H

--- a/rtsp.c
+++ b/rtsp.c
@@ -285,7 +285,7 @@ void cancel_all_RTSP_threads(void) {
   }
 }
 
-static void cleanup_threads(void) {
+void cleanup_threads(void) {
   void *retval;
   int i;
   // debug(2, "culling threads.");
@@ -348,7 +348,7 @@ static char *nextline(char *in, int inbuf) {
   return out;
 }
 
-static void msg_retain(rtsp_message *msg) {
+void msg_retain(rtsp_message *msg) {
   if (msg) {
     int rc = pthread_mutex_lock(&reference_counter_lock);
     if (rc)
@@ -362,7 +362,7 @@ static void msg_retain(rtsp_message *msg) {
   }
 }
 
-static rtsp_message *msg_init(void) {
+rtsp_message *msg_init(void) {
   rtsp_message *msg = malloc(sizeof(rtsp_message));
   if (msg) {
     memset(msg, 0, sizeof(rtsp_message));
@@ -373,7 +373,7 @@ static rtsp_message *msg_init(void) {
   return msg;
 }
 
-static int msg_add_header(rtsp_message *msg, char *name, char *value) {
+int msg_add_header(rtsp_message *msg, char *name, char *value) {
   if (msg->nheaders >= sizeof(msg->name) / sizeof(char *)) {
     warn("too many headers?!");
     return 1;
@@ -386,7 +386,7 @@ static int msg_add_header(rtsp_message *msg, char *name, char *value) {
   return 0;
 }
 
-static char *msg_get_header(rtsp_message *msg, char *name) {
+char *msg_get_header(rtsp_message *msg, char *name) {
   unsigned int i;
   for (i = 0; i < msg->nheaders; i++)
     if (!strcasecmp(msg->name[i], name))
@@ -394,7 +394,7 @@ static char *msg_get_header(rtsp_message *msg, char *name) {
   return NULL;
 }
 
-static void debug_print_msg_headers(int level, rtsp_message *msg) {
+void debug_print_msg_headers(int level, rtsp_message *msg) {
   unsigned int i;
   for (i = 0; i < msg->nheaders; i++) {
     debug(level, "  Type: \"%s\", content: \"%s\"", msg->name[i], msg->value[i]);
@@ -424,7 +424,7 @@ static void debug_print_msg_content(int level, rtsp_message *msg) {
 }
 */
 
-static void msg_free(rtsp_message *msg) {
+void msg_free(rtsp_message *msg) {
 
   if (msg) {
     int rc = pthread_mutex_lock(&reference_counter_lock);
@@ -452,7 +452,7 @@ static void msg_free(rtsp_message *msg) {
   }
 }
 
-static int msg_handle_line(rtsp_message **pmsg, char *line) {
+int msg_handle_line(rtsp_message **pmsg, char *line) {
   rtsp_message *msg = *pmsg;
 
   if (!msg) {
@@ -507,7 +507,7 @@ fail:
   return 0;
 }
 
-static enum rtsp_read_request_response rtsp_read_request(rtsp_conn_info *conn,
+enum rtsp_read_request_response rtsp_read_request(rtsp_conn_info *conn,
                                                          rtsp_message **the_packet) {
   enum rtsp_read_request_response reply = rtsp_read_request_response_ok;
   ssize_t buflen = 4096;
@@ -649,7 +649,7 @@ shutdown:
   return reply;
 }
 
-static void msg_write_response(int fd, rtsp_message *resp) {
+void msg_write_response(int fd, rtsp_message *resp) {
   char pkt[2048];
   int pktfree = sizeof(pkt);
   char *p = pkt;
@@ -697,7 +697,7 @@ static void msg_write_response(int fd, rtsp_message *resp) {
     debug(1, "Error writing an RTSP packet -- requested bytes not fully written.");
 }
 
-static void handle_record(rtsp_conn_info *conn, rtsp_message *req, rtsp_message *resp) {
+void handle_record(rtsp_conn_info *conn, rtsp_message *req, rtsp_message *resp) {
   debug(2, "Connection %d: RECORD", conn->connection_number);
 
   if (conn->player_thread)
@@ -737,7 +737,7 @@ static void handle_record(rtsp_conn_info *conn, rtsp_message *req, rtsp_message 
   }
 }
 
-static void handle_options(rtsp_conn_info *conn, __attribute__((unused)) rtsp_message *req,
+void handle_options(rtsp_conn_info *conn, __attribute__((unused)) rtsp_message *req,
                            rtsp_message *resp) {
   debug(3, "Connection %d: OPTIONS", conn->connection_number);
   resp->respcode = 200;
@@ -746,7 +746,7 @@ static void handle_options(rtsp_conn_info *conn, __attribute__((unused)) rtsp_me
                                  "OPTIONS, GET_PARAMETER, SET_PARAMETER");
 }
 
-static void handle_teardown(rtsp_conn_info *conn, __attribute__((unused)) rtsp_message *req,
+void handle_teardown(rtsp_conn_info *conn, __attribute__((unused)) rtsp_message *req,
                             rtsp_message *resp) {
   debug(2, "Connection %d: TEARDOWN", conn->connection_number);
   // if (!rtsp_playing())
@@ -763,7 +763,7 @@ static void handle_teardown(rtsp_conn_info *conn, __attribute__((unused)) rtsp_m
         conn->connection_number);
 }
 
-static void handle_flush(rtsp_conn_info *conn, rtsp_message *req, rtsp_message *resp) {
+void handle_flush(rtsp_conn_info *conn, rtsp_message *req, rtsp_message *resp) {
   debug(3, "Connection %d: FLUSH", conn->connection_number);
   //  if (!rtsp_playing())
   //    debug(1, "This RTSP conversation thread (%d) doesn't think it's playing, but "
@@ -793,7 +793,7 @@ static void handle_flush(rtsp_conn_info *conn, rtsp_message *req, rtsp_message *
   resp->respcode = 200;
 }
 
-static void handle_setup(rtsp_conn_info *conn, rtsp_message *req, rtsp_message *resp) {
+void handle_setup(rtsp_conn_info *conn, rtsp_message *req, rtsp_message *resp) {
   debug(3, "Connection %d: SETUP", conn->connection_number);
   uint16_t cport, tport;
 
@@ -903,7 +903,7 @@ static void handle_ignore(rtsp_conn_info *conn, rtsp_message *req, rtsp_message 
 }
 */
 
-static void handle_set_parameter_parameter(rtsp_conn_info *conn, rtsp_message *req,
+void handle_set_parameter_parameter(rtsp_conn_info *conn, rtsp_message *req,
                                            __attribute__((unused)) rtsp_message *resp) {
   char *cp = req->content;
   int cp_left = req->contentlength;

--- a/rtsp.c
+++ b/rtsp.c
@@ -507,8 +507,7 @@ fail:
   return 0;
 }
 
-enum rtsp_read_request_response rtsp_read_request(rtsp_conn_info *conn,
-                                                         rtsp_message **the_packet) {
+enum rtsp_read_request_response rtsp_read_request(rtsp_conn_info *conn, rtsp_message **the_packet) {
   enum rtsp_read_request_response reply = rtsp_read_request_response_ok;
   ssize_t buflen = 4096;
   char *buf = malloc(buflen + 1);
@@ -738,7 +737,7 @@ void handle_record(rtsp_conn_info *conn, rtsp_message *req, rtsp_message *resp) 
 }
 
 void handle_options(rtsp_conn_info *conn, __attribute__((unused)) rtsp_message *req,
-                           rtsp_message *resp) {
+                    rtsp_message *resp) {
   debug(3, "Connection %d: OPTIONS", conn->connection_number);
   resp->respcode = 200;
   msg_add_header(resp, "Public", "ANNOUNCE, SETUP, RECORD, "
@@ -747,7 +746,7 @@ void handle_options(rtsp_conn_info *conn, __attribute__((unused)) rtsp_message *
 }
 
 void handle_teardown(rtsp_conn_info *conn, __attribute__((unused)) rtsp_message *req,
-                            rtsp_message *resp) {
+                     rtsp_message *resp) {
   debug(2, "Connection %d: TEARDOWN", conn->connection_number);
   // if (!rtsp_playing())
   //  debug(1, "This RTSP connection thread (%d) doesn't think it's playing, but "
@@ -904,7 +903,7 @@ static void handle_ignore(rtsp_conn_info *conn, rtsp_message *req, rtsp_message 
 */
 
 void handle_set_parameter_parameter(rtsp_conn_info *conn, rtsp_message *req,
-                                           __attribute__((unused)) rtsp_message *resp) {
+                                    __attribute__((unused)) rtsp_message *resp) {
   char *cp = req->content;
   int cp_left = req->contentlength;
   char *next;


### PR DESCRIPTION
The system by which timestamp intervals has been calculated was fragile and has been replaced. It was fragile because, while an occasional simple network error could be dealt with correctly, a sequence of serious network errors could render its fundamental assumptions invalid and completely break it -- on occasions, in fact, Shairport Sync got so confused that it would programmatically quit!

So, these changes will not magically fix problems due to a faulty network, but they should make Shairport Sync more robust in dealing with errors.

There is a possibility that some errors may be reintroduced, particularly in the area of flushing behaviour at the start of a new play session that quickly follows a previous one, or indeed elsewhere.

