### PR TITLE
Rename apple_alac to .c

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,7 @@ endif
 endif
 
 if USE_APPLE_ALAC
-  shairport_sync_SOURCES += apple_alac.cpp
+  shairport_sync_SOURCES += apple_alac.c
 endif
 
 if USE_CUSTOMPIDDIR

--- a/apple_alac.c
+++ b/apple_alac.c
@@ -16,7 +16,7 @@ typedef struct magicCookie {
 magicCookie cookie;
 ALACDecoder *theDecoder;
 
-extern "C" int apple_alac_init(int32_t fmtp[12]) {
+int apple_alac_init(int32_t fmtp[12]) {
 
   memset(&cookie, 0, sizeof(magicCookie));
 
@@ -41,7 +41,7 @@ extern "C" int apple_alac_init(int32_t fmtp[12]) {
   return 0;
 }
 
-extern "C" int apple_alac_decode_frame(unsigned char *sampleBuffer, uint32_t bufferLength,
+int apple_alac_decode_frame(unsigned char *sampleBuffer, uint32_t bufferLength,
                                        unsigned char *dest, int *outsize) {
   uint32_t numFrames = 0;
   BitBuffer theInputBuffer;
@@ -52,7 +52,7 @@ extern "C" int apple_alac_decode_frame(unsigned char *sampleBuffer, uint32_t buf
   return 0;
 }
 
-extern "C" int apple_alac_terminate() {
+int apple_alac_terminate() {
   delete (theDecoder);
   return 0;
 }


### PR DESCRIPTION
This file is only a C file. Compilation with CC instead of CXX allows the
lack of a libc++ dependency.

This is patch 1 of: https://github.com/openwrt/packages/pull/7947

The second patch seems too OpenWrt specific.