### PR TITLE
Development

### DIFF
--- a/audio_jack.c
+++ b/audio_jack.c
@@ -92,12 +92,10 @@ static void deinterleave_and_convert(const char *interleaved_frames,
 }
 
 static int process(jack_nframes_t nframes, __attribute__((unused)) void *arg) {
-
   jack_default_audio_sample_t *left_buffer =
       (jack_default_audio_sample_t *)jack_port_get_buffer(left_port, nframes);
   jack_default_audio_sample_t *right_buffer =
       (jack_default_audio_sample_t *)jack_port_get_buffer(right_port, nframes);
-
   jack_ringbuffer_data_t v[2] = { 0 };
   jack_nframes_t i, thisbuf;
   int frames_written = 0;
@@ -177,7 +175,6 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
       config.jack_client_name = (char *)str;
     }
   }
-
   if (config.jack_client_name == NULL)
     config.jack_client_name = strdup("shairport-sync");
 
@@ -197,15 +194,15 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
     die("The JACK server is running at the wrong sample rate (%d) for Shairport Sync. Must be 44100 Hz.",
         sample_rate);
   }
-  jack_set_process_callback(client, &process, 0);
-  jack_set_graph_order_callback(client, &graph, 0);
+  jack_set_process_callback(client, &process, NULL);
+  jack_set_graph_order_callback(client, &graph, NULL);
   jack_set_error_function(&error);
   jack_set_info_function(&info);
 
   left_port = jack_port_register(client, "out_L", JACK_DEFAULT_AUDIO_TYPE,
-                                 JackPortIsOutput, 0);
-  right_port = jack_port_register(client, "out_R",
-                                  JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+                                 JackPortIsOutput, NULL);
+  right_port = jack_port_register(client, "out_R", JACK_DEFAULT_AUDIO_TYPE, 
+                                 JackPortIsOutput, NULL);
   if (jack_activate(client)) {
     die("Could not activate %s JACK client.", config.jack_client_name);
   } else {

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -36,8 +36,6 @@ static const int bytes_per_frame = 4;
 static pthread_mutex_t buffer_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t client_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-pthread_t *open_client_if_necessary_thread = NULL;
-
 int jack_init(int, char **);
 void jack_deinit(void);
 void jack_start(int, int);
@@ -60,18 +58,18 @@ audio_output audio_jack = {.name = "jack",
                            .parameters = NULL,
                            .mute = NULL};
 
-jack_port_t *left_port;
-jack_port_t *right_port;
+static jack_port_t *left_port;
+static jack_port_t *right_port;
 
-jack_client_t *client;
-jack_nframes_t sample_rate;
-jack_nframes_t jack_latency;
+static jack_client_t *client;
+static jack_nframes_t sample_rate;
+static jack_nframes_t jack_latency;
 
 static jack_ringbuffer_t *jackbuf;
 static int flush_please = 0;
 
-jack_latency_range_t latest_left_latency_range, latest_right_latency_range;
-int64_t time_of_latest_transfer;
+static jack_latency_range_t latest_left_latency_range, latest_right_latency_range;
+static int64_t time_of_latest_transfer;
 
 
 static inline jack_default_audio_sample_t sample_conv(short sample) {

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -121,7 +121,7 @@ static void deinterleave_and_convert(const char *interleaved_frames,
   }
 }
 
-int jack_stream_write_cb(jack_nframes_t nframes, __attribute__((unused)) void *arg) {
+static int jack_stream_write_cb(jack_nframes_t nframes, __attribute__((unused)) void *arg) {
 
   jack_default_audio_sample_t *left_buffer =
       (jack_default_audio_sample_t *)jack_port_get_buffer(left_port, nframes);
@@ -166,9 +166,9 @@ int jack_stream_write_cb(jack_nframes_t nframes, __attribute__((unused)) void *a
 
 // FIXME: set_graph_order_callback(), recompute latencies here!
 
-void default_jack_error_callback(const char *desc) { debug(2, "jackd error: \"%s\"", desc); }
+static void default_jack_error_callback(const char *desc) { debug(2, "jackd error: \"%s\"", desc); }
 
-void default_jack_info_callback(const char *desc) { inform("jackd information: \"%s\"", desc); }
+static void default_jack_info_callback(const char *desc) { inform("jackd information: \"%s\"", desc); }
 
 int jack_is_running() {
   int reply = -1; // meaning jack is not running

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -200,7 +200,7 @@ int jack_is_running() {
   return reply;
 }
 
-int jack_client_open_if_needed(void) {
+static int jack_client_open_if_needed(void) {
   pthread_mutex_lock(&client_mutex);
   if (client_is_open == 0) {
     jack_status_t status;
@@ -231,7 +231,7 @@ int jack_client_open_if_needed(void) {
   return client_is_open;
 }
 
-void jack_close(void) {
+static void jack_close(void) {
   pthread_mutex_lock(&client_mutex);
   if (client_is_open) {
     if (jack_deactivate(client))
@@ -254,7 +254,7 @@ void jack_deinit() {
   }
 }
 
-void *open_client_if_necessary_thread_function(void *arg) {
+static void *open_client_if_necessary_thread_function(void *arg) {
   int *interval = (int *)arg;
   while (*interval != 0) {
     if (client_is_open == 0) {

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -33,11 +33,6 @@
 #include <jack/transport.h>
 #include <jack/ringbuffer.h>
 
-enum ift_type {
-  IFT_frame_left_sample = 0,
-  IFT_frame_right_sample,
-} ift_type;
-
 // Two-channel, 16bit audio:
 static const int bytes_per_frame = 4;
 // Four seconds buffer -- should be plenty
@@ -73,8 +68,6 @@ audio_output audio_jack = {.name = "jack",
 
 jack_port_t *left_port;
 jack_port_t *right_port;
-
-long offset = 0;
 
 int client_is_open;
 jack_client_t *client;

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -46,12 +46,6 @@ static const int bytes_per_frame = 4;
 static pthread_mutex_t buffer_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t client_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-/*
-char *audio_lmb, *audio_umb, *audio_toq, *audio_eoq;
-
-size_t audio_occupancy; // this is in frames, not bytes. A frame is a left and
-                        // right sample, each 16 bits, hence 4 bytes
-*/
 pthread_t *open_client_if_necessary_thread = NULL;
 
 int jack_init(int, char **);
@@ -334,7 +328,7 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
   if (config.jack_right_channel_name == NULL)
     config.jack_right_channel_name = strdup("right");
 
-  jackbuf = jack_ringbuffer_create(buffer_size); // make the jack ringbuffer the same size as audio_lmb
+  jackbuf = jack_ringbuffer_create(buffer_size);
   if (jackbuf == NULL)
     die("Can't allocate %d bytes for the JACK ringbuffer.", buffer_size);
   jack_ringbuffer_mlock(jackbuf);		 // lock buffer into memory so that it never gets paged out

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -194,8 +194,8 @@ int jack_stream_write_cb(jack_nframes_t nframes, __attribute__((unused)) void *a
         frames_required = thisbuf;
       }
       deinterleave_and_convert(v[i].buf, &left_buffer[frames_written], &right_buffer[frames_written], frames_required);
-      frames_written = frames_required;
-      nframes -= frames_written;
+      frames_written += frames_required;
+      nframes -= frames_required;
     }
     jack_ringbuffer_read_advance(jackbuf, frames_written * bytes_per_frame);
   }

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -179,7 +179,7 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
   }
 
   if (config.jack_client_name == NULL)
-    config.jack_client_name = strdup("Shairport Sync");
+    config.jack_client_name = strdup("shairport-sync");
 
   jackbuf = jack_ringbuffer_create(buffer_size);
   if (jackbuf == NULL)

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -361,6 +361,8 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
     config.jack_right_channel_name = strdup("right");
 
   jackbuf = jack_ringbuffer_create(buffer_size); // make the jack ringbuffer the same size as audio_lmb
+  if (jackbuf == NULL)
+    die("Can't allocate %d bytes for the JACK ringbuffer.", buffer_size);
   jack_ringbuffer_mlock(jackbuf);		 // lock buffer into memory so that it never gets paged out
 
   jack_set_error_function(default_jack_error_callback);

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -20,17 +20,11 @@
 #include "audio.h"
 #include "common.h"
 #include <errno.h>
-#include <getopt.h>
 #include <limits.h>
-#include <math.h>
 #include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <jack/jack.h>
-#include <jack/transport.h>
 #include <jack/ringbuffer.h>
 
 // Two-channel, 16bit audio:
@@ -215,6 +209,9 @@ void jack_deinit() {
 void jack_start(__attribute__((unused)) int i_sample_rate,
                 __attribute__((unused)) int i_sample_format) {
   // nothing to do, JACK client has already been set up at jack_init()
+  // also, we have no say over the sample rate or sample format of JACK
+  // we convert the 16bit samples to float, and die if the sample rate is != 44k1.
+  // FIXME: later, resampling would be nice. Fold into soxr if possible
 }
 
 void jack_flush() {

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -106,47 +106,7 @@ int play(void *buf, int samples) {
   if (bytes_transferred < bytes_to_transfer) {
     debug(1, "JACK ringbuffer overrun. Only wrote %d of %d bytes.", bytes_transferred, bytes_to_transfer);
   }
-/*
-  size_t space_to_end_of_buffer = audio_umb - audio_eoq;
-  if (space_to_end_of_buffer >= bytes_to_transfer) {
-    memcpy(audio_eoq, buf, bytes_to_transfer);
-    pthread_mutex_lock(&buffer_mutex);
-    audio_occupancy += samples;
-    audio_eoq += bytes_to_transfer;
-    pthread_mutex_unlock(&buffer_mutex);
-  } else {
-    memcpy(audio_eoq, buf, space_to_end_of_buffer);
-    buf += space_to_end_of_buffer;
-    memcpy(audio_lmb, buf, bytes_to_transfer - space_to_end_of_buffer);
-    pthread_mutex_lock(&buffer_mutex);
-    audio_occupancy += samples;
-    audio_eoq = audio_lmb + bytes_to_transfer - space_to_end_of_buffer;
-    pthread_mutex_unlock(&buffer_mutex);
-  }
-*/
   return 0;
-}
-
-void deinterleave_and_convert_stream(const char *interleaved_frames,
-                                     const jack_default_audio_sample_t *jack_frame_buffer,
-                                     jack_nframes_t number_of_frames, enum ift_type side) {
-  jack_nframes_t i;
-  short *ifp = (short *)interleaved_frames;
-  jack_default_audio_sample_t *fp = (jack_default_audio_sample_t *)jack_frame_buffer;
-  if (side == IFT_frame_right_sample)
-    ifp++;
-  for (i = 0; i < number_of_frames; i++) {
-    short sample = *ifp;
-    jack_default_audio_sample_t converted_value;
-    if (sample >= 0)
-      converted_value = (1.0 * sample) / SHRT_MAX;
-    else
-      converted_value = -(1.0 * sample) / SHRT_MIN;
-    *fp = converted_value;
-    ifp++;
-    ifp++;
-    fp++;
-  }
 }
 
 static inline jack_default_audio_sample_t sample_conv(short sample) {
@@ -212,50 +172,6 @@ int jack_stream_write_cb(jack_nframes_t nframes, __attribute__((unused)) void *a
     frames_written++;
     nframes--;
   }
-
-/*
-  size_t frames_we_can_transfer = nframes;
-  // lock
-  pthread_mutex_lock(&buffer_mutex);
-  if (audio_occupancy < frames_we_can_transfer) {
-    frames_we_can_transfer = audio_occupancy;
-    // This means we effectively have underflow from the Shairport Sync source.
-    // In fact, it may be that there is nothing at all coming from the source,
-    // but the Shairport Sync client is open and active, so it must continue to output something.
-  }
-
-  if (frames_we_can_transfer * 2 * 2 <= (size_t)(audio_umb - audio_toq)) {
-    // the bytes are all in a row in the audio buffer
-    deinterleave_and_convert_stream(audio_toq, &left_buffer[0], frames_we_can_transfer,
-                                    IFT_frame_left_sample);
-    deinterleave_and_convert_stream(audio_toq, &right_buffer[0], frames_we_can_transfer,
-                                    IFT_frame_right_sample);
-    audio_toq += frames_we_can_transfer * 2 * 2;
-  } else {
-    // the bytes are in two places in the audio buffer
-    size_t first_portion_to_write = (audio_umb - audio_toq) / (2 * 2);
-    if (first_portion_to_write != 0) {
-      deinterleave_and_convert_stream(audio_toq, &left_buffer[0], first_portion_to_write,
-                                      IFT_frame_left_sample);
-      deinterleave_and_convert_stream(audio_toq, &right_buffer[0], first_portion_to_write,
-                                      IFT_frame_right_sample);
-    }
-    deinterleave_and_convert_stream(audio_lmb, &left_buffer[first_portion_to_write],
-                                    frames_we_can_transfer - first_portion_to_write,
-                                    IFT_frame_left_sample);
-    deinterleave_and_convert_stream(audio_lmb, &right_buffer[first_portion_to_write],
-                                    frames_we_can_transfer - first_portion_to_write,
-                                    IFT_frame_right_sample);
-    audio_toq = audio_lmb + (frames_we_can_transfer - first_portion_to_write) * 2 * 2;
-  }
-  audio_occupancy -= frames_we_can_transfer;
-  jack_port_get_latency_range(left_port, JackPlaybackLatency, &latest_left_latency_range);
-  jack_port_get_latency_range(right_port, JackPlaybackLatency, &latest_right_latency_range);
-  time_of_latest_transfer = get_absolute_time_in_fp();
-  pthread_mutex_unlock(&buffer_mutex);
-  // unlock
-
-*/
   return 0;
 }
 
@@ -264,26 +180,6 @@ int jack_stream_write_cb(jack_nframes_t nframes, __attribute__((unused)) void *a
 void default_jack_error_callback(const char *desc) { debug(2, "jackd error: \"%s\"", desc); }
 
 void default_jack_info_callback(const char *desc) { inform("jackd information: \"%s\"", desc); }
-
-/*
-void default_jack_set_latency_callback(jack_latency_callback_mode_t mode,
-                                       __attribute__((unused)) void *arg) {
-  if (mode == JackPlaybackLatency) {
-    jack_latency_range_t left_latency_range, right_latency_range;
-    jack_port_get_latency_range(left_port, JackPlaybackLatency, &left_latency_range);
-    jack_port_get_latency_range(right_port, JackPlaybackLatency, &right_latency_range);
-
-    jack_nframes_t b_latency = (left_latency_range.min + left_latency_range.max) / 2;
-    if (b_latency == 0)
-      b_latency = (right_latency_range.min + right_latency_range.max) / 2;
-    // jack_latency = b_latency; // actually, we are not interested in the latency of the jack
-    // devices connected...
-    // FIXME: yes, we are.
-    jack_latency = 0;
-    debug(1, "playback latency callback: %" PRIu32 ".", jack_latency);
-  }
-}
-*/
 
 int jack_is_running() {
   int reply = -1; // meaning jack is not running
@@ -329,19 +225,12 @@ int jack_client_open_if_needed(void) {
       sample_rate = jack_get_sample_rate(client);
       // debug(1, "jackaudio sample rate = %" PRId32 ".", sample_rate);
       if (sample_rate == 44100) {
-        // FIXME: shairport-sync has no need for a latency callback, it's a leaf node with only outputs.
-        // If in the future some jack video player wants to resync to shairplay-sync audio, then yes, but
-        // the current usage seems to suggest a misunderstanding.
-//      if (jack_set_latency_callback(client, default_jack_set_latency_callback, NULL) == 0) {
           if (jack_activate(client)) {
             debug(1, "jackaudio cannot activate client");
           } else {
             debug(2, "jackaudio client opened.");
             client_is_open = 1;
           }
-//      } else {
-//        debug(1, "jackaudio cannot set latency callback");
-//      }
       } else {
         inform(
             "jackaudio is running at the wrong speed (%d) for Shairport Sync, which must be 44100",
@@ -453,16 +342,6 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
   jack_set_error_function(default_jack_error_callback);
   jack_set_info_function(default_jack_info_callback);
 
-/*
-  // allocate space for the audio buffer
-  audio_lmb = malloc(buffer_size);
-  if (audio_lmb == NULL)
-    die("Can't allocate %d bytes for jackaudio buffer.", buffer_size);
-  audio_toq = audio_eoq = audio_lmb;
-  audio_umb = audio_lmb + buffer_size;
-  audio_occupancy = 0; // frames
-*/
-
   client_is_open = 0;
 
   // now, if selected, start a thread to automatically open a client when there is a server.
@@ -534,12 +413,6 @@ int jack_delay(long *the_delay) {
 void jack_flush() {
   debug(1, "Only the consumer can safely flush a lock-free ringbuffer. Asking the process callback to do it...");
   flush_please = 1;
-/*
-  //  debug(1,"jack flush");
-  audio_toq = audio_eoq = audio_lmb;
-  audio_umb = audio_lmb + buffer_size;
-  audio_occupancy = 0; // frames
-*/
 }
 
 void jack_stop(void) {

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -199,9 +199,9 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
   jack_set_info_function(&info);
 
   left_port = jack_port_register(client, "out_L", JACK_DEFAULT_AUDIO_TYPE,
-                                 JackPortIsOutput, NULL);
+                                 JackPortIsOutput, 0);
   right_port = jack_port_register(client, "out_R", JACK_DEFAULT_AUDIO_TYPE, 
-                                 JackPortIsOutput, NULL);
+                                 JackPortIsOutput, 0);
   if (jack_activate(client)) {
     die("Could not activate %s JACK client.", config.jack_client_name);
   } else {

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -57,7 +57,7 @@ audio_output audio_jack = {.name = "jack",
                            .init = &jack_init,
                            .deinit = &jack_deinit,
                            .start = &jack_start,
-                           .stop = &jack_stop,
+                           .stop = NULL,
                            .is_running = &jack_is_running,
                            .flush = &jack_flush,
                            .delay = &jack_delay,
@@ -243,10 +243,6 @@ void jack_start(__attribute__((unused)) int i_sample_rate,
 
   if (jack_client_open_if_needed() == 0)
     debug(1, "cannot open a jack client for a play session");
-}
-
-void jack_stop(void) {
-  // debug(1, "jack stop");
 }
 
 int jack_is_running() {

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -283,7 +283,6 @@ void default_jack_set_latency_callback(jack_latency_callback_mode_t mode,
 
 int jack_is_running() {
   int reply = -1; // meaning jack is not running
-  // if the client is open and initialised, see if the status is "rolling"
   if (client_is_open) {
 
     // check if the ports have a zero latency -- if they both have, then it's disconnected.

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -287,14 +287,24 @@ int jack_is_running() {
 
     // check if the ports have a zero latency -- if they both have, then it's disconnected.
 
-    jack_latency_range_t left_latency_range, right_latency_range;
-    jack_port_get_latency_range(left_port, JackPlaybackLatency, &left_latency_range);
-    jack_port_get_latency_range(right_port, JackPlaybackLatency, &right_latency_range);
+    // FIXME: this causes a segfault when shairport-sync is exited with CTRL-C, because
+    // the client_is_open flag is stale by then. Also, this test is not necessary.
+    // shairport-sync should not worry what's reading its ports. As long as jack is alive,
+    // deliver audio, even if nothing is connected. This behaviour probably stems from 
+    // the wish to not hog an audio device if not needed, which is no longer an issue with
+    // jack. Moreover, don't "conserve" CPU this way, because in a realtime system you want
+    // deterministic  CPU load more than anything else.
+    //    jack_latency_range_t left_latency_range, right_latency_range;
+    //	  jack_port_get_latency_range(left_port, JackPlaybackLatency, &left_latency_range);
+    //    jack_port_get_latency_range(right_port, JackPlaybackLatency, &right_latency_range);
 
     //    if ((left_latency_range.min == 0) && (left_latency_range.max == 0) &&
     //        (right_latency_range.min == 0) && (right_latency_range.max == 0)) {
     //      reply = -2; // meaning Shairport Sync is not connected
     //    } else {
+
+    // FIXME: For now, we assume JACK is always running, as it should.
+    // Still need to understand why shairport-sync needs this function.
     reply = 0; // meaning jack is open and Shairport Sync is connected to it
                //    }
   }

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -153,11 +153,6 @@ int jack_stream_write_cb(jack_nframes_t nframes, __attribute__((unused)) void *a
     }
     jack_ringbuffer_read_advance(jackbuf, frames_written * bytes_per_frame);
   }
-  // debug(1,"transferring %u frames",written);
-  // Why are we doing this? The port latency should never change unless the JACK graph is reordered. Should happen on a graph reorder callback only.
-  jack_port_get_latency_range(left_port, JackPlaybackLatency, &latest_left_latency_range);
-  jack_port_get_latency_range(right_port, JackPlaybackLatency, &latest_right_latency_range);
-
   // now, if there are any more frames to put into the buffer, fill them with
   // silence
   while (nframes > 0) {

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -41,7 +41,7 @@ enum ift_type {
 // Two-channel, 16bit audio:
 static const int bytes_per_frame = 4;
 // Four seconds buffer -- should be plenty
-#define buffer_size 44100 * 4 * bytes_per_frame
+#define buffer_size (44100 * 4 * bytes_per_frame)
 
 static pthread_mutex_t buffer_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t client_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -163,9 +163,9 @@ static int jack_client_open_if_needed(void) {
     client = jack_client_open(config.jack_client_name, JackNoStartServer, &status);
     if (client) {
       jack_set_process_callback(client, jack_stream_write_cb, 0);
-      left_port = jack_port_register(client, config.jack_left_channel_name, JACK_DEFAULT_AUDIO_TYPE,
+      left_port = jack_port_register(client, "out_L", JACK_DEFAULT_AUDIO_TYPE,
                                      JackPortIsOutput, 0);
-      right_port = jack_port_register(client, config.jack_right_channel_name,
+      right_port = jack_port_register(client, "out_R",
                                       JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
       sample_rate = jack_get_sample_rate(client);
       // debug(1, "jackaudio sample rate = %" PRId32 ".", sample_rate);
@@ -235,14 +235,6 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
     if (config_lookup_string(config.cfg, "jack.client_name", &str)) {
       config.jack_client_name = (char *)str;
     }
-    /* Get the Left Channel Name. */
-    if (config_lookup_string(config.cfg, "jack.left_channel_name", &str)) {
-      config.jack_left_channel_name = (char *)str;
-    }
-    /* Get the Right Channel Name. */
-    if (config_lookup_string(config.cfg, "jack.right_channel_name", &str)) {
-      config.jack_right_channel_name = (char *)str;
-    }
 
     /* See if we should attempt to connect to the jack server automatically, and, if so, how often
      * we should try. */
@@ -263,10 +255,6 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
 
   if (config.jack_client_name == NULL)
     config.jack_client_name = strdup("Shairport Sync");
-  if (config.jack_left_channel_name == NULL)
-    config.jack_left_channel_name = strdup("left");
-  if (config.jack_right_channel_name == NULL)
-    config.jack_right_channel_name = strdup("right");
 
   jackbuf = jack_ringbuffer_create(buffer_size);
   if (jackbuf == NULL)

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -490,7 +490,7 @@ int jack_delay(long *the_delay) {
     // this is the buffer occupancy before any
     // subsequent transfer because transfer is blocked
     // by the mutex
-    size_t audio_occupancy_now = jack_ringbuffer_read_space(jackbuf);
+    size_t audio_occupancy_now = jack_ringbuffer_read_space(jackbuf) / bytes_per_frame;
   pthread_mutex_unlock(&buffer_mutex);
 
   int64_t frames_processed_since_latest_latency_check = (delta * 44100) >> 32;

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -39,7 +39,6 @@ static const int bytes_per_frame = 4;
 #define buffer_size (44100 * 4 * bytes_per_frame)
 
 static pthread_mutex_t buffer_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_mutex_t client_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 pthread_t *open_client_if_necessary_thread = NULL;
 
@@ -181,7 +180,6 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
   jack_set_error_function(default_jack_error_callback);
   jack_set_info_function(default_jack_info_callback);
 
-  pthread_mutex_lock(&client_mutex);
   jack_status_t status;
   client = jack_client_open(config.jack_client_name, JackNoStartServer, &status);
   if (!client) {
@@ -202,18 +200,15 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
   } else {
     debug(2, "JACK client %s activated sucessfully.", config.jack_client_name);
   }
-  pthread_mutex_unlock(&client_mutex);
 
   return 0;
 }
 
 void jack_deinit() {
-  pthread_mutex_lock(&client_mutex);
   if (jack_deactivate(client))
     debug(1, "Error deactivating jack client");
   if (jack_client_close(client))
     debug(1, "Error closing jack client");
-  pthread_mutex_unlock(&client_mutex);
   jack_ringbuffer_free(jackbuf);
 }
 

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -58,7 +58,7 @@ audio_output audio_jack = {.name = "jack",
                            .deinit = &jack_deinit,
                            .start = &jack_start,
                            .stop = NULL,
-                           .is_running = &jack_is_running,
+                           .is_running = NULL,
                            .flush = &jack_flush,
                            .delay = &jack_delay,
                            .play = &play,
@@ -230,36 +230,6 @@ void jack_deinit() {
 void jack_start(__attribute__((unused)) int i_sample_rate,
                 __attribute__((unused)) int i_sample_format) {
   // nothing to do, JACK client has already been set up at jack_init()
-}
-
-int jack_is_running() {
-  int reply = -1; // meaning jack is not running
-  if (client_is_open) {
-
-    // check if the ports have a zero latency -- if they both have, then it's disconnected.
-
-    // FIXME: this causes a segfault when shairport-sync is exited with CTRL-C, because
-    // the client_is_open flag is stale by then. Also, this test is not necessary.
-    // shairport-sync should not worry what's reading its ports. As long as jack is alive,
-    // deliver audio, even if nothing is connected. This behaviour probably stems from 
-    // the wish to not hog an audio device if not needed, which is no longer an issue with
-    // jack. Moreover, don't "conserve" CPU this way, because in a realtime system you want
-    // deterministic  CPU load more than anything else.
-    //    jack_latency_range_t left_latency_range, right_latency_range;
-    //	  jack_port_get_latency_range(left_port, JackPlaybackLatency, &left_latency_range);
-    //    jack_port_get_latency_range(right_port, JackPlaybackLatency, &right_latency_range);
-
-    //    if ((left_latency_range.min == 0) && (left_latency_range.max == 0) &&
-    //        (right_latency_range.min == 0) && (right_latency_range.max == 0)) {
-    //      reply = -2; // meaning Shairport Sync is not connected
-    //    } else {
-
-    // FIXME: For now, we assume JACK is always running, as it should.
-    // Still need to understand why shairport-sync needs this function.
-    reply = 0; // meaning jack is open and Shairport Sync is connected to it
-               //    }
-  }
-  return reply;
 }
 
 void jack_flush() {

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -107,10 +107,10 @@ static inline jack_default_audio_sample_t sample_conv(short sample) {
   return ((sample < 0) ? (-1.0 * sample / SHRT_MIN) : (1.0 * sample / SHRT_MAX));
 }
 
-void deinterleave_and_convert(const char *interleaved_frames,
-                              jack_default_audio_sample_t * const jack_buffer_left,
-                              jack_default_audio_sample_t * const jack_buffer_right,
-                              jack_nframes_t nframes) {
+static void deinterleave_and_convert(const char *interleaved_frames,
+                                     jack_default_audio_sample_t * const jack_buffer_left,
+                                     jack_default_audio_sample_t * const jack_buffer_right,
+                                     jack_nframes_t nframes) {
   jack_nframes_t i;
   short *ifp = (short *)interleaved_frames; // we're dealing with 16bit audio here
   jack_default_audio_sample_t *fpl = jack_buffer_left;

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -380,7 +380,7 @@ int jack_delay(long *the_delay) {
     // subsequent transfer because transfer is blocked
     // by the mutex
     size_t audio_occupancy_now = jack_ringbuffer_read_space(jackbuf) / bytes_per_frame;
-    debug(1, "JN: audio_occupancy_now is %d.", audio_occupancy_now);
+    // debug(1, "audio_occupancy_now is %d.", audio_occupancy_now);
   pthread_mutex_unlock(&buffer_mutex);
 
   int64_t frames_processed_since_latest_latency_check = (delta * 44100) >> 32;
@@ -395,12 +395,12 @@ int jack_delay(long *the_delay) {
   // if (base_latency == 0)
   //   base_latency = (latest_right_latency_range.min + latest_right_latency_range.max) / 2;
   *the_delay = base_latency + audio_occupancy_now - frames_processed_since_latest_latency_check;
-  debug(1,"reporting a delay of %d frames",*the_delay);
+  // debug(1,"reporting a delay of %d frames",*the_delay);
   return 0;
 }
 
 void jack_flush() {
-  debug(1, "Only the consumer can safely flush a lock-free ringbuffer. Asking the process callback to do it...");
+  // debug(1, "Only the consumer can safely flush a lock-free ringbuffer. Asking the process callback to do it...");
   flush_please = 1;
 }
 

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -33,6 +33,7 @@ static const int bytes_per_frame = 4;
 #define buffer_size (44100 * 4 * bytes_per_frame)
 
 static pthread_mutex_t buffer_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t client_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 pthread_t *open_client_if_necessary_thread = NULL;
 
@@ -174,6 +175,7 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
   jack_set_error_function(default_jack_error_callback);
   jack_set_info_function(default_jack_info_callback);
 
+  pthread_mutex_lock(&client_mutex);
   jack_status_t status;
   client = jack_client_open(config.jack_client_name, JackNoStartServer, &status);
   if (!client) {
@@ -194,15 +196,18 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
   } else {
     debug(2, "JACK client %s activated sucessfully.", config.jack_client_name);
   }
+  pthread_mutex_unlock(&client_mutex);
 
   return 0;
 }
 
 void jack_deinit() {
+  pthread_mutex_lock(&client_mutex);
   if (jack_deactivate(client))
     debug(1, "Error deactivating jack client");
   if (jack_client_close(client))
     debug(1, "Error closing jack client");
+  pthread_mutex_unlock(&client_mutex);
   jack_ringbuffer_free(jackbuf);
 }
 

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -1,6 +1,7 @@
 /*
  * jack output driver. This file is part of Shairport Sync.
- * Copyright (c) 2018 Mike Brady <mikebrady@iercom.net>
+ * Copyright (c) 2019 Mike Brady <mikebrady@iercom.net>,
+ *                    Jörn Nettingsmeier <nettings@luchtbeweging.nl>
  *
  * All rights reserved.
  *

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -173,6 +173,10 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
     if (config_lookup_string(config.cfg, "jack.client_name", &str)) {
       config.jack_client_name = (char *)str;
     }
+    /* Get the autoconnect pattern. */
+    if (config_lookup_string(config.cfg, "jack.autoconnect_pattern", &str)) {
+      config.jack_autoconnect_pattern = (char *)str;
+    }
   }
   if (config.jack_client_name == NULL)
     config.jack_client_name = strdup("shairport-sync");
@@ -207,6 +211,17 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
   } else {
     debug(2, "JACK client %s activated sucessfully.", config.jack_client_name);
   }
+
+  if (config.jack_autoconnect_pattern != NULL) {
+    debug(1, "config.jack_autoconnect_pattern is %s.", config.jack_autoconnect_pattern);
+    const char** port_list = jack_get_ports(client, config.jack_autoconnect_pattern, JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput);
+    while (*port_list != NULL) {
+      debug(1, "Found matching JACK port %s.", *port_list);
+      port_list++;
+      // FIXME: implement actual connection, warn user if more than 2 hits.
+    }
+  }
+  
   pthread_mutex_unlock(&client_mutex);
 
   return 0;

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -180,8 +180,10 @@ int jack_stream_write_cb(jack_nframes_t nframes, __attribute__((unused)) void *a
   int frames_required = 0;
 
   if (flush_please) {
+    // we just move the read pointer ahead without doing anything with the data.
     jack_ringbuffer_read_advance(jackbuf, jack_ringbuffer_read_space(jackbuf));
     flush_please = 0;
+    // since we don't change nframes, the whole buffer will be zeroed later.
   } else {
     jack_ringbuffer_get_read_vector(jackbuf, v); // an array of two elements because of possible ringbuffer wrap-around
     for (i=0; i<2; i++) {

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -179,6 +179,7 @@ int jack_stream_write_cb(jack_nframes_t nframes, __attribute__((unused)) void *a
 
   if (flush_please) {
     jack_ringbuffer_read_advance(jackbuf, jack_ringbuffer_read_space(jackbuf));
+    flush_please = 0;
   } else {
     jack_ringbuffer_get_read_vector(jackbuf, v); // an array of two elements because of possible ringbuffer wrap-around
     for (i=0; i<2; i++) {
@@ -196,8 +197,8 @@ int jack_stream_write_cb(jack_nframes_t nframes, __attribute__((unused)) void *a
   }
   // debug(1,"transferring %u frames",written);
   // Why are we doing this? The port latency should never change unless the JACK graph is reordered. Should happen on a graph reorder callback only.
-  // jack_port_get_latency_range(left_port, JackPlaybackLatency, &latest_left_latency_range);
-  // jack_port_get_latency_range(right_port, JackPlaybackLatency, &latest_right_latency_range);
+  jack_port_get_latency_range(left_port, JackPlaybackLatency, &latest_left_latency_range);
+  jack_port_get_latency_range(right_port, JackPlaybackLatency, &latest_right_latency_range);
 
   // now, if there are any more frames to put into the buffer, fill them with
   // silence

--- a/audio_jack.c
+++ b/audio_jack.c
@@ -211,10 +211,6 @@ int jack_init(__attribute__((unused)) int argc, __attribute__((unused)) char **a
     if (config_lookup_string(config.cfg, "jack.client_name", &str)) {
       config.jack_client_name = (char *)str;
     }
-
-    /* See if we should close the client at then end of a play session. */
-    config_set_lookup_bool(config.cfg, "jack.auto_client_disconnect",
-                           &config.jack_auto_client_disconnect);
   }
 
   if (config.jack_client_name == NULL)
@@ -251,8 +247,6 @@ void jack_start(__attribute__((unused)) int i_sample_rate,
 
 void jack_stop(void) {
   // debug(1, "jack stop");
-  if (config.jack_auto_client_disconnect)
-    jack_close();
 }
 
 int jack_is_running() {

--- a/common.h
+++ b/common.h
@@ -232,7 +232,7 @@ typedef struct {
   double diagnostic_drop_packet_fraction; // pseudo randomly drop this fraction of packets, for
                                           // debugging. Currently audio packets only...
 #ifdef CONFIG_JACK
-  char *jack_client_name, *jack_left_channel_name, *jack_right_channel_name;
+  char *jack_client_name;
   int jack_auto_client_open_interval; // will try to open a client automatically every second
   int jack_auto_client_disconnect;    // will disconnect from the server on end of session if set,
                                       // normally clear.

--- a/common.h
+++ b/common.h
@@ -233,7 +233,6 @@ typedef struct {
                                           // debugging. Currently audio packets only...
 #ifdef CONFIG_JACK
   char *jack_client_name;
-  int jack_auto_client_open_interval; // will try to open a client automatically every second
   int jack_auto_client_disconnect;    // will disconnect from the server on end of session if set,
                                       // normally clear.
 #endif

--- a/common.h
+++ b/common.h
@@ -233,6 +233,7 @@ typedef struct {
                                           // debugging. Currently audio packets only...
 #ifdef CONFIG_JACK
   char *jack_client_name;
+  char *jack_autoconnect_pattern;
 #endif
 
 } shairport_cfg;

--- a/common.h
+++ b/common.h
@@ -233,8 +233,6 @@ typedef struct {
                                           // debugging. Currently audio packets only...
 #ifdef CONFIG_JACK
   char *jack_client_name;
-  int jack_auto_client_disconnect;    // will disconnect from the server on end of session if set,
-                                      // normally clear.
 #endif
 
 } shairport_cfg;

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -108,8 +108,14 @@ pa =
 // Parameters for the "jack" JACK Audio Connection Kit backend.
 jack =
 {
-//	client_name = "shairport-sync"; //Set this to the name of the client that should appear in "Connections" when Shairport Sync is active.
-//	autoconnect_pattern = ""; //Set this to a pattern that describes the ports you would like to connect to automatically when we start up, like "system:playback_?"
+//	client_name = "shairport-sync"; // Set this to the name of the client that should appear in "Connections" when Shairport Sync is active.
+//	autoconnect_pattern = ""; // Set this to a POSIX regular expression pattern that describes the ports you would like to connect to
+//                                   automatically. Examples:
+//                                   "system:playback_[12]"
+//                                   "some_app_[0-9]*:in-[LR]"
+//                                   "jack_mixer:in_2[78]"
+//                                   Beware: if you make a syntax error, libjack might crash. In that case, fix it and start over.
+//                                   For a good overview, look here: https://www.ibm.com/support/knowledgecenter/SS8NLW_11.0.1/com.ibm.swg.im.infosphere.dataexpl.engine.doc/c_posix-regex-examples.html
 };
 
 // Parameters for the "pipe" audio back end, a back end that directs raw CD-style audio output to a pipe. No interpolation is done.

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -109,7 +109,6 @@ pa =
 jack =
 {
 //	client_name = "Shairport Sync"; //Set this to the name of the client that should appear in "Connections" when Shairport Sync is active.
-//	auto_client_open_interval = 1; // Set this to the interval in seconds between automatic attempts to open a client on the jack server. Set to zero to disable this behaviour.
 //	auto_client_disconnect = "no"; // Set this to "yes" to close the jack client automatically at then end of a play session. Default is no -- the client stays connected.
 };
 

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -109,6 +109,7 @@ pa =
 jack =
 {
 //	client_name = "shairport-sync"; //Set this to the name of the client that should appear in "Connections" when Shairport Sync is active.
+//	autoconnect_pattern = ""; //Set this to a pattern that describes the ports you would like to connect to automatically when we start up, like "system:playback_?"
 };
 
 // Parameters for the "pipe" audio back end, a back end that directs raw CD-style audio output to a pipe. No interpolation is done.

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -109,8 +109,6 @@ pa =
 jack =
 {
 //	client_name = "Shairport Sync"; //Set this to the name of the client that should appear in "Connections" when Shairport Sync is active.
-//	left_channel_name = "left"; //Set this to the name of the left output port that should appear in "Connections" when Shairport Sync is active.
-//	right_channel_name = "right"; //Set this to the name of the right output port that should appear in "Connections" when Shairport Sync is active.
 //	auto_client_open_interval = 1; // Set this to the interval in seconds between automatic attempts to open a client on the jack server. Set to zero to disable this behaviour.
 //	auto_client_disconnect = "no"; // Set this to "yes" to close the jack client automatically at then end of a play session. Default is no -- the client stays connected.
 };

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -109,7 +109,6 @@ pa =
 jack =
 {
 //	client_name = "Shairport Sync"; //Set this to the name of the client that should appear in "Connections" when Shairport Sync is active.
-//	auto_client_disconnect = "no"; // Set this to "yes" to close the jack client automatically at then end of a play session. Default is no -- the client stays connected.
 };
 
 // Parameters for the "pipe" audio back end, a back end that directs raw CD-style audio output to a pipe. No interpolation is done.

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -108,7 +108,7 @@ pa =
 // Parameters for the "jack" JACK Audio Connection Kit backend.
 jack =
 {
-//	client_name = "Shairport Sync"; //Set this to the name of the client that should appear in "Connections" when Shairport Sync is active.
+//	client_name = "shairport-sync"; //Set this to the name of the client that should appear in "Connections" when Shairport Sync is active.
 };
 
 // Parameters for the "pipe" audio back end, a back end that directs raw CD-style audio output to a pipe. No interpolation is done.


### PR DESCRIPTION
Hi @mikebrady, I guess the code is now in a state where you can look at it without wasting your time. I have run the code for more than 24 hours in total without any issues. I did not profile the original code, but I believe the CPU usage is significantly lower now. I did see another spurious segfault on shutdown again despite putting that client_mutex back in. I guess there is some racey stuff going on, maybe we need to resurrect the global client_is_open flag if the problem turns out to be more than cosmetic.
The ALSA mixer integration will have to wait a week, I have jobs coming up...