### PR TITLE
Add --with-libdaemon to FreeBSD docs

### DIFF
--- a/FREEBSD.md
+++ b/FREEBSD.md
@@ -60,7 +60,7 @@ Next, configure the build and compile it:
 
 ```
 $ autoreconf -i -f
-$ ./configure  --with-avahi --with-ssl=openssl --with-alsa --with-sndio --with-os=freebsd --with-freebsd-service
+$ ./configure  --with-avahi --with-ssl=openssl --with-alsa --with-sndio --with-os=freebsd --with-freebsd-service --with-libdaemon
 $ make
 ```
 Omit `--with-alsa` if you don't want to include the ALSA back end. Omit the `--with-sndio` if you don't want the `sndio` back end. Omit the `--with-freebsd-service` if you don't want to install a FreeBSD startup script, runtime folder and user and group -- see below for more details.


### PR DESCRIPTION
Without explicitly adding `--with-libdaemon` when running `./configure` I can't start `3.3rc4` as daemon on FreeBSD.