### PR TITLE
MQTT Bug & usability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ Debian, Ubuntu and Raspbian users can get the basics with:
 - `# apt-get install libssl-dev` if you want to use OpenSSL and libcrypto, or use mbed TLS otherwise.
 - `# apt-get install libmbedtls-dev` if you want to use mbed TLS, or use OpenSSL/libcrypto otherwise. You can still use PolarSSL with `apt-get install libpolarssl-dev` if you want to use PolarSSL, but it is deprecated as it's not longer being supported.
 - `# apt-get install libsoxr-dev` if you want support for libsoxr-based resampling. This library is in many recent distributions; if not, instructions for how to build it from source for Rasbpian/Debian Wheezy are available at [LIBSOXR.md](https://github.com/mikebrady/shairport-sync/blob/master/LIBSOXR.md).
+- `# apt-get install libmosquitto-dev` if you want to use the mqtt client
+
+If you just want to have the default configuration options (systemd):
+- `# apt-get install build-essential git xmltoman autoconf automake libtool libpopt-dev libconfig-dev libasound2-dev libpulse-dev avahi-daemon libavahi-client-dev libssl-dev libsoxr-dev` 
 
 If you wish to include the Apple ALAC decoder, you need install it first – please refer to the [ALAC](https://github.com/mikebrady/alac) repository for more information.
 

--- a/configure.ac
+++ b/configure.ac
@@ -352,6 +352,9 @@ AC_ARG_WITH(mqtt-client, [  --with-mqtt-client = include a client for MQTT -- th
   ],)
 AM_CONDITIONAL([USE_MQTT], [test "x$REQUESTED_MQTT" = "x1"])
 
+if test "x$REQUESTED_MQTT" = "x1" && test "x$REQUESTED_AVAHI" != "x1"; then
+  AC_MSG_WARN([>>MQTT needs Avahi to allow remote control functionality. Only Metadata publishing will be supported])
+fi
 
 if test "x$REQUESTED_MPRIS" = "x1" || test "x$REQUESTED_DBUS" = "x1" || test "x$REQUESTED_MQTT" = "x1"; then
   AC_MSG_RESULT(>>Including extended metadata and DACP client support)

--- a/mqtt.c
+++ b/mqtt.c
@@ -176,7 +176,7 @@ void mqtt_process_metadata(uint32_t type, uint32_t code, char *data, uint32_t le
         mqtt_publish("play_resume", data, length);
         break;
       case 'PICT':
-        if (config.mqtt_publish_parsed) {
+        if (config.mqtt_publish_cover) {
           mqtt_publish("cover", data, length);
         }
         break;

--- a/shairport.c
+++ b/shairport.c
@@ -1761,13 +1761,13 @@ int main(int argc, char **argv) {
   debug(1, "get-coverart is %d.", config.get_coverart);
 #endif
 #ifdef CONFIG_MQTT
-  debug(1, "mqtt is %sabled.", (config.mqtt_enabled?"en":"dis"));
-  debug(1, "mqtt hostname is %s, port is %d.", config.mqtt_hostname. config.mqtt_port);
+  debug(1, "mqtt is %sabled.", config.mqtt_enabled ? "en" : "dis");
+  debug(1, "mqtt hostname is %s, port is %d.", config.mqtt_hostname, config.mqtt_port);
   debug(1, "mqtt topic is %s.", config.mqtt_topic);
-  debug(1, "mqtt will%s publish raw metadata.", (config.mqtt_publish_raw?"":" NOT"));
-  debug(1, "mqtt will%s publish parsed metadata.", (config.mqtt_publish_parsed?"":" NOT"));
-  debug(1, "mqtt will%s publish cover Art.", (config.mqtt_publish_cover?"":" NOT"));
-  debug(1, "mqtt remote control is %sabled .", (config.mqtt_enable_remote?"en":"dis"));
+  debug(1, "mqtt will%s publish raw metadata.", config.mqtt_publish_raw ? "" : " NOT");
+  debug(1, "mqtt will%s publish parsed metadata.", config.mqtt_publish_parsed ? "" : " NOT");
+  debug(1, "mqtt will%s publish cover Art.", config.mqtt_publish_cover ? "" : " NOT");
+  debug(1, "mqtt remote control is %sabled.", config.mqtt_enable_remote ? "en" : "dis");
 #endif
 
 #ifdef CONFIG_CONVOLUTION

--- a/shairport.c
+++ b/shairport.c
@@ -1045,7 +1045,17 @@ int parse_options(int argc, char **argv) {
     config_set_lookup_bool(config.cfg, "mqtt.publish_raw", &config.mqtt_publish_raw);
     config_set_lookup_bool(config.cfg, "mqtt.publish_parsed", &config.mqtt_publish_parsed);
     config_set_lookup_bool(config.cfg, "mqtt.publish_cover", &config.mqtt_publish_cover);
+    if (config.mqtt_publish_cover && !config.get_coverart) {
+      die("You need to have metadata.include_cover_art enabled in order to use mqtt.publish_cover");
+    }
     config_set_lookup_bool(config.cfg, "mqtt.enable_remote", &config.mqtt_enable_remote);
+#ifndef CONFIG_AVAHI
+        if (config.mqtt_enable_remote) {
+          die("You have enabled MQTT remote control which requires shairport-sync to be built with "
+              "Avahi, but your installation is not using avahi. Please reinstall/recompile with "
+              "avahi enabled, or disable remote control.");
+        }
+#endif
 #endif
   }
 
@@ -1749,6 +1759,15 @@ int main(int argc, char **argv) {
         config.metadata_sockport);
   debug(1, "metadata socket packet size is \"%d\".", config.metadata_sockmsglength);
   debug(1, "get-coverart is %d.", config.get_coverart);
+#endif
+#ifdef CONFIG_MQTT
+  debug(1, "mqtt is %sabled.", (config.mqtt_enabled?"en":"dis"));
+  debug(1, "mqtt hostname is %s, port is %d.", config.mqtt_hostname. config.mqtt_port);
+  debug(1, "mqtt topic is %s.", config.mqtt_topic);
+  debug(1, "mqtt will%s publish raw metadata.", (config.mqtt_publish_raw?"":" NOT"));
+  debug(1, "mqtt will%s publish parsed metadata.", (config.mqtt_publish_parsed?"":" NOT"));
+  debug(1, "mqtt will%s publish cover Art.", (config.mqtt_publish_cover?"":" NOT"));
+  debug(1, "mqtt remote control is %sabled .", (config.mqtt_enable_remote?"en":"dis"));
 #endif
 
 #ifdef CONFIG_CONVOLUTION


### PR DESCRIPTION
The following commits fix a bug I recently discovered, where full album art was published via mqtt although being disabled. 
Additionally, some checks were added to inform the user that avahi is neccessary for some functionality in the mqtt client (#795). This also applies to some possibly wrong configurations where the underlaying metadata is not enabled. A bit of debug information may also help.