### PR TITLE
Avoid double free by making a copy of the value received from libconfig9

### DIFF
--- a/shairport.c
+++ b/shairport.c
@@ -471,7 +471,7 @@ int parse_options(int argc, char **argv) {
       config.cfg = &config_file_stuff;
       /* Get the Service Name. */
       if (config_lookup_string(config.cfg, "general.name", &str)) {
-        raw_service_name = (char *)str;
+        raw_service_name = strdup(str);
       }
 #ifdef CONFIG_LIBDAEMON
       /* Get the Daemonize setting. */


### PR DESCRIPTION
I've received this patch through the Debian BTS: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=925577

It looks like libconfig9 tries to free the pointer to the string, so when shairport.c frees it itself around line 1169 you end up with a double-free. On the "wrong" system this leads to a crash.