### PR TITLE
Early exit on version and help arguments

### DIFF
--- a/shairport.c
+++ b/shairport.c
@@ -1363,6 +1363,18 @@ void exit_function() {
 }
 
 int main(int argc, char **argv) {
+  /* Check if we are called with -V or --version parameter */
+  if (argc >= 2 && ((strcmp(argv[1], "-V") == 0) || (strcmp(argv[1], "--version") == 0))) {
+    print_version();
+    exit(EXIT_FAILURE);
+  }
+
+  /* Check if we are called with -h or --help parameter */
+  if (argc >= 2 && ((strcmp(argv[1], "-h") == 0) || (strcmp(argv[1], "--help") == 0))) {
+    usage(argv[0]);
+    exit(EXIT_FAILURE);
+  }
+
 #ifdef CONFIG_LIBDAEMON
   pid = getpid();
 #endif
@@ -1467,18 +1479,6 @@ int main(int argc, char **argv) {
   // initialise the randomw number array
 
   r64arrayinit();
-
-  /* Check if we are called with -V or --version parameter */
-  if (argc >= 2 && ((strcmp(argv[1], "-V") == 0) || (strcmp(argv[1], "--version") == 0))) {
-    print_version();
-    exit(EXIT_FAILURE);
-  }
-
-  /* Check if we are called with -h or --help parameter */
-  if (argc >= 2 && ((strcmp(argv[1], "-h") == 0) || (strcmp(argv[1], "--help") == 0))) {
-    usage(argv[0]);
-    exit(EXIT_FAILURE);
-  }
 
 #ifdef CONFIG_LIBDAEMON
 

--- a/shairport.c
+++ b/shairport.c
@@ -1366,13 +1366,13 @@ int main(int argc, char **argv) {
   /* Check if we are called with -V or --version parameter */
   if (argc >= 2 && ((strcmp(argv[1], "-V") == 0) || (strcmp(argv[1], "--version") == 0))) {
     print_version();
-    exit(EXIT_FAILURE);
+    exit(EXIT_SUCCESS);
   }
 
   /* Check if we are called with -h or --help parameter */
   if (argc >= 2 && ((strcmp(argv[1], "-h") == 0) || (strcmp(argv[1], "--help") == 0))) {
     usage(argv[0]);
-    exit(EXIT_FAILURE);
+    exit(EXIT_SUCCESS);
   }
 
 #ifdef CONFIG_LIBDAEMON


### PR DESCRIPTION
By returning early (and with success) it will always be possible to get version and usage without crashing if there are errors in creation or destruction of i.e. threads.