### PR TITLE
Alac a fmtp seg fault

### DIFF
--- a/rtsp.c
+++ b/rtsp.c
@@ -1867,7 +1867,7 @@ static void handle_announce(rtsp_conn_info *conn, rtsp_message *req, rtsp_messag
       conn->stream.type = ast_apple_lossless;
       debug(3, "An ALAC stream has been detected.");
 
-      // Set connection defaults
+      // Set reasonable connection defaults
       conn->stream.fmtp[0] = 96;
       conn->stream.fmtp[1] = 352;
       conn->stream.fmtp[2] = 0;
@@ -1881,15 +1881,11 @@ static void handle_announce(rtsp_conn_info *conn, rtsp_message *req, rtsp_messag
       conn->stream.fmtp[10] = 0;
       conn->stream.fmtp[11] = 44100;
 
-      unsigned int i;
+      unsigned int i = 0;
+      unsigned int max_param = sizeof(conn->stream.fmtp) / sizeof(conn->stream.fmtp[0]);
       char* found;
-      for (i = 0; i < sizeof(conn->stream.fmtp) / sizeof(conn->stream.fmtp[0]); i++) {
-        found = strsep(&pfmtp, " \t");
-        if (found != NULL) {
-          conn->stream.fmtp[i] = atoi(found);
-        } else {
-          break;
-        }
+      while ((found = strsep(&pfmtp, " \t")) != NULL && i < max_param) {
+        conn->stream.fmtp[i++] = atoi(found);          
       }
       // here we should check the sanity of the fmtp values
       // for (i = 0; i < sizeof(conn->stream.fmtp) / sizeof(conn->stream.fmtp[0]); i++)

--- a/rtsp.c
+++ b/rtsp.c
@@ -1866,9 +1866,31 @@ static void handle_announce(rtsp_conn_info *conn, rtsp_message *req, rtsp_messag
     if (pfmtp) {
       conn->stream.type = ast_apple_lossless;
       debug(3, "An ALAC stream has been detected.");
+
+      // Set connection defaults
+      conn->stream.fmtp[0] = 96;
+      conn->stream.fmtp[1] = 352;
+      conn->stream.fmtp[2] = 0;
+      conn->stream.fmtp[3] = 16;
+      conn->stream.fmtp[4] = 40;
+      conn->stream.fmtp[5] = 10;
+      conn->stream.fmtp[6] = 14;
+      conn->stream.fmtp[7] = 2;
+      conn->stream.fmtp[8] = 255;
+      conn->stream.fmtp[9] = 0;
+      conn->stream.fmtp[10] = 0;
+      conn->stream.fmtp[11] = 44100;
+
       unsigned int i;
-      for (i = 0; i < sizeof(conn->stream.fmtp) / sizeof(conn->stream.fmtp[0]); i++)
-        conn->stream.fmtp[i] = atoi(strsep(&pfmtp, " \t"));
+      char* found;
+      for (i = 0; i < sizeof(conn->stream.fmtp) / sizeof(conn->stream.fmtp[0]); i++) {
+        found = strsep(&pfmtp, " \t");
+        if (found != NULL) {
+          conn->stream.fmtp[i] = atoi(found);
+        } else {
+          break;
+        }
+      }
       // here we should check the sanity of the fmtp values
       // for (i = 0; i < sizeof(conn->stream.fmtp) / sizeof(conn->stream.fmtp[0]); i++)
       //  debug(1,"  fmtp[%2d] is: %10d",i,conn->stream.fmtp[i]);


### PR DESCRIPTION
This fixes a possible seg. fault, when an incomplete a:fmtp parameter set is send by the requesting client (less than 12 parameter).

See also #897  