### PR TITLE
[FIX] Fix verbosity level of player.c debug message

### DIFF
--- a/player.c
+++ b/player.c
@@ -628,7 +628,7 @@ void player_put_packet(seq_t seqno, uint32_t actual_timestamp, uint8_t *data, in
       	int missing_frame_run_count = 0;
       	int start_of_missing_frame_run = -1;
         int number_of_missing_frames = 0;
-        debug(2,"check start");
+        debug(3,"check start");
         while (x != conn->ab_write) {
           abuf_t *check_buf = conn->audio_buffer + BUFIDX(x);
           if (!check_buf->ready) {


### PR DESCRIPTION
### ℹ️ Description
This PR increases the debug level of the constantly repeated resend check log message (`check start`) from `2` to `3`.

### 🚨 Problem
When setting `log_verbosity` to 2, the constantly repeated log message `check start` drowns out any other useful messages. However, the log should still remain human-readable on this "medium" setting.

<p align="center">
    <img width="75%" src="https://user-images.githubusercontent.com/1630917/65640423-a24ff080-dfea-11e9-8051-bedd0dd1c5f1.gif"/><br>
    <i>Screencast</i><br>
</p>

### 📝 Implementation
 - Changed `debug()` call:
    https://github.com/sidneys/shairport-sync/blob/hotfix/log-verbosity-level/player.c#L631