### PR TITLE
Readme raspi alsa instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ To make Shairport Sync output to the built-in audio DAC and use its hardware mix
 alsa =
 {
   output_device = "hw:0"; // the name of the alsa output device. Use "alsamixer" or "aplay" to find out the names of devices, mixers, etc.
-  mixer_control_name = "PCM"; // the name of the mixer to use to adjust output volume. If not specified, volume in adjusted in software.
+  // mixer_control_name = "PCM"; // the name of the mixer to use to adjust output volume. If not specified, volume in adjusted in software.
   // ... other alsa settings
 ```
 (Remember to uncomment the lines by removing the `//` at the start of each.) When these changes have been made, reboot the machine.

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ To make Shairport Sync output to the built-in audio DAC and use its hardware mix
 ```
 alsa =
 {
-  output_device = "hw:0"; // the name of the alsa output device. Use "alsamixer" or "aplay" to find out the names of devices, mixers, etc.
+  output_device = "default"; // the name of the alsa output device. Use "alsamixer" or "aplay" to find out the names of devices, mixers, etc.
   // mixer_control_name = "PCM"; // the name of the mixer to use to adjust output volume. If not specified, volume in adjusted in software.
   // ... other alsa settings
 ```


### PR DESCRIPTION
Updating readme raspi alsa instructions about output device and mixer control.

* Set default as std. output device (already changed in the config).
* Don't recommend using PCM on raspi anymore since it can cause malfunctions.