### PR TITLE
Allow to specify pulseaudio server instead of using default one.

### DIFF
--- a/audio_pa.c
+++ b/audio_pa.c
@@ -85,6 +85,11 @@ static int init(__attribute__((unused)) int argc, __attribute__((unused)) char *
   if (config.cfg != NULL) {
     const char *str;
 
+    /* Get the PulseAudio server name. */
+    if (config_lookup_string(config.cfg, "pa.server", &str)) {
+      config.pa_server = (char *)str;
+    }
+
     /* Get the Application Name. */
     if (config_lookup_string(config.cfg, "pa.application_name", &str)) {
       config.pa_application_name = (char *)str;
@@ -126,7 +131,8 @@ static int init(__attribute__((unused)) int argc, __attribute__((unused)) char *
   // Start the mainloop
   if (pa_threaded_mainloop_start(mainloop) != 0)
     die("could not start the pulseaudio threaded mainloop");
-  if (pa_context_connect(context, NULL, 0, NULL) != 0)
+
+  if (pa_context_connect(context, config.pa_server, 0, NULL) != 0)
     die("failed to connect to the pulseaudio context -- the error message is \"%s\".",
         pa_strerror(pa_context_errno(context)));
 

--- a/common.h
+++ b/common.h
@@ -114,6 +114,7 @@ typedef struct {
                       // on host %h"
 
 #ifdef CONFIG_PA
+  char *pa_server; // the pulseaudio server address that Shairport Sync will play on.
   char *pa_application_name; // the name under which Shairport Sync shows up as an "Application" in
                              // the Sound Preferences in most desktop Linuxes.
   // Defaults to "Shairport Sync". Shairport Sync must be playing to see it.

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -118,6 +118,7 @@ sndio =
 // --with-pa
 pa =
 {
+//	server = "host"; // Set this to override the default pulseaudio server that should be used.
 //	application_name = "Shairport Sync"; //Set this to the name that should appear in the Sounds "Applications" tab when Shairport Sync is active.
 };
 


### PR DESCRIPTION
Add "server" entry to pa config section, allowing to connect to a remote or a local system
pulseaudio instance instead of letting pulseaudio choose.
