### PR TITLE
Updated activity_monitor.c - metadata publishing wrong codes

### DIFF
--- a/activity_monitor.c
+++ b/activity_monitor.c
@@ -62,7 +62,7 @@ void going_active(int block) {
     command_execute(config.cmd_active_start, "", block);
 #ifdef CONFIG_METADATA
   debug(2, "abeg");                       // active mode begin
-  send_ssnc_metadata('pend', NULL, 0, 1); // contains cancellation points
+  send_ssnc_metadata('abeg', NULL, 0, 1); // contains cancellation points
 #endif
 
 #ifdef CONFIG_DBUS_INTERFACE
@@ -89,7 +89,7 @@ void going_inactive(int block) {
     command_execute(config.cmd_active_stop, "", block);
 #ifdef CONFIG_METADATA
   debug(2, "aend");                       // active mode end
-  send_ssnc_metadata('pend', NULL, 0, 1); // contains cancellation points
+  send_ssnc_metadata('aend', NULL, 0, 1); // contains cancellation points
 #endif
 
 #ifdef CONFIG_DBUS_INTERFACE


### PR DESCRIPTION
Found that MQTT activity_start: abeg and activity_end: aend topics where never being published. 

background:
Immediately after a play session started a play_end: pend topic was sent.  Also after the activity_timout a duplicate play_end was received.

Fix:
This commit fixes those bugs by correctly the metadata codes from "pend" to the correct "abeg" and "aend"

This was tested in my docker development setup on a RPI 3. it worked well