### PR TITLE
player: let player_thread exit cleanly without forcing a cancel

### DIFF
--- a/player.h
+++ b/player.h
@@ -269,6 +269,9 @@ typedef struct {
 
   int enable_dither; // needed for filling silences before play actually starts
   uint64_t dac_buffer_queue_minimum_length;
+
+  int player_stop_set;
+
 } rtsp_conn_info;
 
 uint32_t modulo_32_offset(uint32_t from, uint32_t to);


### PR DESCRIPTION
Hello again!

This is my attempt to fix the threading issue I found in #1175 

To go over the problem again. Calling [pthread_cancel](https://man7.org/linux/man-pages/man3/pthread_cancel.3.html) is problematic because it will just terminate the thread immediately (if `pthread_setcancelstate` is `enabled`). This can cause problems when the player output needs to track a state (with pulseaudio that is the threaded mainloop lock).

This PR attempts to fix that by signalling to the player_thread that the thread should stop and exit. This allows the thread state to be tracked properly.

I've only done some limited testing with this but wanted to PR early to get some feedback if this is desired behaviour or not.

One problem I can see is that `pthread_join` is a blocking call so there is the possibility to end up in a deadlock if the player_thread blocks and doesn't exit. This could possibly be handled with a timeout and forced cancellation. In my (limited) experience this hasn't happened yet though. There is also no trivial way to set a timeout other than spawning another thread that will call the cancel after a period of time (again because `pthread_join` blocks).

An alternative to this is to `enable` and `disable` the `pthread_setcancelstate` at the beginning of the loop, though I'm not sure if that is good behaviour or not.

Thoughts?