### PR TITLE
pipewire: add initial support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,6 +80,10 @@ if USE_PA
 shairport_sync_SOURCES += audio_pa.c
 endif
 
+if USE_PW
+shairport_sync_SOURCES += audio_pw.c
+endif
+
 if USE_CONVOLUTION
 shairport_sync_SOURCES += FFTConvolver/AudioFFT.cpp FFTConvolver/FFTConvolver.cpp FFTConvolver/Utilities.cpp FFTConvolver/convolver.cpp
 AM_CXXFLAGS += -std=c++11

--- a/audio.c
+++ b/audio.c
@@ -43,6 +43,9 @@ extern audio_output audio_ao;
 #ifdef CONFIG_SOUNDIO
 extern audio_output audio_soundio;
 #endif
+#ifdef CONFIG_PW
+extern audio_output audio_pw;
+#endif
 #ifdef CONFIG_PA
 extern audio_output audio_pa;
 #endif
@@ -65,6 +68,9 @@ static audio_output *outputs[] = {
 #endif
 #ifdef CONFIG_SNDIO
     &audio_sndio,
+#endif
+#ifdef CONFIG_PW
+    &audio_pw,
 #endif
 #ifdef CONFIG_PA
     &audio_pa,

--- a/audio_pw.c
+++ b/audio_pw.c
@@ -1,0 +1,501 @@
+/*
+ * Asynchronous Pipewire Backend. This file is part of Shairport Sync.
+ * Copyright (c) Shairport Sync 2021
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "audio.h"
+#include "common.h"
+
+#include <pipewire/pipewire.h>
+#include <pipewire/stream.h>
+#include <spa/param/audio/layout.h>
+#include <spa/param/audio/format-utils.h>
+#include <spa/utils/result.h>
+
+#include <math.h>
+
+struct pw_data {
+  struct pw_thread_loop *mainloop;
+  struct pw_context *context;
+
+  struct pw_core *core;
+  struct spa_hook core_listener;
+
+  struct pw_registry *registry;
+  struct spa_hook registry_listener;
+
+  struct pw_stream *stream;
+  struct spa_hook stream_listener;
+
+  struct pw_buffer *pw_buffer;
+
+  struct pw_properties *props;
+  int sync;
+
+  enum spa_audio_format format;
+  uint32_t rate;
+  uint32_t channels;
+  uint32_t stride;
+  uint32_t latency;
+
+} data;
+
+static void on_core_info(__attribute__((unused)) void *userdata, const struct pw_core_info *info)
+{
+  debug(1, "pw: remote %"PRIu32" is named \"%s\"", info->id, info->name);
+}
+
+static void on_core_error(__attribute__((unused)) void *userdata, uint32_t id, int seq, int res, const char *message)
+{
+  warn("pw: remote error: id=%"PRIu32" seq:%d res:%d (%s): %s", id, seq, res, spa_strerror(res), message);
+}
+
+static const struct pw_core_events core_events = {
+  PW_VERSION_CORE_EVENTS,
+  .info = on_core_info,
+  .error = on_core_error,
+};
+
+static void registry_event_global(__attribute__((unused))  void *userdata, uint32_t id,
+    __attribute__((unused)) uint32_t permissions, const char *type, __attribute__((unused)) uint32_t version,
+    const struct spa_dict *props)
+{
+  const struct spa_dict_item *item;
+  const char *name, *media_class;
+
+  if (strcmp(type, PW_TYPE_INTERFACE_Node) == 0) {
+    name = spa_dict_lookup(props, PW_KEY_NODE_NAME);
+    media_class = spa_dict_lookup(props, PW_KEY_MEDIA_CLASS);
+
+    if (!name || !media_class)
+      return;
+
+    debug(1, "pw: registry: id=%"PRIu32" type=%s name=\"%s\" media_class=\"%s\"", id, type, name, media_class);
+
+    spa_dict_for_each(item, props) {
+      debug(1, "pw: \t\t%s = \"%s\"", item->key, item->value);
+    }
+  }
+}
+
+static void registry_event_global_remove(__attribute__((unused)) void *userdata, uint32_t id)
+{
+  debug(1, "pw: registry: remove id=%"PRIu32"", id);
+}
+
+static const struct pw_registry_events registry_events = {
+  PW_VERSION_REGISTRY_EVENTS,
+  .global = registry_event_global,
+  .global_remove = registry_event_global_remove,
+};
+
+static void on_state_changed(void *userdata, enum pw_stream_state old, enum pw_stream_state state, const char *error)
+{
+  struct pw_data *pipewire = userdata;
+
+  debug(1, "pw: stream state changed %s -> %s", pw_stream_state_as_string(old), pw_stream_state_as_string(state));
+
+  if (state == PW_STREAM_STATE_STREAMING)
+    debug(1, "pw: stream node %"PRIu32"", pw_stream_get_node_id(pipewire->stream));
+
+  if (state == PW_STREAM_STATE_ERROR)
+    debug(1, "pw: stream node %"PRIu32" error: %s", pw_stream_get_node_id(pipewire->stream), error);
+
+  pw_thread_loop_signal(pipewire->mainloop, 0);
+}
+
+static void on_process(void *userdata)
+{
+  struct pw_data *pipewire = userdata;
+
+  pw_thread_loop_signal(pipewire->mainloop, 0);
+}
+
+static void on_drained(void *userdata)
+{
+  struct pw_data *pipewire = userdata;
+
+  pw_stream_set_active(pipewire->stream, false);
+
+  pw_thread_loop_signal(pipewire->mainloop, 0);
+}
+
+static const struct pw_stream_events stream_events = {
+  PW_VERSION_STREAM_EVENTS,
+  .state_changed = on_state_changed,
+  .process = on_process,
+  .drained = on_drained,
+};
+
+static void deinit() {
+  pw_thread_loop_stop(data.mainloop);
+
+  if (data.stream) {
+    pw_stream_destroy(data.stream);
+    data.stream = NULL;
+  }
+
+  if (data.registry) {
+    pw_proxy_destroy((struct pw_proxy*)data.registry);
+    data.registry = NULL;
+  }
+
+  if (data.core) {
+    pw_core_disconnect(data.core);
+    data.core = NULL;
+  }
+
+  if (data.context) {
+    pw_context_destroy(data.context);
+    data.context = NULL;
+  }
+
+  if (data.mainloop) {
+    pw_thread_loop_destroy(data.mainloop);
+    data.mainloop = NULL;
+  }
+
+  if (data.props) {
+    pw_properties_free(data.props);
+    data.props = NULL;
+  }
+}
+
+static int init(__attribute__((unused)) int argc, __attribute__((unused)) char** argv) {
+
+  struct pw_loop *loop;
+  struct pw_properties* props;
+
+  // set up default values first
+  config.audio_backend_buffer_desired_length = 0.35;
+  config.audio_backend_buffer_interpolation_threshold_in_seconds = 0.02;
+  config.audio_backend_latency_offset = 0;
+
+  pw_init(NULL, NULL);
+
+  debug(1, "pw: compiled with libpipewire %s", pw_get_headers_version());
+  debug(1, "pw: linked with libpipewire: %s", pw_get_library_version());
+
+  data.props = pw_properties_new(
+      PW_KEY_MEDIA_TYPE, "Audio",
+      PW_KEY_MEDIA_CATEGORY, "Playback",
+      PW_KEY_MEDIA_ROLE, "Music",
+      PW_KEY_APP_NAME, "shairport-sync",
+      PW_KEY_NODE_NAME, "shairport-sync",
+      NULL);
+
+  if (!data.props) {
+    deinit();
+    die("pw: pw_properties_new() failed: %m");
+  }
+
+  data.mainloop = pw_thread_loop_new("pipewire", NULL);
+  if (!data.mainloop) {
+    deinit();
+    die("pw: pw_thread_loop_new_full() failed: %m");
+  }
+
+  props = pw_properties_new(PW_KEY_CONFIG_NAME, "client-rt.conf", NULL);
+  if (!props) {
+    deinit();
+    die("pw: pw_properties_new() failed: %m");
+  }
+
+  loop = pw_thread_loop_get_loop(data.mainloop);
+
+  data.context = pw_context_new(loop, props, 0);
+  if (!data.context) {
+    deinit();
+    die("pw: pw_context_new() failed: %m");
+  }
+
+  props = pw_properties_new(PW_KEY_REMOTE_NAME, NULL, NULL);
+  if (!props) {
+    deinit();
+    die("pw: pw_properties_new() failed: %m");
+  }
+
+  pw_thread_loop_lock(data.mainloop);
+
+  if (pw_thread_loop_start(data.mainloop) != 0) {
+    deinit();
+    die("pw: pw_thread_loop_start() failed: %m");
+  }
+
+  data.core = pw_context_connect(data.context, props, 0);
+  if (!data.core) {
+    deinit();
+    die("pw: pw_context_connect() failed: %m");
+  }
+
+  pw_core_add_listener(data.core, &data.core_listener, &core_events, &data);
+
+  data.registry = pw_core_get_registry(data.core, PW_VERSION_REGISTRY, 0);
+  if (!data.registry) {
+    deinit();
+    die("pw: pw_core_get_registry() failed: %m");
+  }
+
+  pw_registry_add_listener(data.registry, &data.registry_listener, &registry_events, &data);
+
+  data.sync = pw_core_sync(data.core, 0, data.sync);
+
+  pw_thread_loop_unlock(data.mainloop);
+
+  return 0;
+}
+
+static enum spa_audio_format sps_format_to_spa_format(sps_format_t sps_format) {
+  switch (sps_format) {
+    case SPS_FORMAT_S8:
+      return SPA_AUDIO_FORMAT_S8;
+    case SPS_FORMAT_U8:
+      return SPA_AUDIO_FORMAT_U8;
+    case SPS_FORMAT_S16:
+      return SPA_AUDIO_FORMAT_S16;
+    case SPS_FORMAT_S16_LE:
+      return SPA_AUDIO_FORMAT_S16_LE;
+    case SPS_FORMAT_S16_BE:
+      return SPA_AUDIO_FORMAT_S16_BE;
+    case SPS_FORMAT_S24:
+      return SPA_AUDIO_FORMAT_S24_32;
+    case SPS_FORMAT_S24_LE:
+      return SPA_AUDIO_FORMAT_S24_32_LE;
+    case SPS_FORMAT_S24_BE:
+      return SPA_AUDIO_FORMAT_S24_32_BE;
+    case SPS_FORMAT_S24_3LE:
+      return SPA_AUDIO_FORMAT_S24_LE;
+    case SPS_FORMAT_S24_3BE:
+      return SPA_AUDIO_FORMAT_S24_BE;
+    case SPS_FORMAT_S32:
+      return SPA_AUDIO_FORMAT_S32;
+    case SPS_FORMAT_S32_LE:
+      return SPA_AUDIO_FORMAT_S32_LE;
+    case SPS_FORMAT_S32_BE:
+      return SPA_AUDIO_FORMAT_S32_BE;
+
+    case SPS_FORMAT_UNKNOWN:
+    case SPS_FORMAT_AUTO:
+    case SPS_FORMAT_INVALID:
+    default:
+      return SPA_AUDIO_FORMAT_S16;
+  }
+}
+
+static int spa_format_samplesize(enum spa_audio_format audio_format)
+{
+  switch(audio_format) {
+    case SPA_AUDIO_FORMAT_S8:
+    case SPA_AUDIO_FORMAT_U8:
+      return 1;
+    case SPA_AUDIO_FORMAT_S16:
+      return 2;
+    case SPA_AUDIO_FORMAT_S24:
+      return 3;
+    case SPA_AUDIO_FORMAT_S24_32:
+    case SPA_AUDIO_FORMAT_S32:
+      return 4;
+    default:
+      die("pw: unhandled spa_audio_format: %d", audio_format);
+      return -1;
+  }
+}
+
+static const char* spa_format_to_str(enum spa_audio_format audio_format)
+{
+  switch(audio_format) {
+    case SPA_AUDIO_FORMAT_U8:
+      return "u8";
+    case SPA_AUDIO_FORMAT_S8:
+      return "s8";
+    case SPA_AUDIO_FORMAT_S16:
+      return "s16";
+    case SPA_AUDIO_FORMAT_S24:
+    case SPA_AUDIO_FORMAT_S24_32:
+      return "s24";
+    case SPA_AUDIO_FORMAT_S32:
+      return "s32";
+    default:
+      die("pw: unhandled spa_audio_format: %d", audio_format);
+      return "(invalid)";
+  }
+}
+
+static void start(int sample_rate, int sample_format) {
+
+  pw_thread_loop_lock(data.mainloop);
+
+  const struct spa_pod *params[1];
+  uint8_t buffer[1024];
+  struct spa_pod_builder pod_builder = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
+  struct spa_audio_info_raw info;
+  uint32_t nom;
+  int ret;
+
+  data.format = sps_format_to_spa_format(sample_format);
+  data.rate = sample_rate;
+  data.channels = 2;
+  data.stride = spa_format_samplesize(data.format) * data.channels;
+  data.latency = 20000;
+
+  nom = nearbyint((data.latency * data.rate) / 1000000.0);
+
+  pw_properties_setf(data.props, PW_KEY_NODE_LATENCY, "%u/%u", nom, data.rate);
+
+  debug(1, "pw: rate: %d", data.rate);
+  debug(1, "pw: channgels: %d", data.channels);
+  debug(1, "pw: format: %s", spa_format_to_str(data.format));
+  debug(1, "pw: samplesize: %d", spa_format_samplesize(data.format));
+  debug(1, "pw: stride: %d", data.stride);
+  debug(1, "pw: latency: %d samples (%.3fs)", nom, (double)nom/data.rate);
+
+  info = SPA_AUDIO_INFO_RAW_INIT(
+    .flags = SPA_AUDIO_FLAG_NONE,
+    .format = data.format,
+    .rate = data.rate,
+    .channels = data.channels);
+
+  params[0] = spa_format_audio_raw_build(&pod_builder, SPA_PARAM_EnumFormat, &info);
+
+  data.stream = pw_stream_new(data.core, "shairport-sync", data.props);
+
+  if (!data.stream) {
+    deinit();
+    die("pw: pw_stream_new() failed: %m");
+  }
+
+  debug(1, "pw: connecting stream: target_id=%"PRIu32"", PW_ID_ANY);
+
+  pw_stream_add_listener(data.stream, &data.stream_listener, &stream_events, &data);
+
+  ret = pw_stream_connect(data.stream,
+          PW_DIRECTION_OUTPUT,
+          PW_ID_ANY,
+          PW_STREAM_FLAG_INACTIVE | PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_MAP_BUFFERS,
+          params, 1);
+
+  if (ret < 0) {
+    deinit();
+    die("pw: pw_stream_connect() failed: %s", spa_strerror(ret));
+  }
+
+  const struct pw_properties *props;
+  void *pstate;
+  const char *key, *val;
+
+  if ((props = pw_stream_get_properties(data.stream)) != NULL) {
+    debug(1, "pw: stream properties:");
+    pstate = NULL;
+    while ((key = pw_properties_iterate(props, &pstate)) != NULL &&
+      (val = pw_properties_get(props, key)) != NULL) {
+      debug(1, "pw: \t%s = \"%s\"", key, val);
+    }
+  }
+
+  while(1) {
+    enum pw_stream_state stream_state = pw_stream_get_state(data.stream, NULL);
+    if (stream_state == PW_STREAM_STATE_PAUSED)
+      break;
+
+    pw_thread_loop_wait(data.mainloop);
+  }
+
+  pw_thread_loop_unlock(data.mainloop);
+}
+
+static void stop() {
+  pw_thread_loop_lock(data.mainloop);
+
+  pw_stream_flush(data.stream, true);
+
+  pw_thread_loop_unlock(data.mainloop);
+}
+
+static void flush() {
+  pw_thread_loop_lock(data.mainloop);
+
+  pw_stream_flush(data.stream, false);
+
+  pw_thread_loop_unlock(data.mainloop);
+}
+
+static int play(void *buf, int samples) {
+  struct pw_buffer *pw_buffer;
+  struct spa_buffer *spa_buffer;
+  struct spa_data *spa_data;
+
+  pw_thread_loop_lock(data.mainloop);
+
+  if (pw_stream_get_state(data.stream, NULL) == PW_STREAM_STATE_PAUSED)
+    pw_stream_set_active(data.stream, true);
+
+  while (pw_buffer == NULL) {
+    pw_buffer = pw_stream_dequeue_buffer(data.stream);
+    if (pw_buffer)
+      break;
+
+    pw_thread_loop_wait(data.mainloop);
+  }
+
+  spa_buffer = pw_buffer->buffer;
+  spa_data = &spa_buffer->datas[0];
+
+  size_t bytes_to_copy = samples * data.stride;
+
+  debug(3, "pw: bytes_to_copy: %d", bytes_to_copy);
+
+  if (spa_data->maxsize < bytes_to_copy)
+    bytes_to_copy = spa_data->maxsize;
+
+  debug(3, "pw: spa_data->maxsize: %d", spa_data->maxsize);
+
+  memcpy(spa_data->data, buf, bytes_to_copy);
+
+  spa_data->chunk->offset = 0;
+  spa_data->chunk->stride = data.stride;
+  spa_data->chunk->size = bytes_to_copy;
+
+  pw_stream_queue_buffer(data.stream, pw_buffer);
+
+  pw_thread_loop_unlock(data.mainloop);
+
+  return 0;
+}
+
+audio_output audio_pw = {
+  .name = "pw",
+  .help = NULL,
+  .init = &init,
+  .deinit = &deinit,
+  .prepare = NULL,
+  .start = &start,
+  .stop = &stop,
+  .is_running = NULL,
+  .flush = &flush,
+  .delay = NULL,
+  .play = &play,
+  .volume = NULL,
+  .parameters = NULL,
+  .mute = NULL
+};

--- a/configure.ac
+++ b/configure.ac
@@ -299,6 +299,21 @@ if test "x$with_pa" = "xyes" ; then
 fi
 AM_CONDITIONAL([USE_PA], [test "x$with_pa" = "xyes"])
 
+# Look for pipewire flag
+AC_ARG_WITH(pw, [AS_HELP_STRING([--with-pw],[choose Pipewire support.])])
+if test "x$with_pw" = "xyes" ; then
+  AC_DEFINE([CONFIG_PW], 1, [Include Pipewire support.])
+  if  test "x${with_pkg_config}" = xyes ; then
+    PKG_CHECK_MODULES(
+      [PIPEWIRE], [libpipewire-0.3 >= 0.3.24],
+      [CFLAGS="${PIPEWIRE_CFLAGS} ${CFLAGS} -Wno-missing-field-initializers" LIBS="${PIPEWIRE_LIBS} ${LIBS}"],
+      [AC_MSG_ERROR(Pipewire support requires the libpipewire-dev library!)])
+  else
+    AC_CHECK_LIB([pipewire], [pw_stream_queue_buffer], , AC_MSG_ERROR(Pipewire support requires the libpipewire-dev library.))
+  fi
+fi
+AM_CONDITIONAL([USE_PW], [test "x$with_pw" = "xyes"])
+
 # Look for Convolution flag
 AC_ARG_WITH(convolution, [AS_HELP_STRING([--with-convolution],[choose audio DSP convolution support])])
 if test "x$with_convolution" = "xyes" ; then


### PR DESCRIPTION
Hey! It's me again.

I've been wanting to work with pipewire more so I decided to write an audio output for it!

This audio backend takes a lot of design decisions from my pulseaudio rewrite in #1175 

Pipewire and pulseaudio share a lot of similarities and you will see that in the design. There are some major differences in the way data is queued though. You will see that a buffer needs to be dequeued (acquired) from pipewire, data can then be copied into the buffer, then the buffer can be queued again. If a buffer isn't returned when dequeuing we wait for the pipewire mainthread to signal that we can process more data and try to dequeue a buffer again.

This actually works quite well as pipewire let's you throw data at it quickly the blocking/waiting that happens is very minimal.

A lot of design was taken from the [pw-cat](https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/src/tools/pw-cat.c) tool though that application doesn't use the pipewire threaded mainloop.

This PR does currently require #1176 or else you'll get in a stuck state as I didn't add the lock/unlock hacks that I have in #1175 

This also closes #1171 


sample output
```
         0.000874781 "../audio_pw.c:66" pw: remote 0 is named "pipewire-0"
         0.000101418 "../audio_pw.c:94" pw: registry: id=34 type=PipeWire:Interface:Node name="Midi-Bridge" media_class="Midi/Bridge"
         0.000017748 "../audio_pw.c:97" pw: 		factory.id = "10"
         0.000010296 "../audio_pw.c:97" pw: 		client.id = "31"
         0.000008204 "../audio_pw.c:97" pw: 		node.name = "Midi-Bridge"
         0.000007678 "../audio_pw.c:97" pw: 		media.class = "Midi/Bridge"
         0.000017149 "../audio_pw.c:94" pw: registry: id=39 type=PipeWire:Interface:Node name="alsa_output.pci-0000_01_00.1.hdmi-stereo-extra4" media_class="Audio/Sink"
         0.000010759 "../audio_pw.c:97" pw: 		object.path = "alsa:pcm:1:hdmi:1,4:playback"
         0.000007868 "../audio_pw.c:97" pw: 		factory.id = "18"
         0.000031092 "../audio_pw.c:97" pw: 		client.id = "31"
         0.000008614 "../audio_pw.c:97" pw: 		device.id = "37"
         0.000007539 "../audio_pw.c:97" pw: 		priority.session = "520"
         0.000006500 "../audio_pw.c:97" pw: 		priority.driver = "520"
         0.000004866 "../audio_pw.c:97" pw: 		node.description = "Polaris 22 HDMI Audio Digital Stereo (HDMI 5)"
         0.000005054 "../audio_pw.c:97" pw: 		node.name = "alsa_output.pci-0000_01_00.1.hdmi-stereo-extra4"
         0.000004953 "../audio_pw.c:97" pw: 		node.nick = "HDA ATI HDMI"
         0.000004694 "../audio_pw.c:97" pw: 		media.class = "Audio/Sink"
         0.000007413 "../audio_pw.c:94" pw: registry: id=40 type=PipeWire:Interface:Node name="alsa_input.pci-0000_00_1f.3.analog-stereo" media_class="Audio/Source"
         0.000005695 "../audio_pw.c:97" pw: 		object.path = "alsa:pcm:0:front:0:capture"
         0.000004931 "../audio_pw.c:97" pw: 		factory.id = "18"
         0.000004628 "../audio_pw.c:97" pw: 		client.id = "31"
         0.000004524 "../audio_pw.c:97" pw: 		device.id = "38"
         0.000004546 "../audio_pw.c:97" pw: 		priority.session = "2009"
         0.000004847 "../audio_pw.c:97" pw: 		priority.driver = "2009"
         0.000004587 "../audio_pw.c:97" pw: 		node.description = "Built-in Audio Analog Stereo"
         0.000004887 "../audio_pw.c:97" pw: 		node.name = "alsa_input.pci-0000_00_1f.3.analog-stereo"
         0.000004963 "../audio_pw.c:97" pw: 		node.nick = "HDA Intel PCH"
         0.000004674 "../audio_pw.c:97" pw: 		media.class = "Audio/Source"
         0.005409661 "../audio_pw.c:366" pw: rate: 44100
         0.000035739 "../audio_pw.c:367" pw: channgels: 2
         0.000011691 "../audio_pw.c:368" pw: format: s16
         0.000009392 "../audio_pw.c:369" pw: samplesize: 2
         0.000009172 "../audio_pw.c:370" pw: stride: 4
         0.000009280 "../audio_pw.c:371" pw: latency: 882 samples (0.020s)
         0.000039548 "../audio_pw.c:388" pw: connecting stream: target_id=4294967295
         0.000028941 "../audio_pw.c:117" pw: stream state changed unconnected -> connecting
         0.001642486 "../audio_pw.c:408" pw: stream properties:
         0.000026548 "../audio_pw.c:412" pw: 	media.type = "Audio"
         0.000012632 "../audio_pw.c:412" pw: 	media.category = "Playback"
         0.000009579 "../audio_pw.c:412" pw: 	media.role = "Music"
         0.000009160 "../audio_pw.c:412" pw: 	application.name = "shairport-sync"
         0.000008819 "../audio_pw.c:412" pw: 	node.name = "shairport-sync"
         0.000008526 "../audio_pw.c:412" pw: 	node.latency = "882/44100"
         0.000009153 "../audio_pw.c:412" pw: 	media.name = "shairport-sync"
         0.000007953 "../audio_pw.c:412" pw: 	stream.is-live = "true"
         0.000008950 "../audio_pw.c:412" pw: 	node.autoconnect = "true"
         0.000006652 "../audio_pw.c:412" pw: 	media.class = "Stream/Output/Audio"
         0.001613739 "../audio_pw.c:117" pw: stream state changed connecting -> paused
         0.000130686 "../audio_pw.c:94" pw: registry: id=55 type=PipeWire:Interface:Node name="shairport-sync" media_class="Stream/Output/Audio"
         0.000025312 "../audio_pw.c:97" pw: 		factory.id = "8"
         0.000013847 "../audio_pw.c:97" pw: 		client.id = "49"
         0.000011366 "../audio_pw.c:97" pw: 		application.name = "shairport-sync"
         0.000012982 "../audio_pw.c:97" pw: 		node.name = "shairport-sync"
         0.000056083 "../audio_pw.c:97" pw: 		media.class = "Stream/Output/Audio"
         0.000018484 "../audio_pw.c:97" pw: 		media.type = "Audio"
         0.000010842 "../audio_pw.c:97" pw: 		media.category = "Playback"
         0.000010348 "../audio_pw.c:97" pw: 		media.role = "Music"
         0.098302342 "../audio_pw.c:117" pw: stream state changed paused -> streaming
         0.000014038 "../audio_pw.c:120" pw: stream node 55
```