### PR TITLE
Changed order of includes in shairport.c

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ If you are using WiFi, you should turn off WiFi Power Management:
 ```
 # iwconfig wlan0 power off
 ```
-WiFi Power Management will put the WiFi system in low-power mode when the WiFi system considered inactive, and in this mode it may not respond to events initiated from the network, such as AirPlay requests. Hence, WiFi Power Management should be turned off. (See [TROUBLESHOOTING.md](https://github.com/mikebrady/shairport-sync/blob/master/TROUBLESHOOTING.md#wifi-adapter-running-in-power-saving--low-power-mode) for more details.)
+WiFi Power Management will put the WiFi system in low-power mode when the WiFi system is considered inactive, and in this mode it may not respond to events initiated from the network, such as AirPlay requests. Hence, WiFi Power Management should be turned off. (See [TROUBLESHOOTING.md](https://github.com/mikebrady/shairport-sync/blob/master/TROUBLESHOOTING.md#wifi-adapter-running-in-power-saving--low-power-mode) for more details.)
 
 Reboot the Pi.
 


### PR DESCRIPTION
I moved #include &lt;net/if.h&gt; after #include &lt;sys/socket.h&gt;
because the old order caused compilation errors like "error: field ‘ifru_addr’ has incomplete type" when I tried to compile with gcc-7.
This fixed it for me. Maybe this fix is useful to some else as well.