### PR TITLE
small change to fix codec loading for ubuntu-18/ffmpeg-3.4

### DIFF
--- a/rtp.c
+++ b/rtp.c
@@ -2114,8 +2114,8 @@ void *rtp_buffered_audio_processor(void *arg) {
 
   // initialize all muxers, demuxers and protocols for libavformat
   // (does nothing if called twice during the course of one program execution)
-  // not needed in ffmpeg 4.0 and later...
-  // av_register_all();
+  // not needed in ffmpeg 4.0 and later... but still needed in ffmpeg 3.6 / ubuntu 18
+  avcodec_register_all();
 
   AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_AAC);
   if (codec == NULL) {


### PR DESCRIPTION
Hi @mikebrady , thank you for your effort on making shairport-sync work with Airplay2.

I was trying to get this working on another flavour of the Pi (RockPi-E, https://wiki.radxa.com/RockpiE), which supports Ubuntu 18.

This had the unfortunate problem where shairport-sync fails with the message "Can't find an AAC decoder!". Upon digging, the issue appears to be that Ubuntu 18's default apt repository has FFmpeg 3.4, not FFmpeg 4.x.

After some more digging, I found adding this line resolves the issue. My understanding is that this shouldn't introduce any bad side effects when built using FFmpeg 4.x.

Would appreciate your thoughts on whether this is a reasonable addition, or if you are aware of a more elegant way of handling this.

Thanks