### PR TITLE
configure.ac: use pkg_config for sndfile is --with-pkg-config

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           stale-issue-message: 'This issue has been inactive for 60 days so will be closed 7 days from now. To prevent this, please remove the "stale" label or post a comment.'
           stale-pr-message: 'This PR has been inactive for 60 days so will be closed 7 days from now. To prevent this, please remove the "stale" label or post a comment.'
-          operations-per-run: 50
+          operations-per-run: 100
           # These are the defaults at the time of writing. https://github.com/marketplace/actions/close-stale-issues
           # days-before-stale: 60
           # days-before-close: 7

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,7 +44,7 @@ Okay, now let's get the tools and sources for building and installing Shairport 
 
 First, install the packages needed by Shairport Sync:
 ```
-# apt-get install build-essential git xmltoman autoconf automake libtool \
+# apt install --no-install-recommends build-essential git xmltoman autoconf automake libtool \
     libpopt-dev libconfig-dev libasound2-dev avahi-daemon libavahi-client-dev libssl-dev libsoxr-dev
 ```
 Next, download Shairport Sync, configure it, compile and install it:

--- a/configure.ac
+++ b/configure.ac
@@ -302,9 +302,16 @@ AM_CONDITIONAL([USE_PA], [test "x$with_pa" = "xyes"])
 # Look for Convolution flag
 AC_ARG_WITH(convolution, [AS_HELP_STRING([--with-convolution],[choose audio DSP convolution support])])
 if test "x$with_convolution" = "xyes" ; then
+  if test "x${with_pkg_config}" = "xyes" ; then
+    PKG_CHECK_MODULES(
+      [sndfile], [sndfile],
+      [CFLAGS="${sndfile_CFLAGS} ${CFLAGS}"
+      LIBS="${sndfile_LIBS} ${LIBS}"], AC_MSG_ERROR(Convolution support requires the sndfile library.))
+  else
+    AC_CHECK_LIB([sndfile], [sf_open], , AC_MSG_ERROR(Convolution support requires the sndfile library -- libsndfile1-dev suggested!))
+  fi
   AM_INIT_AUTOMAKE([subdir-objects])
   AC_DEFINE([CONFIG_CONVOLUTION], 1, [Include audio DSP convolution support.])
-  AC_CHECK_LIB([sndfile], [sf_open], , AC_MSG_ERROR(Convolution support requires the sndfile library -- libsndfile1-dev suggested!))
 fi
 AM_CONDITIONAL([USE_CONVOLUTION], [test "x$with_convolution" = "xyes"])
 


### PR DESCRIPTION
When building `shairport-sync` with `Convolution` if sndfile is built statically then the dependent libraries are not included in the build of `shairport-sync` - resulting in the below error:
```
checking for sf_open in -lsndfile... no
configure: error: Convolution support requires the sndfile library -- libsndfile1-dev suggested!
```
the config.log has the following in it.
```
configure:8616: checking for sf_open in -lsndfile
configure:8639: /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc -o conftest -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include -march=x86-64 -m64 -mmmx -msse -msse2 -mfpmath=sse -Wall -pipe  -O2 -fomit-frame-pointer  -march=x86-64 -m64 -Wl,--as-needed -fuse-ld=gold conftest.c -lsndfile  -L/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib -lpulse -pthread -L/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib -lasound -lavahi-common -lavahi-client -L/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib -lsoxr -L/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib -L/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib -lssl -lcrypto -L/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib -lconfig -L/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib -lpopt -lm -lpthread -lrt  >&5
/sysroot/usr/lib/libsndfile.a(flac.c.o):flac.c:function sf_flac_error_callback: error: undefined reference to 'FLAC__StreamDecoderErrorStatusString'
/sysroot/usr/lib/libsndfile.a(ogg.c.o):ogg.c:function ogg_close: error: undefined reference to 'ogg_sync_clear'
/sysroot/usr/lib/libsndfile.a(ogg_vorbis.c.o):ogg_vorbis.c:function vorbis_calculate_page_duration: error: undefined reference to 'vorbis_packet_blocksize'
/sysroot/usr/lib/libsndfile.a(ogg_opus.c.o):ogg_opus.c:function ogg_opus_open: error: undefined reference to 'ogg_stream_init'
collect2: error: ld returned 1 exit status
```
This is fixed through the use of PKG_CHECK_MODULES bringing in the libraries from `sndfile.pc`
```
prefix=/usr
exec_prefix=${prefix}
libdir=${prefix}/lib
includedir=${prefix}/include

Name: sndfile
Description: A library for reading and writing audio files
Requires:
Requires.private: flac ogg vorbis vorbisenc opus
Version: 1.0.31
Libs: -L${libdir} -lsndfile -lFLAC -logg -lvorbis -lvorbisenc -lopus
Cflags: -I${includedir}
```