### PR TITLE
configure.ac: fix build with automake 1.16.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ([2.50])
 AC_INIT([shairport-sync], [4.1-dev], [4265913+mikebrady@users.noreply.github.com])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR([shairport.c])
 AC_CONFIG_HEADERS([config.h])
 AC_PROG_RANLIB
@@ -323,7 +323,6 @@ AM_CONDITIONAL([USE_PW], [test "x$with_pw" = "xyes"])
 # Look for Convolution flag
 AC_ARG_WITH(convolution, [AS_HELP_STRING([--with-convolution],[choose audio DSP convolution support])])
 if test "x$with_convolution" = "xyes" ; then
-  AM_INIT_AUTOMAKE([subdir-objects])
   AC_DEFINE([CONFIG_CONVOLUTION], 1, [Include audio DSP convolution support.])
   if  test "x${with_pkg_config}" = xyes ; then
     PKG_CHECK_MODULES(


### PR DESCRIPTION
Fix the following build failure with convolution raised since automake 1.16.5 and https://git.savannah.gnu.org/cgit/automake.git/commit/?id=f4a3a70f69e1dbccb6578f39ef47835098a04624:

```
configure.ac:305: error: AM_INIT_AUTOMAKE expanded multiple times
/home/giuliobenetti/autobuild/run/instance-1/output-1/host/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:6: the top level
/home/giuliobenetti/autobuild/run/instance-1/output-1/host/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:305: the top level
```

Fixes:
 - http://autobuild.buildroot.org/results/464148bdccb705d8992dc860262bfdeb01b7e2a1

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>