### PR TITLE
use s6 process manager in Docker container.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -113,6 +113,14 @@ RUN apk -U add \
 
 RUN rm -rf  /lib/apk/db/*
 
+# set version for s6 overlay
+ARG OVERLAY_VERSION="v2.2.0.3"
+ARG OVERLAY_ARCH="armhf"
+
+# add s6 overlay
+ADD https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${OVERLAY_ARCH}-installer /tmp/
+RUN chmod +x /tmp/s6-overlay-${OVERLAY_ARCH}-installer && /tmp/s6-overlay-${OVERLAY_ARCH}-installer / && rm /tmp/s6-overlay-${OVERLAY_ARCH}-installer
+
 COPY --from=builder-alac /usr/local/lib/libalac.* /usr/local/lib/
 COPY --from=builder-sps /etc/shairport-sync* /etc/
 COPY --from=builder-sps /etc/dbus-1/system.d/shairport-sync-dbus.conf /etc/dbus-1/system.d/
@@ -129,8 +137,10 @@ RUN adduser -D shairport-sync -G shairport-sync
 # Add the shairport-sync user to the pre-existing audio group, which has ID 29, for access to the ALSA stuff
 RUN addgroup -g 29 docker_audio && addgroup shairport-sync docker_audio && addgroup shairport-sync audio
 
-COPY ./docker/start.sh /
+#COPY ./docker/start.sh /
+#RUN chmod +x ./start.sh
+#ENTRYPOINT [ "/start.sh" ]
 
-RUN chmod +x ./start.sh
-
-ENTRYPOINT [ "/start.sh" ]
+# s6 start
+COPY ./docker/etc /etc
+ENTRYPOINT ["/init"]

--- a/docker/etc/cont-init.d/10-dbus
+++ b/docker/etc/cont-init.d/10-dbus
@@ -1,0 +1,10 @@
+#!/usr/bin/with-contenv sh
+
+# make our folders
+mkdir -p /var/run/dbus
+
+[ -e /var/run/dbus.pid ] && \
+	rm -f /var/run/dbus.pid
+
+dbus-uuidgen --ensure
+sleep 1

--- a/docker/etc/services.d/avahi/run
+++ b/docker/etc/services.d/avahi/run
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv sh
+
+until [ -e /var/run/dbus/system_bus_socket ]; do
+    sleep 1s
+done
+
+exec avahi-daemon --no-chroot

--- a/docker/etc/services.d/dbus/run
+++ b/docker/etc/services.d/dbus/run
@@ -1,0 +1,2 @@
+#!/usr/bin/execlineb -P
+dbus-daemon --system --nofork

--- a/docker/etc/services.d/nqptp/run
+++ b/docker/etc/services.d/nqptp/run
@@ -1,0 +1,2 @@
+#!/usr/bin/execlineb -P
+/usr/local/bin/nqptp

--- a/docker/etc/services.d/shairport-sync/finish
+++ b/docker/etc/services.d/shairport-sync/finish
@@ -1,0 +1,2 @@
+#!/usr/bin/execlineb -S0
+s6-svscanctl -t /var/run/s6/services

--- a/docker/etc/services.d/shairport-sync/run
+++ b/docker/etc/services.d/shairport-sync/run
@@ -1,0 +1,3 @@
+#!/usr/bin/execlineb -P
+s6-setuidgid shairport-sync
+/usr/local/bin/shairport-sync -vu --statistics


### PR DESCRIPTION
Here is a refactoring of the current "start.sh" script that starts all processes (avahi, dbus, nqptp, shairport-sync) using the https://github.com/just-containers/s6-overlay system.

The s6 system should be better at dealing with signals, zombie processes, running processes under different user-ids, and it is a cleaner setup with separate configuration for each service.

I am no wizard in process handling, so there may be errors, but this setup works for me ;-)
