### PR TITLE
Die on unrecoverable error so the app can be restarted automatically

### DIFF
--- a/player.c
+++ b/player.c
@@ -1243,7 +1243,7 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
                         if (config.cmd_unfixable) {
                           command_execute(config.cmd_unfixable, "output_device_stalled", 1);
                         } else {
-                          warn("an unrecoverable error, \"output_device_stalled\", has been "
+                          die("an unrecoverable error, \"output_device_stalled\", has been "
                                "detected.",
                                conn->connection_number);
                         }

--- a/rtsp.c
+++ b/rtsp.c
@@ -343,7 +343,7 @@ void *player_watchdog_thread_code(void *arg) {
               conn->unfixable_error_reported = 1;
               command_execute(config.cmd_unfixable, "unable_to_cancel_play_session", 1);
             } else {
-              warn("an unrecoverable error, \"unable_to_cancel_play_session\", has been detected.",
+              die("an unrecoverable error, \"unable_to_cancel_play_session\", has been detected.",
                    conn->connection_number);
             }
           }


### PR DESCRIPTION
As discussed yesterday, die if we hit an unrecoverable error, so the system can restart the application.