### PR TITLE
Add PulseAudio (--with-pa) the docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,8 @@ RUN apk -U add \
         libressl-dev \
         openssl-dev \
         libplist-dev \
-        libgcrypt-dev
+        libgcrypt-dev \
+        pulseaudio-dev
 
 # ALAC Build System:
 FROM builder-base AS builder-alac
@@ -85,7 +86,7 @@ RUN autoreconf -fi
 #         --with-airplay-2
 # RUN make -j $(nproc)
 RUN CFLAGS="-O0 -g" CXXFLAGS="-O0 -g" ./configure --sysconfdir=/etc --with-metadata --with-dummy --with-pipe \
-        --with-alsa --with-soxr --with-avahi --with-ssl=openssl --with-dbus-interface --with-stdout \
+        --with-alsa --with-pa --with-soxr --with-avahi --with-ssl=openssl --with-dbus-interface --with-stdout \
         --with-mpris-interface --with-mqtt-client --with-apple-alac --with-convolution --with-airplay-2
 RUN make -j
 RUN make install
@@ -109,7 +110,8 @@ RUN apk -U add \
         ffmpeg \
         libsodium \
         libplist \
-        libgcrypt
+        libgcrypt \
+        pulseaudio
 
 RUN rm -rf  /lib/apk/db/*
 


### PR DESCRIPTION
I found a way to easily run multiple instances of SPS-AP2 in Docker containers all with their own IP addresses on the host network. ALSA doesn't seem to work well in Docker or LXC containers so I had to make use of PulseAudio. I figured I would put in a pull request to get PulseAudio added to the official Docker image in case others are interested. If you are trying to keep the official docker image as minimal as possible I will not be offended if you reject this pull request.