### PR TITLE
Automated docker tagging.

### DIFF
--- a/.github/workflows/docker-build-on-push.yaml
+++ b/.github/workflows/docker-build-on-push.yaml
@@ -1,0 +1,47 @@
+# Builds & pushes a docker image when a commit is made to one of the branches specified below.
+# Tag pattern: 'unstable-[BRANCH NAME]'.
+
+name: Build and push docker image based on commit to specified branches.
+
+on:
+  push:
+    branches: [ master ]
+
+env:
+  DOCKER_PLATFORMS: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set SHAIRPORT_SYNC_BRANCH env.
+        run: echo "SHAIRPORT_SYNC_BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./docker/airplay1/Dockerfile
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: true
+          tags: ${{ secrets.DOCKER_IMAGE_NAME }}:unstable-${{ env.SHAIRPORT_SYNC_BRANCH }}
+          build-args: |
+            SHAIRPORT_SYNC_BRANCH=${{ env.SHAIRPORT_SYNC_BRANCH }}

--- a/.github/workflows/docker-build-on-tag.yaml
+++ b/.github/workflows/docker-build-on-tag.yaml
@@ -1,0 +1,57 @@
+# Builds & pushes a docker image when a tag occurs.
+# It seems this yaml has to exist on the branch the tag refers to.
+
+# The following tags are created & pushed:
+# [RELEASE TAG] and latest
+
+name: Build and push docker images on releases.
+
+on:
+  push:
+    tags:
+      - '*' # Push events to every tag (not containing '/')
+
+env:
+  DOCKER_PLATFORMS: linux/386,linux/amd64,linux/arm/v6,linux/arm64,linux/arm/v7
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set SHAIRPORT_SYNC_BRANCH env.
+        run: |
+          raw=$(git branch -r --contains ${{ github.ref }})
+          branch=${raw##*/}
+          echo "SHAIRPORT_SYNC_BRANCH=${branch}" >> $GITHUB_ENV
+
+      - name: Set tag env
+        run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./docker/airplay1/Dockerfile
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: true
+          tags: ${{ secrets.DOCKER_IMAGE_NAME }}:latest, ${{ secrets.DOCKER_IMAGE_NAME }}:${{ env.GIT_TAG }}
+          build-args: |
+            SHAIRPORT_SYNC_BRANCH=${{ env.SHAIRPORT_SYNC_BRANCH }}

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,13 @@
+# Shairport Sync Docker Image
+
+Available at: https://hub.docker.com/r/mikebrady/shairport-sync
+
+## Original AirPlay 1 Image
+Please see: [airplay1/README.md](airplay1/README.md)
+
+## GitHub Action Builds
+Requires the following secrets to be set in the repo:
+- `DOCKER_REGISTRY` - docker.io if using Docker Hub, else set to your registry URL.
+- `DOCKER_REGISTRY_TOKEN` - Access token for your registry.
+- `DOCKER_REGISTRY_USER` - Login user for your registry.
+- `DOCKER_IMAGE_NAME` - The name of the image, for example `your-registry.com/shairport-sync` or just `your-username/shairport-sync` if using Docker Hub.

--- a/docker/airplay1/Dockerfile
+++ b/docker/airplay1/Dockerfile
@@ -1,0 +1,103 @@
+FROM alpine:3.12 AS builder-base
+# General Build System:
+RUN apk -U add \
+        git \
+        build-base \
+        autoconf \
+        automake \
+        libtool \
+        dbus \
+        su-exec \
+        alsa-lib-dev \
+        libdaemon-dev \
+        popt-dev \
+        mbedtls-dev \
+        soxr-dev \
+        avahi-dev \
+        libconfig-dev \
+        libsndfile-dev \
+        mosquitto-dev \
+        xmltoman
+
+# ALAC Build System:
+FROM builder-base AS builder-alac
+
+RUN git clone https://github.com/mikebrady/alac
+WORKDIR alac
+RUN autoreconf -fi
+RUN ./configure
+RUN make
+RUN make install
+
+# Shairport Sync Build System:
+FROM builder-base AS builder-sps
+
+# This will be modified by the Github Action Workflow and is required
+# to ensure the correct branch is being used.
+ARG SHAIRPORT_SYNC_BRANCH
+RUN test -n "$SHAIRPORT_SYNC_BRANCH"
+
+COPY --from=builder-alac /usr/local/lib/libalac.* /usr/local/lib/
+COPY --from=builder-alac /usr/local/lib/pkgconfig/alac.pc /usr/local/lib/pkgconfig/alac.pc
+COPY --from=builder-alac /usr/local/include /usr/local/include
+
+WORKDIR shairport-sync
+COPY . .
+RUN git checkout "$SHAIRPORT_SYNC_BRANCH"
+RUN autoreconf -fi
+RUN ./configure \
+        --with-alsa \
+        --with-dummy \
+        --with-pipe \
+        --with-stdout \
+        --with-avahi \
+        --with-ssl=mbedtls \
+        --with-soxr \
+        --sysconfdir=/etc \
+        --with-dbus-interface \
+        --with-mpris-interface \
+        --with-mqtt-client \
+        --with-apple-alac \
+        --with-convolution
+RUN make -j $(nproc)
+RUN make install
+
+# Shairport Sync Runtime System:
+FROM alpine:3.12
+
+RUN apk -U add \
+        alsa-lib \
+        dbus \
+        popt \
+        glib \
+        mbedtls \
+        soxr \
+        avahi \
+        libconfig \
+        libsndfile \
+        mosquitto-libs \
+        su-exec \
+        libgcc \
+        libgc++
+
+RUN rm -rf  /lib/apk/db/*
+
+COPY --from=builder-alac /usr/local/lib/libalac.* /usr/local/lib/
+COPY --from=builder-sps /etc/shairport-sync* /etc/
+COPY --from=builder-sps /etc/dbus-1/system.d/shairport-sync-dbus.conf /etc/dbus-1/system.d/
+COPY --from=builder-sps /etc/dbus-1/system.d/shairport-sync-mpris.conf /etc/dbus-1/system.d/
+COPY --from=builder-sps /usr/local/bin/shairport-sync /usr/local/bin/shairport-sync
+
+# Create non-root user for running the container -- running as the user 'shairport-sync' also allows
+# Shairport Sync to provide the D-Bus and MPRIS interfaces within the container
+
+RUN addgroup shairport-sync 
+RUN adduser -D shairport-sync -G shairport-sync
+
+# Add the shairport-sync user to the pre-existing audio group, which has ID 29, for access to the ALSA stuff
+RUN addgroup -g 29 docker_audio && addgroup shairport-sync docker_audio
+
+COPY ./docker/airplay1/start.sh /
+RUN chmod +x /start.sh
+
+ENTRYPOINT [ "/start.sh" ]

--- a/docker/airplay1/README.md
+++ b/docker/airplay1/README.md
@@ -1,0 +1,22 @@
+# Original AirPlay 1 Only Docker Image
+
+## Basic Usage
+
+```
+$ docker run -d --restart unless-stopped --net host --device /dev/snd \
+    mikebrady/shairport-sync
+```
+The above command will run Shairport Sync as a daemon in a Docker container, accessing the computer's ALSA audio infrastructure. It will send audio to the default output device and make no use of any hardware mixers the default device might have. The AirPlay service name will be the host's `hostname` with the first letter capitalised, e.g. `Ubuntu`.
+
+## Options
+
+Any options you add to the command above will be passed to Shairport Sync. Here is an example:
+```
+$ docker run -d --restart unless-stopped --net host --device /dev/snd \
+    mikebrady/shairport-sync -a DenSystem -- -d hw:0 -c PCM
+```
+This will sent audio to alsa hardware device `hw:0` and make use of the that device's mixer control called `PCM`. The service will be visible as `DenSystem` on the network.
+
+## Configuration File
+
+Edit the configuration file `/etc/shairport-sync.conf` in the container (or use the `-v` option to mirror an external copy of `shairport-sync.conf` in to `/etc/shairport-sync.conf`) to get access to the full range of configuration options.

--- a/docker/airplay1/start.sh
+++ b/docker/airplay1/start.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+rm -rf /var/run/dbus.pid
+#mkdir -p /var/run/dbus
+
+dbus-uuidgen --ensure
+dbus-daemon --system
+
+avahi-daemon --daemonize --no-chroot
+
+su-exec shairport-sync shairport-sync "$@"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,15 @@
+# Example docker compose config.
+
+services:
+  shairport-sync:
+    image: mikebrady/shairport-sync
+    network_mode: host
+    restart: unless-stopped
+    devices:
+      - "/dev/snd"
+    # volumes:
+    #   - ./volumes/shairport-sync/shairport-sync.conf:/etc/shairport-sync.conf # Customised Shairport Sync configuration file.
+    logging:
+      options:
+        max-size: "200k"
+        max-file: "10"


### PR DESCRIPTION
Automatically builds a docker image based on master (AP1 only) on push to branch or on git tag.

`unstable-master` is created on a commit to the branch.
`latest` and `[TAG]` are created on tag to main branch.

Means `shairport-sync-docker` repo can be depreciated.