### PR TITLE
Update BUILDFORAP2.md

### DIFF
--- a/BUILDFORAP2.md
+++ b/BUILDFORAP2.md
@@ -116,7 +116,7 @@ general =
 alsa =
 {
   output_device = "hw:Headphones";
-  mixer_control_name = "Headphone";
+  mixer_control_name = "PCM";
 };
 
 ```


### PR DESCRIPTION
I followed the instruction but no audio came through, I went back to my original file and noticed 

alsa =
{
  output_device = "hw:Headphones";
  mixer_control_name = "Headphone";
};

ONCE I changed it to what I was using I now have the audio and I can see it as an Airplay 2 device.

alsa =
{
  output_device = "hw:Headphones";
  mixer_control_name = "PCM";
};