### PR TITLE
Makefile.am: allow building and installing from a separate build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ gitversion.h
 
 # separate build directory
 build
+
+# vscode
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ shairport-sync.xcodeproj
 # version string generation
 gitversion.h
 
+# separate build directory
+build

--- a/Makefile.am
+++ b/Makefile.am
@@ -161,7 +161,7 @@ noinst_HEADERS += $(BUILT_SOURCES)
 CLEANFILES += $(BUILT_SOURCES)
 
 dbus-interface.c:  org.gnome.ShairportSync.xml
-	gdbus-codegen --interface-prefix org.gnome --generate-c-code dbus-interface org.gnome.ShairportSync.xml
+	gdbus-codegen --interface-prefix org.gnome --generate-c-code dbus-interface $<
 dbus-interface.h: dbus-interface.c
 	touch dbus-interface.h
 endif
@@ -178,7 +178,7 @@ noinst_HEADERS += $(BUILT_SOURCES)
 CLEANFILES += $(BUILT_SOURCES)
 
 mpris-interface.c:  org.mpris.MediaPlayer2.xml
-	gdbus-codegen --interface-prefix org.mpris --generate-c-code mpris-interface org.mpris.MediaPlayer2.xml
+	gdbus-codegen --interface-prefix org.mpris --generate-c-code mpris-interface $<
 mpris-interface.h: mpris-interface.c
 	touch mpris-interface.h
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -199,59 +199,98 @@ shairport_sync_mpris_test_client_SOURCES = shairport-sync-mpris-test-client.c
 shairport_sync_mpris_test_client_LDADD = lib_mpris_interface.a
 endif
 
-install-exec-hook:
-if BUILD_FOR_LINUX
-DBUS_POLICY_DIR=$(DESTDIR)/etc/dbus-1/system.d
-else
-DBUS_POLICY_DIR=$(DESTDIR)$(sysconfdir)/dbus-1/system.d
-endif
 if INSTALL_CONFIG_FILES
-	[ -e $(DESTDIR)$(sysconfdir) ] || mkdir $(DESTDIR)$(sysconfdir)
-	cp scripts/shairport-sync.conf $(DESTDIR)$(sysconfdir)/shairport-sync.conf.sample
-	[ -f $(DESTDIR)$(sysconfdir)/shairport-sync.conf ] || cp scripts/shairport-sync.conf $(DESTDIR)$(sysconfdir)/shairport-sync.conf
+
+configdir = $(sysconfdir)
+config_DATA = scripts/shairport-sync.conf
+
+if BUILD_FOR_LINUX
+dbusdir = /etc/dbus-1/system.d
+else
+dbusdir = $(sysconfdir)/dbus-1/system.d
+endif
+
 if USE_DBUS
-	[ -e $(DBUS_POLICY_DIR) ] || mkdir -p $(DBUS_POLICY_DIR)
+
 if INSTALL_CYGWIN_SERVICE
-	cp scripts/shairport-sync-dbus-policy-cygwin.conf $(DBUS_POLICY_DIR)/shairport-sync-dbus.conf
+dbus_DATA = scripts/shairport-sync-dbus-policy-cygwin.conf
 else
-	cp scripts/shairport-sync-dbus-policy.conf $(DBUS_POLICY_DIR)/shairport-sync-dbus.conf
-endif
-endif
+dbus_DATA = scripts/shairport-sync-dbus-policy.conf
+endif # INSTALL_CYGWIN_SERVIC
+
+endif # USE_DBUS
+
 if USE_MPRIS
-	[ -e $(DBUS_POLICY_DIR) ] || mkdir -p $(DBUS_POLICY_DIR)
+
+mprisdir = $(dbusdir)
+
 if INSTALL_CYGWIN_SERVICE
-	cp scripts/shairport-sync-mpris-policy-cygwin.conf $(DBUS_POLICY_DIR)/shairport-sync-mpris.conf
+mpris_DATA = scripts/shairport-sync-mpris-policy-cygwin.conf
 else
-	cp scripts/shairport-sync-mpris-policy.conf $(DBUS_POLICY_DIR)/shairport-sync-mpris.conf
-endif
-endif
-endif
+mpris_DATA = scripts/shairport-sync-mpris-policy.conf
+endif # INSTALL_CYGWIN_SERVICE
+
+endif # USE_MPRIS
+
+endif # INSTALL_CONFIG_FILES
+
+INSTALL_GROUP_TARGET = install-group-local
+
+$(INSTALL_GROUP_TARGET):
+	getent group shairport-sync &>/dev/null || groupadd -r shairport-sync >/dev/null
+
+INSTALL_USER_TARGET = install-user-local
+
+$(INSTALL_USER_TARGET): $(INSTALL_GROUP_TARGET)
+	getent passwd shairport-sync &> /dev/null || useradd -r -M -g shairport-sync -s /usr/sbin/nologin -G audio shairport-sync >/dev/null
+
 if INSTALL_SYSTEMV
-	getent group shairport-sync &>/dev/null || groupadd -r shairport-sync >/dev/null
-	getent passwd shairport-sync &> /dev/null || useradd -r -M -g shairport-sync -s /usr/sbin/nologin -G audio shairport-sync >/dev/null
-	[ -e $(DESTDIR)$(sysconfdir)/init.d ] || mkdir -p $(DESTDIR)$(sysconfdir)/init.d
-	[ -e $(DESTDIR)$(sysconfdir)/init.d/shairport-sync ] || cp scripts/shairport-sync $(DESTDIR)$(sysconfdir)/init.d/
-endif
+
+INSTALL_SYSTEMV_TARGET = install-systemv-local
+
+$(INSTALL_SYSTEMV_TARGET): scripts/shairport-sync $(INSTALL_USER_TARGET)
+	install -d $(DESTDIR)$(sysconfdir)/init.d
+	install -m 0644 $< $(DESTDIR)$(sysconfdir)/init.d
+
+endif # INSTALL_SYSTEMV
+
 if INSTALL_SYSTEMD
-	getent group shairport-sync &>/dev/null || groupadd -r shairport-sync >/dev/null
-	getent passwd shairport-sync &> /dev/null || useradd -r -M -g shairport-sync -s /usr/sbin/nologin -G audio shairport-sync >/dev/null
-	[ -e $(DESTDIR)$(systemdsystemunitdir) ] || mkdir -p $(DESTDIR)$(systemdsystemunitdir)
+
 if USE_AVAHI
-	[ -e $(DESTDIR)$(systemdsystemunitdir)/shairport-sync.service ] || cp scripts/shairport-sync.service-avahi $(DESTDIR)$(systemdsystemunitdir)/shairport-sync.service
+SYSTEMD_SERVICE = shairport-sync.service-avahi
 else
-	[ -e $(DESTDIR)$(systemdsystemunitdir)/shairport-sync.service ] || cp scripts/shairport-sync.service $(DESTDIR)$(systemdsystemunitdir)
-endif
-endif
+SYSTEMD_SERVICE = shairport-sync.service
+endif # USE_AVAHI
+
+INSTALL_SYSTEMD_TARGET = install-systemd-local
+
+$(INSTALL_SYSTEMD_TARGET): scripts/$(SYSTEMD_SERVICE) $(INSTALL_USER_TARGET)
+	install -d $(DESTDIR)$(systemdsystemunitdir)
+	install -m 0644 $< $(DESTDIR)$(systemdsystemunitdir)/shairport-sync.service
+
+endif # INSTALL_SYSTEMD
+
 if INSTALL_FREEBSD_SERVICE
-  # Choose a uid and gid of 801 completely arbitrarity, except that it should be below 1000. FreeBSD doesn't seem to allow you to say "an ID in the range of..."
+
+# Choose a uid and gid of 801 completely arbitrarity, except that it should be below 1000. FreeBSD doesn't seem to allow you to say "an ID in the range of..."
+install-freebsd-user-local:
 	pw showgroup shairport-sync > /dev/null 2>&1 || pw addgroup -n shairport-sync -g 801 > /dev/null 2>&1
 	pw showuser shairport-sync > /dev/null 2>&1 || pw adduser -c "shairport-sync unprivileged user" -n shairport-sync -u 801 -s /usr/sbin/nologin -d /nonexistent > /dev/null 2>&1
-	[ -e /var/run/shairport-sync ] || mkdir -p /var/run/shairport-sync
-	chown shairport-sync:shairport-sync /var/run/shairport-sync
-  # Always update the startup script -- this is different to the Linux systemd situation, where the startup script is untouched if it exists.
-	cp scripts/shairport-sync.freebsd /usr/local/etc/rc.d/shairport_sync
-	chmod 555 /usr/local/etc/rc.d/shairport_sync
-endif
+
+INSTALL_FREEBSD_TARGET = install-freebsd-local
+
+$(INSTALL_FREEBSD_TARGET): scripts/shairport-sync.freebsd install-freebsd-user-local
+	install -d -o shairport-sync -g shairport-sync $(DESTDIR)/var/run/shairport-sync
+	install -d $(DESTDIR)/usr/local/etc/rc.d/
+	install -m 0555 $< $(DESTDIR)/usr/local/etc/rc.d/shairport_sync
+
+endif # INSTALL_FREEBSD_SERVICE
+
 if INSTALL_CYGWIN_SERVICE
-	[ -e /usr/local/bin/shairport-sync-config ] || cp scripts/shairport-sync-config /usr/local/bin
-endif
+cygwindir = /usr/local/bin
+cygwin_DATA = scripts/shairport-sync-config
+endif # INSTALL_CYGWIN_SERVICE
+
+install-exec-hook: $(INSTALL_SYSTEMV_TARGET) \
+                   $(INSTALL_SYSTEMD_TARGET) \
+                   $(INSTALL_FREEBSD_TARGET)


### PR DESCRIPTION
This allow building in a separate build directory (rather than in the source directory)

```
mkdir -p build && cd build
autoreconf -ivf ..
../configure --with-avahi --with-pw --without-pa --with-ssl=openssl --with-mpris-interface --with-dbus-interface --with-systemd --prefix=/usr
make $(nproc)
DESTDIR=install make install
```

I've also changed from `cp` to using `install` this is used anyways by autotools. Hopefully there is no change in behaviour.

without the build fix
```
$ make 
gdbus-codegen --interface-prefix org.gnome --generate-c-code dbus-interface org.gnome.ShairportSync.xml
Traceback (most recent call last):
  File "/usr/bin/gdbus-codegen", line 55, in <module>
    sys.exit(codegen_main.codegen_main())
  File "/usr/share/glib-2.0/codegen/codegen_main.py", line 412, in codegen_main
    with open(fname, "rb") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'org.gnome.ShairportSync.xml'
make: *** [Makefile:1623: dbus-interface.c] Error 1
```

without the install fix
```
$ DESTDIR=install make install
<snip>
make[4]: Entering directory '/home/lukas/Documents/git/shairport-sync/build'
[ -e install/etc ] || mkdir install/etc
cp scripts/shairport-sync.conf install/etc/shairport-sync.conf.sample
cp: cannot stat 'scripts/shairport-sync.conf': No such file or directory
```

with the fixes
```
$ DESTDIR=install make install
make  install-recursive
make[1]: Entering directory '/home/lukas/Documents/git/shairport-sync/build'
Making install in man
make[2]: Entering directory '/home/lukas/Documents/git/shairport-sync/build/man'
make[3]: Entering directory '/home/lukas/Documents/git/shairport-sync/build/man'
make[3]: Nothing to be done for 'install-exec-am'.
 /usr/bin/mkdir -p 'install/usr/share/man/man7'
 /usr/bin/install -c -m 644 ../../man/shairport-sync.7 'install/usr/share/man/man7'
make[3]: Leaving directory '/home/lukas/Documents/git/shairport-sync/build/man'
make[2]: Leaving directory '/home/lukas/Documents/git/shairport-sync/build/man'
make[2]: Entering directory '/home/lukas/Documents/git/shairport-sync/build'
make[3]: Entering directory '/home/lukas/Documents/git/shairport-sync/build'
 /usr/bin/mkdir -p 'install/usr/bin'
  /usr/bin/install -c shairport-sync 'install/usr/bin'
make  install-exec-hook
make[4]: Entering directory '/home/lukas/Documents/git/shairport-sync/build'
getent group shairport-sync &>/dev/null || groupadd -r shairport-sync >/dev/null
getent passwd shairport-sync &> /dev/null || useradd -r -M -g shairport-sync -s /usr/sbin/nologin -G audio shairport-sync >/dev/null
install -d install/usr/lib/systemd/system
install -m 0644 scripts/shairport-sync.service-avahi install/usr/lib/systemd/system/shairport-sync.service
make[4]: Leaving directory '/home/lukas/Documents/git/shairport-sync/build'
 /usr/bin/mkdir -p 'install/etc'
 /usr/bin/install -c -m 644 ../scripts/shairport-sync.conf 'install/etc'
 /usr/bin/mkdir -p 'install/etc/dbus-1/system.d'
 /usr/bin/install -c -m 644 ../scripts/shairport-sync-dbus-policy.conf 'install/etc/dbus-1/system.d'
 /usr/bin/mkdir -p 'install/etc/dbus-1/system.d'
 /usr/bin/install -c -m 644 ../scripts/shairport-sync-mpris-policy.conf 'install/etc/dbus-1/system.d'
make[3]: Leaving directory '/home/lukas/Documents/git/shairport-sync/build'
make[2]: Leaving directory '/home/lukas/Documents/git/shairport-sync/build'
make[1]: Leaving directory '/home/lukas/Documents/git/shairport-sync/build'
```

installation
```
$ tree install
install
├── etc
│   ├── dbus-1
│   │   └── system.d
│   │       ├── shairport-sync-dbus-policy.conf
│   │       └── shairport-sync-mpris-policy.conf
│   └── shairport-sync.conf
└── usr
    ├── bin
    │   └── shairport-sync
    └── lib
        └── systemd
            └── system
                └── shairport-sync.service

```