### PR TITLE
Don't drop old packets

### DIFF
--- a/common.h
+++ b/common.h
@@ -160,7 +160,7 @@ typedef struct {
   int mqtt_enable_remote;
   char *mqtt_empty_payload_substitute;
 #endif
-  uint8_t ap1_prefix[6]; 
+  uint8_t ap1_prefix[6];
   uint8_t hw_addr[8]; // only needs 6 but 8 is handy when converting this to a number
   int port;
   int udp_port_base;
@@ -186,6 +186,7 @@ typedef struct {
   uint32_t userSuppliedLatency; // overrides all other latencies -- use with caution
   uint32_t fixedLatencyOffset;  // add this to all automatic latencies supplied to get the actual
                                 // total latency
+  int keep_old_packets;    // set to 1 if you want to keep old packets (default is 0: drop)
 // the total latency will be limited to the min and max-latency values, if supplied
 #ifdef CONFIG_LIBDAEMON
   int daemonise;

--- a/player.c
+++ b/player.c
@@ -946,13 +946,13 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
 
                 // clang-format off
                 // Now we have to work out if the flush frame is in the buffer.
-                
+
                 // If it is later than the end of the buffer, flush everything and keep the
                 // request active.
-                
+
                 // If it is in the buffer, we need to flush part of the buffer.
                 // (Actually we flush the entire buffer and drop the request.)
-                
+
                 // If it is before the buffer, no flush is needed. Drop the request.
                 // clang-format on
 
@@ -1087,7 +1087,7 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
           local_time_to_frame(time_to_aim_for, &should_be_frame, conn);
           // debug(1,"should_be frame is %u.",should_be_frame);
           int32_t frame_difference = thePacket->given_timestamp - should_be_frame;
-          if (frame_difference < 0) {
+          if (config.keep_old_packets == 0 && frame_difference < 0) {
             debug(2, "Dropping out of date packet %u with timestamp %u. Lead time is %f seconds.",
                   conn->ab_read, thePacket->given_timestamp,
                   frame_difference * 1.0 / 44100.0 + desired_lead_time * 0.000000001);

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -20,7 +20,7 @@ general =
 //	mdns_backend = "avahi"; // Run "shairport-sync -h" to get a list of all mdns_backends. The default is the first one.
 //	interface = "name"; // Use this advanced setting to specify the interface on which Shairport Sync should provide its service. Leave it commented out to get the default, which is to select the interface(s) automatically.
 //	port = <number>; // Listen for service requests on this port. 5000 for AirPlay 1, 7000 for AirPlay 2
-//	udp_port_base = 6001; // (AirPlay 1 only) start allocating UDP ports from this port number when needed 
+//	udp_port_base = 6001; // (AirPlay 1 only) start allocating UDP ports from this port number when needed
 //	udp_port_range = 10; // (AirPlay 1 only) look for free ports in this number of places, starting at the UDP port base. Allow at least 10, though only three are needed in a steady state.
 //	airplay_device_id_offset = 0; // (AirPlay 2 only) add this to the default airplay_device_id calculated from one of the device's MAC address
 //	airplay_device_id = 0x<six-digit_hexadecimal_number>L; // (AirPlay 2 only) use this as the airplay_device_id e.g. 0xDCA632D4E8F3L -- remember the "L" at the end as it's a 64-bit quantity!
@@ -114,6 +114,7 @@ alsa =
 //	maximum_stall_time = 0.200; // Use this optional advanced setting to control how long to wait for data to be consumed by the output device before considering it an error. It should never approach 200 ms.
 //	use_precision_timing = "auto"; // Use this optional advanced setting to control how Shairport Sync gathers timing information. When set to "auto", if the output device is a real hardware device, precision timing will be used. Choose "no" for more compatible standard timing, choose "yes" to force the use of precision timing, which may cause problems.
 
+//  keep_old_packets = "no"; // Use this optional advanced setting to keep old packets. Choose "yes" to keep.
 //	disable_standby_mode = "never"; // This setting prevents the DAC from entering the standby mode. Some DACs make small "popping" noises when they go in and out of standby mode. Settings can be: "always", "auto" or "never". Default is "never", but only for backwards compatibility. The "auto" setting prevents entry to standby mode while Shairport Sync is in the "active" mode. You can use "yes" instead of "always" and "no" instead of "never".
 //	disable_standby_mode_silence_threshold = 0.040; // Use this optional advanced setting to control how little audio should remain in the output buffer before the disable_standby code should start sending silence to the output device.
 //	disable_standby_mode_silence_scan_interval = 0.004; // Use this optional advanced setting to control how often the amount of audio remaining in the output buffer should be checked.

--- a/shairport.c
+++ b/shairport.c
@@ -969,6 +969,17 @@ int parse_options(int argc, char **argv) {
                dvalue, config.missing_port_dacp_scan_interval_seconds);
       }
 
+      if (config_lookup_string(config.cfg, "general.keep_old_packets", &str)) {
+        if (strcasecmp(str, "no") == 0)
+          config.keep_old_packets = 0;
+        else if (strcasecmp(str, "yes") == 0)
+          config.keep_old_packets = 1;
+        else
+          die("Invalid general keep_old_packets option choice \"%s\". It should be \"yes\" or "
+              "\"no\"",
+              str);
+      }
+
       /* Get the default latency. Deprecated! */
       if (config_lookup_int(config.cfg, "latencies.default", &value))
         config.userSuppliedLatency = value;


### PR DESCRIPTION
Hello!

My audio playback was very choppy and it turns out it was due to packets being dropped, like this:

    Dec 19 11:40:53 box shairport-sync[85840]:          0.000002661 "player.c:1091" Dropping out of date packet 45054 with timestamp 1010961918. Lead time is 0.118594 seconds.

So I patched the code not to drop these packets, and now my audio is good.

So I reworked it into a configuration knob.

Attached is a PR to add the `general.keep_old_packets` configuration setting which defaults to `no` which is the current old behavior.

If the config is edited to  `general.keep_old_packets = "yes"`, then shairport-sync will no longer drop old packets.



### With this patch

playback sounds correctly as far as I can tell.

```
Dec 19 13:04:55 box shairport-sync[27404]:          0.023976265 "player.c:1114" Check packet from buffer 48545, timestamp 1457743140, 0.182129 seconds ahead.
Dec 19 13:04:55 box shairport-sync[27404]:          0.000109540 "player.c:1114" Check packet from buffer 48546, timestamp 1457743492, 0.189999 seconds ahead.
Dec 19 13:04:55 box shairport-sync[27404]:          0.000302211 "player.c:1114" Check packet from buffer 48547, timestamp 1457743844, 0.197679 seconds ahead.
Dec 19 13:04:55 box shairport-sync[27404]:          0.000072207 "player.c:1114" Check packet from buffer 48548, timestamp 1457744196, 0.205588 seconds ahead.
Dec 19 13:04:55 box shairport-sync[27404]:          0.032194187 "player.c:1114" Check packet from buffer 48548, timestamp 1457744196, 0.173396 seconds ahead.
Dec 19 13:04:55 box shairport-sync[27404]:          0.000108235 "player.c:1114" Check packet from buffer 48549, timestamp 1457744548, 0.181267 seconds ahead.
Dec 19 13:04:55 box shairport-sync[27404]:          0.000063037 "player.c:1114" Check packet from buffer 48550, timestamp 1457744900, 0.189186 seconds ahead.
Dec 19 13:04:55 box shairport-sync[27404]:          0.000056908 "player.c:1114" Check packet from buffer 48551, timestamp 1457745252, 0.197111 seconds ahead.
```



### Without this patch

packets get dropped and the audio played is very choppy and corrupted:

```
Dec 19 11:40:53 box shairport-sync[85840]:          0.000002661 "player.c:1091" Dropping out of date packet 45054 with timestamp 1010961918. Lead time is 0.118594 seconds.
Dec 19 11:40:53 box shairport-sync[85840]:          0.000001704 "player.c:1114" Check packet from buffer 45055, timestamp 1010962270, 0.006574 seconds ahead.
Dec 19 11:40:53 box shairport-sync[85840]:          0.000002020 "player.c:2426" Player: packets out of sequence: expected: 45054, got: 45055, with ab_read: 45056 and ab_write: 45318.
Dec 19 11:40:53 box shairport-sync[85840]:          0.000002796 "audio_pw.c:491" pw: bytes_to_copy: 1408
Dec 19 11:40:53 box shairport-sync[85840]:          0.000000960 "audio_pw.c:496" pw: spa_data->maxsize: 125744
Dec 19 11:40:53 box shairport-sync[85840]:          0.000001185 "player.c:1114" Check packet from buffer 45056, timestamp 1010962622, 0.014547 seconds ahead.
Dec 19 11:40:53 box shairport-sync[85840]:          0.021249110 "audio_pw.c:491" pw: bytes_to_copy: 1408
Dec 19 11:40:53 box shairport-sync[85840]:          0.000007196 "audio_pw.c:496" pw: spa_data->maxsize: 125744
Dec 19 11:40:53 box shairport-sync[85840]:          0.000002781 "player.c:1114" Check packet from buffer 45057, timestamp 1010962974, 0.001270 seconds ahead.
Dec 19 11:40:53 box shairport-sync[85840]:          0.010704286 "audio_pw.c:491" pw: bytes_to_copy: 1408
Dec 19 11:40:53 box shairport-sync[85840]:          0.000007063 "audio_pw.c:496" pw: spa_data->maxsize: 125744
Dec 19 11:40:53 box shairport-sync[85840]:          0.000002647 "player.c:1091" Dropping out of date packet 45058 with timestamp 1010963326. Lead time is 0.118549 seconds.
Dec 19 11:40:53 box shairport-sync[85840]:          0.000001971 "player.c:1114" Check packet from buffer 45059, timestamp 1010963678, 0.006519 seconds ahead.
Dec 19 11:40:53 box shairport-sync[85840]:          0.000001824 "player.c:2426" Player: packets out of sequence: expected: 45058, got: 45059, with ab_read: 45060 and ab_write: 45330.
Dec 19 11:40:53 box shairport-sync[85840]:          0.010668146 "audio_pw.c:491" pw: bytes_to_copy: 1408
Dec 19 11:40:53 box shairport-sync[85840]:          0.000007114 "audio_pw.c:496" pw: spa_data->maxsize: 125744
Dec 19 11:40:53 box shairport-sync[85840]:          0.000002668 "player.c:1114" Check packet from buffer 45060, timestamp 1010964030, 0.003820 seconds ahead.
Dec 19 11:40:53 box shairport-sync[85840]:          0.000003674 "audio_pw.c:491" pw: bytes_to_copy: 1408
Dec 19 11:40:53 box shairport-sync[85840]:          0.000001190 "audio_pw.c:496" pw: spa_data->maxsize: 125744
Dec 19 11:40:53 box shairport-sync[85840]:          0.000001196 "player.c:1114" Check packet from buffer 45061, timestamp 1010964382, 0.011795 seconds ahead.
Dec 19 11:40:53 box shairport-sync[85840]:          0.021257521 "audio_pw.c:491" pw: bytes_to_copy: 1408
Dec 19 11:40:53 box shairport-sync[85840]:          0.000007141 "audio_pw.c:496" pw: spa_data->maxsize: 125744
Dec 19 11:40:53 box shairport-sync[85840]:          0.000002601 "player.c:1091" Dropping out of date packet 45062 with timestamp 1010964734. Lead time is 0.118526 seconds.
Dec 19 11:40:53 box shairport-sync[85840]:          0.000001867 "player.c:1114" Check packet from buffer 45063, timestamp 1010965086, 0.006492 seconds ahead.
Dec 19 11:40:53 box shairport-sync[85840]:          0.000001889 "player.c:2426" Player: packets out of sequence: expected: 45062, got: 45063, with ab_read: 45064 and ab_write: 45330.
Dec 19 11:40:53 box shairport-sync[85840]:          0.010708282 "audio_pw.c:491" pw: bytes_to_copy: 1408
Dec 19 11:40:53 box shairport-sync[85840]:          0.000007172 "audio_pw.c:496" pw: spa_data->maxsize: 125744
Dec 19 11:40:53 box shairport-sync[85840]:          0.000002618 "player.c:1114" Check packet from buffer 45064, timestamp 1010965438, 0.003752 seconds ahead.
Dec 19 11:40:53 box shairport-sync[85840]:          0.010590029 "audio_pw.c:491" pw: bytes_to_copy: 1408
Dec 19 11:40:53 box shairport-sync[85840]:          0.000007015 "audio_pw.c:496" pw: spa_data->maxsize: 125744
Dec 19 11:40:53 box shairport-sync[85840]:          0.000002756 "player.c:1114" Check packet from buffer 45065, timestamp 1010965790, 0.001134 seconds ahead.
Dec 19 11:40:53 box shairport-sync[85840]:          0.000003778 "audio_pw.c:491" pw: bytes_to_copy: 1408
Dec 19 11:40:53 box shairport-sync[85840]:          0.000001010 "audio_pw.c:496" pw: spa_data->maxsize: 125744
Dec 19 11:40:53 box shairport-sync[85840]:          0.000001271 "player.c:1114" Check packet from buffer 45066, timestamp 1010966142, 0.009109 seconds ahead.
Dec 19 11:40:53 box shairport-sync[85840]:          0.021399310 "audio_pw.c:491" pw: bytes_to_copy: 1408
Dec 19 11:40:53 box shairport-sync[85840]:          0.000007237 "audio_pw.c:496" pw: spa_data->maxsize: 125744
Dec 19 11:40:53 box shairport-sync[85840]:          0.000002746 "player.c:1091" Dropping out of date packet 45067 with timestamp 1010966494. Lead time is 0.115692 seconds.
Dec 19 11:40:53 box shairport-sync[85840]:          0.000001677 "player.c:1114" Check packet from buffer 45068, timestamp 1010966846, 0.003664 seconds ahead.
Dec 19 11:40:53 box shairport-sync[85840]:          0.000001680 "player.c:2426" Player: packets out of sequence: expected: 45067, got: 45068, with ab_read: 45069 and ab_write: 45330.
Dec 19 11:40:53 box shairport-sync[85840]:          0.010566446 "audio_pw.c:491" pw: bytes_to_copy: 1408
Dec 19 11:40:53 box shairport-sync[85840]:          0.000007140 "audio_pw.c:496" pw: spa_data->maxsize: 125744
Dec 19 11:40:53 box shairport-sync[85840]:          0.000002739 "player.c:1114" Check packet from buffer 45069, timestamp 1010967198, 0.001066 seconds ahead.
```

