### PR TITLE
Migrate to new HA mqtt configuration

### DIFF
--- a/MQTT.md
+++ b/MQTT.md
@@ -171,54 +171,47 @@ Examples of consuming "parsed" MQTT data in [Home Assistant](https://www.home-as
 The `active_start` and `active_end` have good potential use as triggers to turn on and off various connect receivers/zones.  The messages published are empty and therefor no "payload_on" is set, "payload_off" however is set to prevent accidental triggering.
 
 ```yml
-binary_sensor:
+mqtt:
+  binary_sensor:
+    - name: "shairport active start"
+      state_topic: "shairport/active_start"
+      payload_on: ""
+      payload_off: "OFF"
+      off_delay: 300
 
-  - platform: mqtt
-    name: "shairport active start"
-    state_topic: "shairport/active_start"
-    payload_on: ""
-    payload_off: "OFF"
-    off_delay: 300
-
-  - platform: mqtt
-    name: "shairport active end"
-    state_topic: "shairport/active_end"
-    payload_on: ""
-    payload_off: "OFF"
-    off_delay: 300
+    - name: "shairport active end"
+      state_topic: "shairport/active_end"
+      payload_on: ""
+      payload_off: "OFF"
+      off_delay: 300
 ```
 
 Below parsed data is saved into the Home Assistant database as sensor data.  Please note the conversion of the volume from dB to percentage.
 
 ```yml
-sensor:
-  - platform: mqtt
-    name: "shairport album"
-    state_topic: "shairport/album"
-    expire_after: 600
-  
-  - platform: mqtt
-    name: "shairport artist"
-    state_topic: "shairport/artist"
-    expire_after: 600
-    
-  - platform: mqtt
-    name: "shairport title"
-    state_topic: "shairport/title"
-    expire_after: 600
-    
-  - platform: mqtt
-    name: "shairport genre"
-    state_topic: "shairport/genre" 
-    expire_after: 600
-    
-  - platform: mqtt
-    name: "shairport volume (dB)"
-    state_topic: "shairport/volume"
-    
-  - platform: mqtt
-    name: "shairport volume (PCT)"
-    state_topic: "shairport/volume"
-    value_template: "{{ value |  regex_findall_index(find='^(.+?),', index=0, ignorecase=False) | float / 30 + 1  }}"
-    unit_of_measurement: 'percent'
+mqtt:
+  sensor:
+    - name: "shairport album"
+      state_topic: "shairport/album"
+      expire_after: 600
+
+    - name: "shairport artist"
+      state_topic: "shairport/artist"
+      expire_after: 600
+
+    - name: "shairport title"
+      state_topic: "shairport/title"
+      expire_after: 600
+
+    - name: "shairport genre"
+      state_topic: "shairport/genre"
+      expire_after: 600
+
+    - name: "shairport volume (dB)"
+      state_topic: "shairport/volume"
+
+    - name: "shairport volume (PCT)"
+      state_topic: "shairport/volume"
+      value_template: "{{ value |  regex_findall_index(find='^(.+?),', index=0, ignorecase=False) | float / 30 + 1  }}"
+      unit_of_measurement: 'percent'
 ```


### PR DESCRIPTION
The old way of configuring mqtt entities is not supported anymore since `v2022.12`