### PR TITLE
Fix s6-timeout issues on slower devices

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,6 +68,9 @@ WORKDIR /
 # Shairport Sync Runtime System
 FROM crazymax/alpine-s6:3.17-3.1.1.2
 
+ENV S6_CMD_WAIT_FOR_SERVICES=1
+ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
+
 RUN apk -U add \
         alsa-lib \
         avahi \

--- a/docker/classic/Dockerfile
+++ b/docker/classic/Dockerfile
@@ -52,6 +52,9 @@ WORKDIR /
 # Shairport Sync Runtime System
 FROM crazymax/alpine-s6:3.17-3.1.1.2
 
+ENV S6_CMD_WAIT_FOR_SERVICES=1
+ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
+
 RUN apk -U add \
         alsa-lib \
         avahi \

--- a/docker/etc/s6-overlay/s6-rc.d/04-nqptp/dependencies
+++ b/docker/etc/s6-overlay/s6-rc.d/04-nqptp/dependencies
@@ -1,1 +1,1 @@
-03-avahi
+01-startup


### PR DESCRIPTION
Fixes https://github.com/mikebrady/shairport-sync/issues/1677

On slower hardware startup (and readiness) of the `s6` services (`dbus` and `avahi`) can exceed the default `s6` timeout of 5000ms. 
Adding `S6_CMD_WAIT_FOR_SERVICES=1` and `S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0` should fix the issue. For the flags see https://github.com/just-containers/s6-overlay#customizing-s6-overlay-behaviour

Additionally, `nqptp` does not depend on `avahi` and `dbus` so it's started right away.