### PR TITLE
Fix libao matrix option by specifying channel ordering

### DIFF
--- a/audio_ao.c
+++ b/audio_ao.c
@@ -131,6 +131,7 @@ static int init(int argc, char **argv) {
     fmt.rate = 44100;
     fmt.channels = 2;
     fmt.byte_format = AO_FMT_NATIVE;
+    fmt.matrix = strdup("L,R");
   }
   return 0;
 }


### PR DESCRIPTION
The `libao` library provides the `matrix` option to allow rearranging output channel ordering, but this only works when the application specifies the input channel ordering.

Before: `shairport-sync -o ao -- -o matrix=R,L` does nothing
After: `shairport-sync -o ao -- -o matrix=R,L` swaps L and R channels

Multichannel is still an issue, e.g. `shairport-sync -o ao -- -o matrix=X,X,L,R` still does nothing, but AFAICT this is a problem with `libao` and not `shairport-sync`.
