### PR TITLE
Fix some openssl 3.0 deprecation warnings

### DIFF
--- a/metadata_hub.c
+++ b/metadata_hub.c
@@ -56,7 +56,7 @@
 #endif
 
 #ifdef CONFIG_OPENSSL
-#include <openssl/md5.h>
+#include <openssl/evp.h>
 #endif
 
 struct metadata_bundle metadata_store;
@@ -209,10 +209,14 @@ char *metadata_write_image_file(const char *buf, int len) {
     // uint8_t ap_md5[16];
 
 #ifdef CONFIG_OPENSSL
-    MD5_CTX ctx;
-    MD5_Init(&ctx);
-    MD5_Update(&ctx, buf, len);
-    MD5_Final(img_md5, &ctx);
+    EVP_MD_CTX *ctx;
+    unsigned int img_md5_len = EVP_MD_size(EVP_md5());
+    
+    ctx = EVP_MD_CTX_new();
+    EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
+    EVP_DigestUpdate(ctx, buf, len);
+    EVP_DigestFinal_ex(ctx, img_md5, &img_md5_len);
+    EVP_MD_CTX_free(ctx);
 #endif
 
 #ifdef CONFIG_MBEDTLS


### PR DESCRIPTION
When building against recent `openssl` versions (>3.0) (e.g. used by `alpine:3.17`) a lot of deprecation warnings are generated. Reason is that `openssl` removed some low-levl API functions, e.g. `MD5XXX()` or changed the function mappings, e.g. `RSAXXX()`, `AESXXX()`. For more details see [here](https://www.openssl.org/docs/man3.0/man7/migration_guide.html).

This PR fixes the `MD5XX()` related warnings. 

```
 ../rtsp.c:4889:3: warning: 'MD5_Init' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
#31 1.227  4889 |   MD5_Init(&ctx);
#31 1.227       |   ^~~~~~~~
#31 1.227 In file included from ../rtsp.c:58:
#31 1.227 /usr/include/openssl/md5.h:49:27: note: declared here
#31 1.227    49 | OSSL_DEPRECATEDIN_3_0 int MD5_Init(MD5_CTX *c);
#31 1.227       |                           ^~~~~~~~
#31 1.235 ../rtsp.c:4890:3: warning: 'MD5_Update' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
#31 1.235  4890 |   MD5_Update(&ctx, username, strlen(username));
#31 1.235       |   ^~~~~~~~~~
#31 1.235 /usr/include/openssl/md5.h:50:27: note: declared here
#31 1.235    50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
#31 1.235       |                           ^~~~~~~~~~
#31 1.238 ../rtsp.c:4891:3: warning: 'MD5_Update' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
#31 1.238  4891 |   MD5_Update(&ctx, ":", 1);
#31 1.238       |   ^~~~~~~~~~
#31 1.238 /usr/include/openssl/md5.h:50:27: note: declared here
#31 1.238    50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
#31 1.238       |                           ^~~~~~~~~~
#31 1.240 ../rtsp.c:4892:3: warning: 'MD5_Update' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
#31 1.240  4892 |   MD5_Update(&ctx, realm, strlen(realm));
#31 1.240       |   ^~~~~~~~~~
#31 1.240 /usr/include/openssl/md5.h:50:27: note: declared here
#31 1.240    50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
#31 1.240       |                           ^~~~~~~~~~
#31 1.243 ../rtsp.c:4893:3: warning: 'MD5_Update' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
#31 1.243  4893 |   MD5_Update(&ctx, ":", 1);
#31 1.243       |   ^~~~~~~~~~
#31 1.243 /usr/include/openssl/md5.h:50:27: note: declared here
#31 1.243    50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
#31 1.243       |                           ^~~~~~~~~~
#31 1.246 ../rtsp.c:4894:3: warning: 'MD5_Update' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
#31 1.246  4894 |   MD5_Update(&ctx, config.password, strlen(config.password));
#31 1.246       |   ^~~~~~~~~~
#31 1.246 /usr/include/openssl/md5.h:50:27: note: declared here
#31 1.246    50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
#31 1.246       |                           ^~~~~~~~~~
#31 1.249 ../rtsp.c:4895:3: warning: 'MD5_Final' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
#31 1.249  4895 |   MD5_Final(digest_urp, &ctx);
#31 1.249       |   ^~~~~~~~~
#31 1.249 /usr/include/openssl/md5.h:51:27: note: declared here
#31 1.249    51 | OSSL_DEPRECATEDIN_3_0 int MD5_Final(unsigned char *md, MD5_CTX *c);
```
___

`libressl` seems not to be affected.

The warnings regarding `RSAXXX()` and `AESXXX()` are not fixed due to lack of C knowledge. 
Please review carefully. 