### PR TITLE
Fix channels deprecation warning

### DIFF
--- a/rtp.c
+++ b/rtp.c
@@ -2916,14 +2916,14 @@ void *rtp_buffered_audio_processor(void *arg) {
                           else if (ret < 0) {
                             debug(1, "error %d during decoding", ret);
                           } else {
-                            av_samples_alloc(&pcm_audio, &dst_linesize, codec_context->channels,
+                            av_samples_alloc(&pcm_audio, &dst_linesize, codec_context->ch_layout.nb_channels,
                                              decoded_frame->nb_samples, av_format, 1);
                             // remember to free pcm_audio
                             ret = swr_convert(swr, &pcm_audio, decoded_frame->nb_samples,
                                               (const uint8_t **)decoded_frame->extended_data,
                                               decoded_frame->nb_samples);
                             dst_bufsize = av_samples_get_buffer_size(
-                                &dst_linesize, codec_context->channels, ret, av_format, 1);
+                                &dst_linesize, codec_context->ch_layout.nb_channels, ret, av_format, 1);
                             // debug(1,"generated %d bytes of PCM", dst_bufsize);
                             // copy the PCM audio into the PCM buffer.
                             // make sure it's big enough first


### PR DESCRIPTION
`ffmpeg` is version 5.1.3 in the Docker images and triggers `deprecation` warnings (see [this run](https://github.com/mikebrady/shairport-sync/actions/runs/5177874809/jobs/9328544535)).

```shell
#92 15.67 ../rtp.c: In function 'rtp_buffered_audio_processor':
#92 15.68 ../rtp.c:2919:29: warning: 'channels' is deprecated [-Wdeprecated-declarations]
#92 15.68  2919 |                             av_samples_alloc(&pcm_audio, &dst_linesize, codec_context->channels,
#92 15.68       |                             ^~~~~~~~~~~~~~~~
#92 15.70 In file included from ../rtp.c:49:
#92 15.70 /usr/include/libavcodec/avcodec.h:1006:9: note: declared here
#92 15.70  1006 |     int channels;
#92 15.70       |         ^~~~~~~~
#92 15.70 ../rtp.c:2926:33: warning: 'channels' is deprecated [-Wdeprecated-declarations]
#92 15.70  2926 |                                 &dst_linesize, codec_context->channels, ret, av_format, 1);
#92 15.70       |                                 ^
#92 15.70 /usr/include/libavcodec/avcodec.h:1006:9: note: declared here
#92 15.70  1006 |     int channels;
#92 15.70       |         ^~~~~~~~
```

Reason is that `channels` in `AVCodecContext` has been replaced with the more complex structure `AVChannelLayout` (see [here](https://ffmpeg.org/doxygen/5.1/structAVCodecContext.html#a167ff73c67960acf2d5ca73d93e13f64)). `AVChannelLayout` has a [data field ](https://ffmpeg.org/doxygen/5.1/structAVChannelLayout.html)`nb_channels` which can be used instead.