### PR TITLE
Add new "dasl_tapered" volume control profile

### DIFF
--- a/common.c
+++ b/common.c
@@ -1207,7 +1207,7 @@ double flat_vol2attn(double vol, long max_db, long min_db) {
   return vol_setting;
 }
 
-double logarithmic_vol2attn(double vol, long max_db, long min_db) {
+double dasl_tapered_vol2attn(double vol, long max_db, long min_db) {
   double vol_setting = min_db; // if all else fails, set this, for safety
 
   if ((vol <= 0.0) && (vol >= -30.0)) {
@@ -1226,7 +1226,7 @@ double logarithmic_vol2attn(double vol, long max_db, long min_db) {
     return vol_setting;
   } else if (vol != -144.0) {
     debug(1,
-          "Logarithmic volume request value %f is out of range: should be from 0.0 to -30.0 or -144.0.",
+          "dasl_tapered volume request value %f is out of range: should be from 0.0 to -30.0 or -144.0.",
           vol);
   }
   return vol_setting;

--- a/common.c
+++ b/common.c
@@ -1216,7 +1216,7 @@ double logarithmic_vol2attn(double vol, long max_db, long min_db) {
       return min_db;
     }
 
-    vol_setting = 1000 * log10(vol_pct) / log10(2); // This will be in the range [-inf, 0]
+    vol_setting = max_db + 1000 * log10(vol_pct) / log10(2); // This will be in the range [-inf, max_db]
     if (vol_setting < min_db) {
       return min_db;
     }

--- a/common.h
+++ b/common.h
@@ -73,7 +73,7 @@ typedef enum {
 typedef enum {
   VCP_standard = 0,
   VCP_flat,
-  VCP_logarithmic,
+  VCP_dasl_tapered,
 } volume_control_profile_type;
 
 typedef enum {
@@ -392,8 +392,11 @@ uint8_t *rsa_apply(uint8_t *input, int inlen, int *outlen, int mode);
 double flat_vol2attn(double vol, long max_db, long min_db);
 
 // given a volume (0 to -30) and high and low attenuations in dB*100 (e.g. 0 to -6000 for 0 to -60
-// dB), return an attenuation depending on a logarithmic interpolation along along the range
-double logarithmic_vol2attn(double vol, long max_db, long min_db);
+// dB), return an attenuation depending on a logarithmic interpolation along along the range.
+// The intention behind this attenuation function is that a given percentage change in volume
+// should result in the same percentage change in perceived loudness. For instance, a doubling
+// (100% increase) of volume level should result in a doubling of perceived loudness.
+double dasl_tapered_vol2attn(double vol, long max_db, long min_db);
 
 // given a volume (0 to -30) and high and low attenuations in dB*100 (e.g. 0 to -6000 for 0 to -60
 // dB), return an attenuation depending on the transfer function

--- a/common.h
+++ b/common.h
@@ -388,11 +388,11 @@ char *base64_enc(uint8_t *input, int length);
 uint8_t *rsa_apply(uint8_t *input, int inlen, int *outlen, int mode);
 
 // given a volume (0 to -30) and high and low attenuations in dB*100 (e.g. 0 to -6000 for 0 to -60
-// dB), return an attenuation depending on a linear interpolation along along the range
+// dB), return an attenuation depending on a linear interpolation along the range
 double flat_vol2attn(double vol, long max_db, long min_db);
 
 // given a volume (0 to -30) and high and low attenuations in dB*100 (e.g. 0 to -6000 for 0 to -60
-// dB), return an attenuation depending on a logarithmic interpolation along along the range.
+// dB), return an attenuation depending on a logarithmic interpolation along the range.
 // The intention behind this attenuation function is that a given percentage change in volume
 // should result in the same percentage change in perceived loudness. For instance, a doubling
 // (100% increase) of volume level should result in a doubling of perceived loudness.

--- a/common.h
+++ b/common.h
@@ -73,6 +73,7 @@ typedef enum {
 typedef enum {
   VCP_standard = 0,
   VCP_flat,
+  VCP_logarithmic,
 } volume_control_profile_type;
 
 typedef enum {
@@ -389,6 +390,10 @@ uint8_t *rsa_apply(uint8_t *input, int inlen, int *outlen, int mode);
 // given a volume (0 to -30) and high and low attenuations in dB*100 (e.g. 0 to -6000 for 0 to -60
 // dB), return an attenuation depending on a linear interpolation along along the range
 double flat_vol2attn(double vol, long max_db, long min_db);
+
+// given a volume (0 to -30) and high and low attenuations in dB*100 (e.g. 0 to -6000 for 0 to -60
+// dB), return an attenuation depending on a logarithmic interpolation along along the range
+double logarithmic_vol2attn(double vol, long max_db, long min_db);
 
 // given a volume (0 to -30) and high and low attenuations in dB*100 (e.g. 0 to -6000 for 0 to -60
 // dB), return an attenuation depending on the transfer function

--- a/dbus-service.c
+++ b/dbus-service.c
@@ -765,8 +765,8 @@ gboolean notify_volume_control_profile_callback(ShairportSync *skeleton,
     config.volume_control_profile = VCP_standard;
   else if (strcasecmp(th, "flat") == 0)
     config.volume_control_profile = VCP_flat;
-  else if (strcasecmp(th, "logarithmic") == 0)
-    config.volume_control_profile = VCP_logarithmic;
+  else if (strcasecmp(th, "dasl_tapered") == 0)
+    config.volume_control_profile = VCP_dasl_tapered;
   else {
     warn("Unrecognised Volume Control Profile: \"%s\".", th);
     switch (config.volume_control_profile) {
@@ -776,8 +776,8 @@ gboolean notify_volume_control_profile_callback(ShairportSync *skeleton,
     case VCP_flat:
       shairport_sync_set_volume_control_profile(skeleton, "flat");
       break;
-    case VCP_logarithmic:
-      shairport_sync_set_volume_control_profile(skeleton, "logarithmic");
+    case VCP_dasl_tapered:
+      shairport_sync_set_volume_control_profile(skeleton, "dasl_tapered");
       break;
     default:
       debug(1, "This should never happen!");
@@ -1070,8 +1070,8 @@ static void on_dbus_name_acquired(GDBusConnection *connection, const gchar *name
 
   if (config.volume_control_profile == VCP_standard)
     shairport_sync_set_volume_control_profile(SHAIRPORT_SYNC(shairportSyncSkeleton), "standard");
-  else if (config.volume_control_profile == VCP_logarithmic)
-    shairport_sync_set_volume_control_profile(SHAIRPORT_SYNC(shairportSyncSkeleton), "logarithmic");
+  else if (config.volume_control_profile == VCP_dasl_tapered)
+    shairport_sync_set_volume_control_profile(SHAIRPORT_SYNC(shairportSyncSkeleton), "dasl_tapered");
   else
     shairport_sync_set_volume_control_profile(SHAIRPORT_SYNC(shairportSyncSkeleton), "flat");
 

--- a/dbus-service.c
+++ b/dbus-service.c
@@ -765,6 +765,8 @@ gboolean notify_volume_control_profile_callback(ShairportSync *skeleton,
     config.volume_control_profile = VCP_standard;
   else if (strcasecmp(th, "flat") == 0)
     config.volume_control_profile = VCP_flat;
+  else if (strcasecmp(th, "logarithmic") == 0)
+    config.volume_control_profile = VCP_logarithmic;
   else {
     warn("Unrecognised Volume Control Profile: \"%s\".", th);
     switch (config.volume_control_profile) {
@@ -773,6 +775,9 @@ gboolean notify_volume_control_profile_callback(ShairportSync *skeleton,
       break;
     case VCP_flat:
       shairport_sync_set_volume_control_profile(skeleton, "flat");
+      break;
+    case VCP_logarithmic:
+      shairport_sync_set_volume_control_profile(skeleton, "logarithmic");
       break;
     default:
       debug(1, "This should never happen!");
@@ -1065,6 +1070,8 @@ static void on_dbus_name_acquired(GDBusConnection *connection, const gchar *name
 
   if (config.volume_control_profile == VCP_standard)
     shairport_sync_set_volume_control_profile(SHAIRPORT_SYNC(shairportSyncSkeleton), "standard");
+  else if (config.volume_control_profile == VCP_logarithmic)
+    shairport_sync_set_volume_control_profile(SHAIRPORT_SYNC(shairportSyncSkeleton), "logarithmic");
   else
     shairport_sync_set_volume_control_profile(SHAIRPORT_SYNC(shairportSyncSkeleton), "flat");
 

--- a/player.c
+++ b/player.c
@@ -3432,6 +3432,9 @@ void player_volume_without_notification(double airplay_volume, rtsp_conn_info *c
       else if (config.volume_control_profile == VCP_flat)
         scaled_attenuation =
             flat_vol2attn(airplay_volume, max_db, min_db); // no cancellation points
+      else if (config.volume_control_profile == VCP_logarithmic)
+        scaled_attenuation =
+            logarithmic_vol2attn(airplay_volume, max_db, min_db); // no cancellation points
       else
         debug(1, "player_volume_without_notification: unrecognised volume control profile");
     }

--- a/player.c
+++ b/player.c
@@ -3432,9 +3432,9 @@ void player_volume_without_notification(double airplay_volume, rtsp_conn_info *c
       else if (config.volume_control_profile == VCP_flat)
         scaled_attenuation =
             flat_vol2attn(airplay_volume, max_db, min_db); // no cancellation points
-      else if (config.volume_control_profile == VCP_logarithmic)
+      else if (config.volume_control_profile == VCP_dasl_tapered)
         scaled_attenuation =
-            logarithmic_vol2attn(airplay_volume, max_db, min_db); // no cancellation points
+            dasl_tapered_vol2attn(airplay_volume, max_db, min_db); // no cancellation points
       else
         debug(1, "player_volume_without_notification: unrecognised volume control profile");
     }

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -42,6 +42,7 @@ general =
 //	volume_control_profile = "standard" ; // use this advanced setting to specify how the airplay volume is transferred to the mixer volume.
 //		"standard" makes the volume change more quickly at lower volumes and slower at higher volumes.
 //		"flat" makes the volume change at the same rate at all volumes.
+//		"logarithmic" makes the volume change logarithmically.
 //	volume_control_combined_hardware_priority = "no"; // when extending the volume range by combining the built-in software attenuator with the hardware mixer attenuator, set this to "yes" to reduce volume by using the hardware mixer first, then the built-in software attenuator.
 
 //	default_airplay_volume = -24.0; // this is the suggested volume after a reset or after the high_volume_threshold has been exceed and the high_volume_idle_timeout_in_minutes has passed

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -42,7 +42,9 @@ general =
 //	volume_control_profile = "standard" ; // use this advanced setting to specify how the airplay volume is transferred to the mixer volume.
 //		"standard" makes the volume change more quickly at lower volumes and slower at higher volumes.
 //		"flat" makes the volume change at the same rate at all volumes.
-//		"logarithmic" makes the volume change logarithmically.
+//		"dasl_tapered" is similar to "standard" - it makes the volume change more quickly at lower volumes and slower at higher volumes.
+//			The intention behind dasl_tapered is that a given percentage change in volume should result in the same percentage change in
+//			perceived loudness. For instance, a doubling (100% increase) of volume level should result in a doubling of perceived loudness.
 //	volume_control_combined_hardware_priority = "no"; // when extending the volume range by combining the built-in software attenuator with the hardware mixer attenuator, set this to "yes" to reduce volume by using the hardware mixer first, then the built-in software attenuator.
 
 //	default_airplay_volume = -24.0; // this is the suggested volume after a reset or after the high_volume_threshold has been exceed and the high_volume_idle_timeout_in_minutes has passed

--- a/shairport.c
+++ b/shairport.c
@@ -905,9 +905,11 @@ int parse_options(int argc, char **argv) {
           config.volume_control_profile = VCP_standard;
         else if (strcasecmp(str, "flat") == 0)
           config.volume_control_profile = VCP_flat;
+        else if (strcasecmp(str, "logarithmic") == 0)
+          config.volume_control_profile = VCP_logarithmic;
         else
-          die("Invalid volume_control_profile choice \"%s\". It should be \"standard\" (default) "
-              "or \"flat\"",
+          die("Invalid volume_control_profile choice \"%s\". It should be \"standard\" (default), "
+              "\"logarithmic\", or \"flat\"",
               str);
       }
 

--- a/shairport.c
+++ b/shairport.c
@@ -905,11 +905,11 @@ int parse_options(int argc, char **argv) {
           config.volume_control_profile = VCP_standard;
         else if (strcasecmp(str, "flat") == 0)
           config.volume_control_profile = VCP_flat;
-        else if (strcasecmp(str, "logarithmic") == 0)
-          config.volume_control_profile = VCP_logarithmic;
+        else if (strcasecmp(str, "dasl_tapered") == 0)
+          config.volume_control_profile = VCP_dasl_tapered;
         else
           die("Invalid volume_control_profile choice \"%s\". It should be \"standard\" (default), "
-              "\"logarithmic\", or \"flat\"",
+              "\"dasl_tapered\", or \"flat\"",
               str);
       }
 


### PR DESCRIPTION
Although I'm not an expert, to my ears, this logarithmic mode of volume control does a better job of making the volume percentage match the perceived volume level. That is, with logarithmic mode, 50% volume sounds half as loud as 100% volume. And 25% volume sounds a quarter as loud as 100% volume, etc. 

Dealing with airplay protocol, we have a volume between [-30, 0]. So we want -15 to sound half as loud as 0. And we want -22.5 to sound a quarter as loud as 0. Etc.

I found this page helpful for my understanding: http://www.sengpielaudio.com/calculator-levelchange.htm

FWIW I use the builtin raspberry pi soundcard. I'm not sure if perceptual loudness maps differently when using a different soundcard.

Also, no worries if you don't want to merge additional volume_control_profiles. I could maintain a fork if you're not into the idea.