### PR TITLE
Makefile.am: allow manually installing config files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -211,8 +211,6 @@ shairport_sync_mpris_test_client_SOURCES = shairport-sync-mpris-test-client.c
 shairport_sync_mpris_test_client_LDADD = lib_mpris_interface.a
 endif
 
-if INSTALL_CONFIG_FILES
-
 CONFIG_FILE_INSTALL_TARGET = config-file-install-local
 $(CONFIG_FILE_INSTALL_TARGET): scripts/shairport-sync.conf
 	install -d $(DESTDIR)$(sysconfdir)
@@ -256,8 +254,6 @@ $(MPRIS_POLICY_INSTALL_TARGET): $(MPRIS_POLICY_FILE)
 	install -m 0644 $(top_srcdir)/$(MPRIS_POLICY_FILE) $(DESTDIR)$(DBUS_POLICY_DIR)/shairport-sync-mpris.conf
 
 endif # USE_MPRIS
-
-endif # INSTALL_CONFIG_FILES
 
 INSTALL_GROUP_TARGET = install-group-local
 
@@ -329,10 +325,16 @@ $(INSTALL_CYGWIN_TARGET): scripts/shairport-sync-config
 
 endif # INSTALL_CYGWIN_SERVICE
 
-install-exec-hook: $(CONFIG_FILE_INSTALL_TARGET) \
+install-config-files: $(CONFIG_FILE_INSTALL_TARGET) \
                    $(DBUS_POLICY_INSTALL_TARGET) \
                    $(MPRIS_POLICY_INSTALL_TARGET) \
                    $(INSTALL_SYSTEMV_TARGET) \
                    $(INSTALL_SYSTEMD_TARGET) \
                    $(INSTALL_FREEBSD_TARGET) \
                    $(INSTALL_CYGWIN_TARGET)
+
+if INSTALL_CONFIG_FILES
+
+install-exec-hook: install-config-files
+
+endif


### PR DESCRIPTION
Mostly to help with packaging in NixOS.

In NixOS, we set `--prefix=/nix/store/xxxxxx/`. However, we also have to use `--without-configfiles`, lest the Makefile attempts to install the config files and friends to `/etc` (which is a complete no-go).

Specifying `DESTDIR=/nix/store/xxxxxx/` when using `--prefix=/nix/store/xxxxxx/` causes the config files to be put in the right place, but the binaries will be at `$DESTDIR/$PREFIX` (in this case `/nix/store/xxxxxx/nix/store/xxxxxx`).

This PR adds a separate `install-config-files` Makefile target that installs the config files and dbus policies to DESTDIR=, regardless of whether --with{,out}-configfiles is specified. This target exists unconditionally.

To keep the existing `make install` behaviour, `install-exec-hook` is changed to depend on `install-config-files` only if `INSTALL_CONFIG_FILES` is set.

In effect, this allows us to use:
```
./configure --prefix=/nix/store/xxxxxx --without-config-files
make
make install

make DESTDIR=/nix/store/xxxxxx install-config-files
```

For context: https://github.com/NixOS/nixpkgs/pull/276693

