### PR TITLE
No per-socket TCP keepidle on OpenBSD

### DIFF
--- a/definitions.h
+++ b/definitions.h
@@ -30,6 +30,10 @@
 #define COMPILE_FOR_FREEBSD 1
 #endif
 
+#if defined(__OpenBSD__)
+#define COMPILE_FOR_OPENBSD 1
+#endif
+
 // struct sockaddr_in6 is bigger than struct sockaddr. derp
 #ifdef AF_INET6
 #define SOCKADDR struct sockaddr_storage

--- a/rtsp.c
+++ b/rtsp.c
@@ -5623,6 +5623,7 @@ void *rtsp_listen_loop(__attribute((unused)) void *arg) {
 #define KEEP_ALIVE_OR_IDLE_OPTION TCP_KEEPIDLE
 #endif
 
+#ifndef COMPILE_FOR_OPENBSD
           if (setsockopt(conn->fd, SOL_OPTION, KEEP_ALIVE_OR_IDLE_OPTION,
                          (void *)&keepAliveIdleTime, sizeof(keepAliveIdleTime))) {
             debug(1, "can't set the keepidle wait time");
@@ -5636,6 +5637,7 @@ void *rtsp_listen_loop(__attribute((unused)) void *arg) {
                          sizeof(keepAliveInterval))) {
             debug(1, "can't set the keepidle missing count interval");
           };
+#endif
 
           // initialise the connection info
           void *client_addr = NULL, *self_addr = NULL;


### PR DESCRIPTION
A system-wide sysctl(2) net.inet.tcp.keepidle exists, but there is no
setsockopt(2) equivalent.
