### PR TITLE
Move shairport-sync manual from section 7 to 1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ARFLAGS = cr
 
-man_MANS = $(top_srcdir)/man/shairport-sync.7
+man_MANS = $(top_srcdir)/man/shairport-sync.1
 
 lib_pair_ap_a_CFLAGS = -Wall -g -DCONFIG_GCRYPT -pthread
 lib_tinyhttp_a_CFLAGS = -pthread

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,7 +95,7 @@ RUN apk -U add \
 
 # Copy build files.
 COPY --from=builder /shairport-sync/build/install/usr/local/bin/shairport-sync /usr/local/bin/shairport-sync
-COPY --from=builder /shairport-sync/build/install/usr/local/share/man/man7 /usr/share/man/man7
+COPY --from=builder /shairport-sync/build/install/usr/local/share/man/man1 /usr/share/man/man1
 COPY --from=builder /nqptp/nqptp /usr/local/bin/nqptp
 COPY --from=builder /usr/local/lib/libalac.* /usr/local/lib/
 COPY --from=builder /shairport-sync/build/install/etc/shairport-sync.conf /etc/

--- a/docker/classic/Dockerfile
+++ b/docker/classic/Dockerfile
@@ -75,7 +75,7 @@ RUN apk -U add \
 
 # Copy build files.
 COPY --from=builder /shairport-sync/build/install/usr/local/bin/shairport-sync /usr/local/bin/shairport-sync
-COPY --from=builder /shairport-sync/build/install/usr/local/share/man/man7 /usr/share/man/man7
+COPY --from=builder /shairport-sync/build/install/usr/local/share/man/man1 /usr/share/man/man1
 COPY --from=builder /usr/local/lib/libalac.* /usr/local/lib/
 COPY --from=builder /shairport-sync/build/install/etc/shairport-sync.conf /etc/
 COPY --from=builder /shairport-sync/build/install/etc/shairport-sync.conf.sample /etc/

--- a/man/Makefile
+++ b/man/Makefile
@@ -1,11 +1,11 @@
-shairport-sync.7: shairport-sync.7.xml
-	xmltoman shairport-sync.7.xml > shairport-sync.7
+shairport-sync.1: shairport-sync.1.xml
+	xmltoman shairport-sync.1.xml > shairport-sync.1
 
-shairport-sync.html: shairport-sync.7.xml
-	xsltproc xmltoman.xsl shairport-sync.7.xml > shairport-sync.html
+shairport-sync.html: shairport-sync.1.xml
+	xsltproc xmltoman.xsl shairport-sync.1.xml > shairport-sync.html
 
-all: shairport-sync.7 shairport-sync.html
+all: shairport-sync.1 shairport-sync.html
 
 clean:
-	rm shairport-sync.7
+	rm shairport-sync.1
 	rm shairport-sync.html

--- a/man/shairport-sync.1
+++ b/man/shairport-sync.1
@@ -1,4 +1,4 @@
-.TH shairport-sync 7 User Manuals
+.TH shairport-sync 1 User Manuals
 .SH NAME
 shairport-sync \- AirPlay and AirPlay 2 Audio Player
 .SH SYNOPSIS

--- a/man/shairport-sync.1.xml
+++ b/man/shairport-sync.1.xml
@@ -29,7 +29,7 @@
   OTHER DEALINGS IN THE SOFTWARE.
   -->
 
-  <manpage name="shairport-sync" section="7" desc="AirPlay and AirPlay 2 Audio Player">
+  <manpage name="shairport-sync" section="1" desc="AirPlay and AirPlay 2 Audio Player">
 
 	<synopsis>
 	<!--

--- a/shairport-sync.spec
+++ b/shairport-sync.spec
@@ -60,7 +60,7 @@ getent passwd %{name} &> /dev/null || useradd --system -c "%{name} User" \
 %files
 %config(noreplace) /etc/shairport-sync.conf
 /usr/bin/shairport-sync
-/usr/share/man/man7/shairport-sync.7.gz
+/usr/share/man/man1/shairport-sync.1.gz
 %{_unitdir}/%{name}.service
 %doc README.md RELEASENOTES.md TROUBLESHOOTING.md
 %license LICENSES


### PR DESCRIPTION
From mandoc man(1) [-s] section:
```
                   1         General commands (tools and utilities).
                   [...]
                   7         Miscellaneous information.
```

From GNU man(1) DESCRIPTION:
```
     1   Executable programs or shell commands
     [...]
     7   Miscellaneous (including macro packages and conventions), e.g.
         man(7), groff(7)
```

shairport-sync is an executable, shairport-sync(1) ought to be its documentation, not merely miscellaneous information.

OpenBSD adjusts this in its audio/shairport-sync port/package ever since.