### PR TITLE
Exit on config read error to avoid crash on EACCES

### DIFF
--- a/shairport.c
+++ b/shairport.c
@@ -1207,8 +1207,8 @@ int parse_options(int argc, char **argv) {
 
     } else {
       if (config_error_type(&config_file_stuff) == CONFIG_ERR_FILE_IO)
-        debug(2, "Error reading configuration file \"%s\": \"%s\".",
-              config_error_file(&config_file_stuff), config_error_text(&config_file_stuff));
+        die("Error reading configuration file \"%s\": \"%s\".",
+              config_file_real_path, config_error_text(&config_file_stuff));
       else {
         die("Line %d of the configuration file \"%s\":\n%s", config_error_line(&config_file_stuff),
             config_error_file(&config_file_stuff), config_error_text(&config_file_stuff));


### PR DESCRIPTION
Failure to read does not exit despite
`    /* Read the file. If there is an error, report it and exit. */`

EACCES (e.g. insufficient filesystem permissions) is enough to crash on access through later `config_*()` such as those when either of either of D-Bus, MPRIS or MQTT is used.

Seen `--with-mpris-interface` and
```
$ ls -l /etc/shairport-sync.conf
-rw-r-----  1 root  _shairport  28114 Jan 25 01:53 /etc/shairport-sync.conf
$ shairport-sync
Segmentation fault (core dumped)
```