### PR TITLE
Fix crash on double pthread_cancel(3) on exit

### DIFF
--- a/rtsp.c
+++ b/rtsp.c
@@ -5694,7 +5694,7 @@ void *rtsp_listen_loop(__attribute((unused)) void *arg) {
     } while (1);
     pthread_cleanup_pop(1); // should never happen
   } else {
-    warn("could not establish a service on port %d -- program terminating. Is another instance of "
+    die("could not establish a service on port %d -- program terminating. Is another instance of "
          "Shairport Sync running on this device?",
          config.port);
   }


### PR DESCRIPTION
Process teardown stops all threads, thus calling pthread_cancel(3) in an
atexit(3) handler immediately before main() exits seems redundant.

On OpenBSD 7.4-current, failure to listen on the RTSP socket triggers
```
$ nc -4l 5000 &
$ nc -6l 5000 &
$ shairport-sync -c/dev/null
warning: could not establish a service on port 5000 -- program terminating. Is another instance of Shairport Sync running on this device?
Segmentation fault (core dumped)
```
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  pthread_cancel (thread=0x6207604e640) at /usr/src/lib/librthread/rthread.c:433
433             if (tib->tib_canceled == 0 && tid != 0 &&
[Current thread is 1 (process 290061)]
#0  pthread_cancel (thread=0x6207604e640) at /usr/src/lib/librthread/rthread.c:433
#1  0x0000061e5377df14 in exit_rtsp_listener ()
#2  0x000006212fdb4140 in _libc___cxa_finalize (dso=0x0) at /usr/src/lib/libc/stdlib/atexit.c:177
#3  0x000006212fde9c45 in _libc_exit (status=0) at /usr/src/lib/libc/stdlib/exit.c:54
#4  0x0000061e5377ba88 in _start ()
```

Fix this by omitting the explicit pthread_cancel(3), at which point
exit_rtsp_listener() becomes redundant, so remove it entirely.