### PR TITLE
Use pledge(2) on OpenBSD to restrict system calls

### DIFF
--- a/shairport.c
+++ b/shairport.c
@@ -2395,15 +2395,15 @@ int main(int argc, char **argv) {
     /*
      * unveil(2) TODO:
      * - assume system D-Bus, hoist setup/defer unveil
-     * - glib2 locale (not critical!)
+     *   - glib2 locale (not critical!)
      * - MQTT?
      */
 # if defined(CONFIG_DBUS_INTERFACE) || defined(CONFIG_MPRIS_INTERFACE)
     if (unveil("/var/run/dbus/system_bus_socket", "rw") == -1)
       die("unveil D-Bus");
-# endif
     if (unveil("/usr/local/share/locale", "r") == -1)
       die("unveil locale");
+# endif
 
     /*
      * Only coverart cache is created/written.

--- a/shairport.c
+++ b/shairport.c
@@ -114,6 +114,10 @@
 #include <FFTConvolver/convolver.h>
 #endif
 
+#ifdef CONFIG_OPENBSD
+#include <string.h>	// strerror
+#endif
+
 pid_t pid;
 #ifdef CONFIG_LIBDAEMON
 int this_is_the_daemon_process = 0;
@@ -1932,7 +1936,7 @@ int main(int argc, char **argv) {
 #ifdef COMPILE_FOR_OPENBSD
   /* Start with the superset of all potentially required promises. */
   if (pledge("stdio rpath wpath cpath dpath inet unix dns proc exec unveil audio", NULL) == -1)
-    die("pledge");
+    die("pledge: %s", strerror(errno));
 #endif
 
   memset(&config, 0, sizeof(config)); // also clears all strings, BTW
@@ -2121,9 +2125,9 @@ int main(int argc, char **argv) {
   if (!run_cmds && !config.daemonise)
 # else
   if (!run_cmds)
-#endif
+# endif
     if (pledge("stdio rpath wpath cpath dpath inet unix dns unveil audio", NULL) == -1)
-      die("pledge");
+      die("pledge: %s", strerror(errno));
 #endif
 
   // mDNS supports maximum of 63-character names (we append 13).
@@ -2263,7 +2267,7 @@ int main(int argc, char **argv) {
   /* Drop "proc exec", if possible. */
   if (!run_cmds)
     if (pledge("stdio rpath wpath cpath dpath inet unix dns unveil audio", NULL) == -1)
-      die("pledge");
+      die("pledge: %s", strerror(errno));
 # endif
 
 #endif
@@ -2400,9 +2404,9 @@ int main(int argc, char **argv) {
      */
 # if defined(CONFIG_DBUS_INTERFACE) || defined(CONFIG_MPRIS_INTERFACE)
     if (unveil("/var/run/dbus/system_bus_socket", "rw") == -1)
-      die("unveil D-Bus");
+      die("unveil D-Bus: %s", strerror(errno));
     if (unveil("/usr/local/share/locale", "r") == -1)
-      die("unveil locale");
+      die("unveil locale: %s", strerror(errno));
 # endif
 
     /*
@@ -2424,21 +2428,21 @@ int main(int argc, char **argv) {
 
       if (do_cache)
         if (unveil(config.cover_art_cache_dir, "wc") == -1)
-          die("unveil %s", config.cover_art_cache_dir);
+          die("unveil %s: %s", config.cover_art_cache_dir, strerror(errno));
 #  endif
       if (unveil(config.metadata_pipename, "wc") == -1)
-        die("unveil %s", config.metadata_pipename);
+        die("unveil %s: %s", config.metadata_pipename, strerror(errno));
     }
 # endif
 
     /* Drop "unveil". */
     if (need_cpath_dpath) {
       if (pledge("stdio rpath wpath cpath dpath inet unix dns audio", NULL) == -1)
-        die("pledge");
+        die("pledge: %s", strerror(errno));
     } else {
       /* Drop "cpath dpath". */
       if (pledge("stdio rpath wpath inet unix dns audio", NULL) == -1)
-        die("pledge");
+        die("pledge: %s", strerror(errno));
     }
   }
 #endif

--- a/shairport.c
+++ b/shairport.c
@@ -2383,6 +2383,31 @@ int main(int argc, char **argv) {
   }
   config.output->init(argc - audio_arg, argv + audio_arg);
 
+#ifdef COMPILE_FOR_OPENBSD
+  /*
+   * At this point, the first and last sio_open(3) call was made, i.e.
+   * the sndio(7) cookie is dealt with and only "audio" is needed.
+   */
+
+  if (run_cmds) {
+    /* Do not bother with "*path" as long as "proc exec" can do everything. */
+  } else {
+    /*
+     * Only coverart cache is created/written.
+     * Only metadata pipe is special.
+     */
+    int need_cpath_dpath = 0;
+# ifdef CONFIG_METADATA
+    if (config.metadata_enabled)
+      need_cpath_dpath = 1;
+# endif
+    /* Drop "cpath dpath". */
+    if (!need_cpath_dpath)
+      if (pledge("stdio rpath wpath inet unix dns audio", NULL) == -1)
+        die("pledge");
+  }
+#endif
+
   // pthread_cleanup_push(main_cleanup_handler, NULL);
 
   // daemon_log(LOG_NOTICE, "startup");

--- a/shairport.c
+++ b/shairport.c
@@ -2414,6 +2414,10 @@ int main(int argc, char **argv) {
     if (config.metadata_enabled) {
       need_cpath_dpath = 1;
 #  ifdef CONFIG_METADATA_HUB
+      /*
+       * XXX unveiling default /tmp/shairport-sync/.cache/coverart may fail
+       * as parent directories do not exist.
+       */
       int do_cache =
         config.cover_art_cache_dir != NULL &&
         config.cover_art_cache_dir[0] != '\0';

--- a/shairport.c
+++ b/shairport.c
@@ -2108,18 +2108,6 @@ int main(int argc, char **argv) {
   // parse arguments into config -- needed to locate pid_dir
   int audio_arg = parse_options(argc, argv);
 
-#ifdef COMPILE_FOR_OPENBSD
-  /* Drop "proc exec" unless external commands are to be run. */
-  if ((config.cmd_active_start == NULL) &&
-      (config.cmd_active_stop == NULL) &&
-      (config.cmd_start == NULL) &&
-      (config.cmd_stop == NULL) &&
-      (config.cmd_set_volume == NULL)) {
-    if (pledge("stdio rpath wpath cpath dpath inet unix dns audio", NULL) == -1)
-      die("pledge");
-  }
-#endif
-
   // mDNS supports maximum of 63-character names (we append 13).
   if (strlen(config.service_name) > 50) {
     warn("The service name \"%s\" is too long (max 50 characters) and has been truncated.",
@@ -2253,6 +2241,18 @@ int main(int argc, char **argv) {
     /* end libdaemon stuff */
   }
 
+#endif
+
+#ifdef COMPILE_FOR_OPENBSD
+  /* Drop "proc exec" unless external commands are to be run. */
+  if ((config.cmd_active_start == NULL) &&
+      (config.cmd_active_stop == NULL) &&
+      (config.cmd_start == NULL) &&
+      (config.cmd_stop == NULL) &&
+      (config.cmd_set_volume == NULL)) {
+    if (pledge("stdio rpath wpath cpath dpath inet unix dns audio", NULL) == -1)
+      die("pledge");
+  }
 #endif
 
 #ifdef CONFIG_AIRPLAY_2


### PR DESCRIPTION
As per sio_open(3) "Use with pledge(2)" and
```
"cpath wpath dpath" - metadata pipe, coverart cache
"inet dns"          - metadata socket, RTSP, NQPTP, MQTT
"unix"              - Avahi, D-Bus, MPRIS
"proc exec"         - external hooks/scripts
```

Filesystem access is limited to a handful of paths, but accounting for
them takes careful work, thus full "[rwcd]path" is not dropped.

More importantly, prevent fork(2) and execve(2) if no hooks have been
defined (default configuration).

(As `config.cmd_*` are split into individual argv[] strings, they cannot
 be unveil(2)ed to limit "x" permissions to those commands.)