### PR TITLE
Omit password in debug (syslog) output

### DIFF
--- a/shairport.c
+++ b/shairport.c
@@ -2429,7 +2429,7 @@ int main(int argc, char **argv) {
   debug(1, "allow a session to be interrupted: %d.", config.allow_session_interruption);
   debug(1, "busy timeout time is %d.", config.timeout);
   debug(1, "drift tolerance is %f seconds.", config.tolerance);
-  debug(1, "password is \"%s\".", strnull(config.password));
+  debug(1, "password is %s.", config.password == NULL ? "not set" : "set (omitted)");
   debug(1, "default airplay volume is: %.6f.", config.default_airplay_volume);
   debug(1, "high threshold airplay volume is: %.6f.", config.high_threshold_airplay_volume);
   if (config.limit_to_high_volume_threshold_time_in_minutes == 0)


### PR DESCRIPTION
Configuration files may contain it, but those can be protected with filesystem permissions.

Debug log, however, may end up in syslog(3) which is usually accessible by all users on a system.

Avoid disclosing user secrets by simply not printing the password.