### PR TITLE
Limit PTP addresses to configured network interface

### DIFF
--- a/rtsp.c
+++ b/rtsp.c
@@ -3044,7 +3044,8 @@ void handle_setup_2(rtsp_conn_info *conn, rtsp_message *req, rtsp_message *resp)
                 // debug(1, "Interface index %d, name: \"%s\"",if_nametoindex(iap->ifa_name),
                 // iap->ifa_name);
                 if ((iap->ifa_addr) && (iap->ifa_netmask) && (iap->ifa_flags & IFF_UP) &&
-                    ((iap->ifa_flags & IFF_LOOPBACK) == 0)) {
+                    ((iap->ifa_flags & IFF_LOOPBACK) == 0) &&
+		    (config.interface == NULL || (strcmp(config.interface, iap->ifa_name) == 0))) {
                   char buf[INET6_ADDRSTRLEN + 1]; // +1 for a NUL
                   memset(buf, 0, sizeof(buf));
                   if (iap->ifa_addr->sa_family == AF_INET6) {


### PR DESCRIPTION
This is a conservative change. I think I have identified an even better fix, but with more risk of regression.

Without this change (or with no general.interface configured) every address of the ShairPort Sync server seems to be advertised via PTP, including many internal Docker networks that are not reachable from elsewhere. My AirPlay sources (at least macOS 12.7.2 & iOS 17.3.1) send a lot of PTP messages to all of these addresses in parallel, most of which are rejected by my firewall.

With this change and when general.interface is set, only addresses for that interface are advertised for PTP. Even in this case my ShairPort Sync server still receives 4x seemingly duplicate streams of PTP messages to each of those addresses (static IPv4, link-local IPv6, ULA IPv6, public IPv6). The actual audio only goes to the public IPv6 address in my case.

I stumbled upon a potentally even better fix by accident when I mucked up the logic during testing: Don't advertise any addresses here. ShairPort still worked fine. PTP messages are still sent to the same address as the audio stream (public IPv6 address in my case) and recognised by ShairPort ("Connection 1: AP2 PTP connection from IPHONE_IPV6_ADDR"). Multi-room sync between ShairPort & a HomePod Mini seemed good. For now I'm going to run my build with the following hack as it minimises network traffic without any apparent drawbacks.

```
                //if ((iap->ifa_addr) && (iap->ifa_netmask) && (iap->ifa_flags & IFF_UP) &&
                //    ((iap->ifa_flags & IFF_LOOPBACK) == 0)) {
                // AirPlay sources seem to use the correct PTP address if
                // we don't advertise any addresses here.
                if (false) {
```

Testing performed:
- Built & run in Docker