### PR TITLE
Add configure option to enable/disable creation of user/group

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -261,7 +261,11 @@ INSTALL_GROUP_TARGET = install-group-local
 $(INSTALL_GROUP_TARGET):
 	getent group shairport-sync &>/dev/null || groupadd -r shairport-sync &>/dev/null
 
+if INSTALL_CREATE_USER_GROUP
 INSTALL_USER_TARGET = install-user-local
+else
+INSTALL_USER_TARGET =
+endif
 
 $(INSTALL_USER_TARGET): $(INSTALL_GROUP_TARGET)
 	getent passwd shairport-sync &>/dev/null || useradd -r -M -g shairport-sync -s /usr/sbin/nologin -G audio shairport-sync &>/dev/null

--- a/configure.ac
+++ b/configure.ac
@@ -115,6 +115,11 @@ if  test "x$with_external_mdns" = xyes ; then
 fi
 AM_CONDITIONAL([USE_EXTERNAL_MDNS], [test "x$with_external_mdns" = "xyes" ])
 
+# Check if we want to create user/group (default to yes):
+
+AC_ARG_WITH([create-user-group],[AS_HELP_STRING([--with-create-user-group],[create user/group during a make install])], ,[with_with_create_user_group=yes])
+AM_CONDITIONAL([INSTALL_CREATE_USER_GROUP], [test "x$with_with_create_user_group" = "xyes"])
+
 # Add the libconfig package
 if  test "x${with_pkg_config}" = xyes ; then
   PKG_CHECK_MODULES(


### PR DESCRIPTION
Useful for Yocto, for example, where groupadd or getenv is not available.

Enabled by default, to keep same behavior as before.