### PR TITLE
Minor formatting fixes

### DIFF
--- a/audio_pa.c
+++ b/audio_pa.c
@@ -41,7 +41,7 @@
 #define RATE 44100
 
 // Four seconds buffer -- should be plenty
-#define buffer_allocation 44100 * 4 * 2 * 2
+#define buffer_allocation RATE * 4 * 2 * 2
 
 static pthread_mutex_t buffer_mutex = PTHREAD_MUTEX_INITIALIZER;
 

--- a/man/Makefile
+++ b/man/Makefile
@@ -9,5 +9,3 @@ all: shairport-sync.7 shairport-sync.html
 clean:
 	rm shairport-sync.7
 	rm shairport-sync.html
-
-.DELETE_ON_ERROR:

--- a/man/Makefile
+++ b/man/Makefile
@@ -1,11 +1,13 @@
-shairport-sync.7: shairport-sync.7.xml
-	xmltoman shairport-sync.7.xml > shairport-sync.7
-
-shairport-sync.html: shairport-sync.7.xml
-	xsltproc xmltoman.xsl shairport-sync.7.xml > shairport-sync.html
-
 all: shairport-sync.7 shairport-sync.html
+
+%.7: %.7.xml
+	xmltoman $*.7.xml > $*.tmp && mv $*.tmp $*.7
+
+%.html: %.7.xml
+	xsltproc xmltoman.xsl $*.7.xml > $*.tmp && mv $*.tmp $*.html
 
 clean:
 	rm shairport-sync.7
 	rm shairport-sync.html
+
+.DELETE_ON_ERROR:

--- a/man/shairport-sync.7.xml
+++ b/man/shairport-sync.7.xml
@@ -353,7 +353,7 @@
 	  <option>
 		<p><opt>--statistics</opt></p>
 		<optdesc><p>
-		Print some performance information to <file>STDERR</file>, or to <opt>syslog</opt> if the <opt>-log-to-syslog</opt> command line option is also chosen.
+		Print some performance information to <file>STDERR</file>, or to <opt>syslog</opt> if the <opt>--log-to-syslog</opt> command line option is also chosen.
 		</p></optdesc>
 	  </option>
 
@@ -416,7 +416,7 @@
 	  <option>
 		<p><opt>-v | --verbose</opt></p>
 		<optdesc><p>
-		Print debug information to the <file>STDERR</file>, or to <opt>syslog</opt> if the <opt>-log-to-syslog</opt> command line option is also chosen.
+		Print debug information to the <file>STDERR</file>, or to <opt>syslog</opt> if the <opt>--log-to-syslog</opt> command line option is also chosen.
 		Repeat up to three times (i.e. <opt>-vv</opt> or <opt>-vvv</opt>) for more detail. You should use <opt>-vvv</opt> very sparingly -- it is really noisy.
 		</p></optdesc>
 	  </option>

--- a/shairport.c
+++ b/shairport.c
@@ -291,7 +291,7 @@ void usage(char *progname) {
     printf("    -c, --configfile=FILE   Read configuration settings from FILE. Default is %s.\n", configuration_file_path);
     printf("    -a, --name=NAME         Set service name. Default is the hostname with first letter capitalised.\n");
     printf("    --password=PASSWORD     Require PASSWORD to connect. Default is no password. (Classic AirPlay only.)\n");
-    printf("    -p, --port=PORT         Set RTSP listening port. Default 5000; 7000 for AirPlay 2./\n");
+    printf("    -p, --port=PORT         Set RTSP listening port. Default 5000; 7000 for AirPlay 2.\n");
     printf("    -L, --latency=FRAMES    [Deprecated] Set the latency for audio sent from an unknown device.\n");
     printf("                            The default is to set it automatically.\n");
     printf("    -S, --stuffing=MODE     Set how to adjust current latency to match desired latency, where:\n");


### PR DESCRIPTION
Use constant RATE for clarity in audio_pa.c and fixed a few minor typos.

Also did some minor corrections in man/Makefile. The existing makefile was not very safe; it would clobber an existing shairport-sync.7 or shairport-sync.html if an error occurred (for example because xmltoman and/or xsltproc was not installed) and “all” was not the default target.