### PR TITLE
ci: build docker with pipewire

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,7 @@ RUN apk -U add \
         libsndfile-dev \
         libsodium-dev \
         libtool \
+        pipewire-dev \
         mosquitto-dev \
         popt-dev \
         pulseaudio-dev \
@@ -58,7 +59,7 @@ RUN autoreconf -i ../
 RUN CFLAGS="-O3" CXXFLAGS="-O3" ../configure --sysconfdir=/etc --with-alsa --with-pa --with-soxr --with-avahi --with-ssl=openssl \
         --with-airplay-2 --with-metadata --with-dummy --with-pipe --with-dbus-interface \
         --with-stdout --with-mpris-interface --with-mqtt-client \
-        --with-apple-alac --with-convolution
+        --with-apple-alac --with-convolution --with-pw
 RUN make -j $(nproc)
 RUN DESTDIR=install make install
 WORKDIR /
@@ -87,6 +88,7 @@ RUN apk -U add \
         libsndfile \
         libsodium \
         libuuid \
+        pipewire \
         man-pages \
         mandoc \
         mosquitto \

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -9,11 +9,14 @@ services:
     #  S6_KEEP_ENV: 1 # Allow S6 to pass environment variables from compose file
     #  PULSE_SERVER: unix:/tmp/pulseaudio.socket # Path for PulseAudio socket
     #  PULSE_COOKIE: /tmp/pulseaudio.cookie # Path for PulseAudio cookie
+    #  XDG_RUNTIME_DIR: /tmp # Path for pipewire
     devices:
       - "/dev/snd" # ALSA device, omit if using PulseAudio
     # volumes:
     #   - ./volumes/shairport-sync/shairport-sync.conf:/etc/shairport-sync.conf # Customised Shairport Sync configuration file.
     #   - /run/user/1000/pulse/native:/tmp/pulseaudio.socket # PulseAudio socket when using that backend
+    #   - /run/user/1000/pipewire-0:/tmp/pipewire-0 # Pipewire socket when using pipewire
+    # command: -o pw # You can specify the desired output with command:
     logging:
       options:
         max-size: "200k"


### PR DESCRIPTION
Working on top of #1642 I really needed a pipewire way of running this on my server

Thankfully adding it was not hard

One more thing I would do is move docker-compose.yaml to docker-compose.example.yaml, since most users would need to modify the file to fit their needs
