### PR TITLE
Allow for 2+ instances of shairplay-sync to run at once

### DIFF
--- a/audio_alsa.c
+++ b/audio_alsa.c
@@ -560,7 +560,11 @@ static int actual_open_alsa_device(int do_auto_setup) {
     return ret;
   }
 
-  ret = snd_pcm_hw_params_set_channels(alsa_handle, alsa_params, 2);
+  int channels = 2;
+  if (config.playback_mode == ST_one_channel){
+    channels = 1;
+  }
+  ret = snd_pcm_hw_params_set_channels(alsa_handle, alsa_params, channels);
   if (ret < 0) {
     die("audio_alsa: Channels count (2) not available for device \"%s\": %s", alsa_out_dev,
         snd_strerror(ret));

--- a/common.h
+++ b/common.h
@@ -68,6 +68,7 @@ typedef enum {
   ST_reverse_stereo,
   ST_left_only,
   ST_right_only,
+  ST_one_channel,
 } playback_mode_type;
 
 typedef enum {

--- a/mdns_avahi.c
+++ b/mdns_avahi.c
@@ -256,9 +256,26 @@ static void register_service(AvahiClient *c) {
       selected_interface = config.interface_index;
     else
       selected_interface = AVAHI_IF_UNSPEC;
+    //Both eth0 and eth0:1 are 2?
+    debug(1, "avahi:ERROR: selected interface %d", selected_interface);
+    char *host = "192.168.1.241";
+    host = NULL;
+    host = "piamp2_henry.local";
+
+    if (strcmp(config.service_name, "dinning") == 0 ){
+      debug(1, "Here 1" );
+      //something else
+      host = "piamp2_dinning.local";
+    }else{
+      //Something
+      debug(1, "Here 2" );
+      host = "piamp2_henry.local";
+    }
+    //https://andrewdupont.net/2022/01/27/using-mdns-aliases-within-your-home-network/
+    ///usr/bin/avahi-publish -a homebridge.home.local -R 192.168.1.99
     if (ap2_text_record_string_list) {
       ret = avahi_entry_group_add_service_strlst(group, selected_interface, AVAHI_PROTO_UNSPEC, 0,
-                                                 ap2_service_name, config.regtype2, NULL, NULL,
+                                                 ap2_service_name, config.regtype2, NULL, host,
                                                  port, ap2_text_record_string_list);
       if (ret == AVAHI_ERR_COLLISION) {
         die("Error: AirPlay 2 name \"%s\" is already in use.", ap2_service_name);
@@ -266,7 +283,7 @@ static void register_service(AvahiClient *c) {
     }
     if ((ret == 0) && (text_record_string_list)) {
       ret = avahi_entry_group_add_service_strlst(group, selected_interface, AVAHI_PROTO_UNSPEC, 0,
-                                                 service_name, config.regtype, NULL, NULL, port,
+                                                 service_name, config.regtype, NULL, host, port,
                                                  text_record_string_list);
       if (ret == AVAHI_ERR_COLLISION) {
         die("Error: AirPlay 1 name \"%s\" is already in use.", service_name);

--- a/player.c
+++ b/player.c
@@ -1133,6 +1133,7 @@ static abuf_t *buffer_get_frame(rtsp_conn_info *conn) {
             conn->ab_read++;
           } else {
             if (conn->first_packet_timestamp == 0)
+              //Here??
               debug(2, "Accepting packet %u with timestamp %u. Lead time is %f seconds.",
                     conn->ab_read, thePacket->given_timestamp,
                     frame_difference * 1.0 / 44100.0 + desired_lead_time * 0.000000001);
@@ -2357,6 +2358,7 @@ void *player_thread_func(void *arg) {
               // also, raise the 16-bit samples to 32 bits.
 
               switch (config.playback_mode) {
+              case ST_one_channel:
               case ST_mono: {
                 int32_t lsl = ls;
                 int32_t rsl = rs;
@@ -2396,7 +2398,8 @@ void *player_thread_func(void *arg) {
 
               for (j = 0; j < conn->output_sample_ratio; j++) {
                 *outpl++ = ll;
-                *outpl++ = rl;
+                if (config.playback_mode != ST_one_channel)
+                  *outpl++ = rl;
               }
             }
           } break;
@@ -2413,6 +2416,7 @@ void *player_thread_func(void *arg) {
               // here, do the mode stuff -- mono / reverse stereo / leftonly / rightonly
 
               switch (config.playback_mode) {
+              case ST_one_channel:
               case ST_mono: {
                 int64_t lsl = ls;
                 int64_t rsl = rs;
@@ -2444,7 +2448,8 @@ void *player_thread_func(void *arg) {
 
               for (j = 0; j < conn->output_sample_ratio; j++) {
                 *outpl++ = ll;
-                *outpl++ = rl;
+                if (config.playback_mode != ST_one_channel)
+                  *outpl++ = rl;
               }
             }
           } break;
@@ -2705,6 +2710,7 @@ void *player_thread_func(void *arg) {
                 if ((resp != -EBUSY) &&
                     (resp != -ENODEV)) // delay and not-there errors can be reported if the device
                                        // is (hopefully temporarily) busy or unavailable
+                  //Here ??
                   debug(1, "Delay error %d when checking running latency.", resp);
               }
             }

--- a/rtp.c
+++ b/rtp.c
@@ -1436,6 +1436,7 @@ int get_ptp_anchor_local_time_info(rtsp_conn_info *conn, uint32_t *anchorRTP,
       debug(1, "Connection %d: NQPTP clock is not synchronised.", conn->connection_number);
       break;
     case clock_not_valid:
+      //Here
       debug(2, "Connection %d: NQPTP clock information is not valid.", conn->connection_number);
       break;
     default:

--- a/rtsp.c
+++ b/rtsp.c
@@ -2860,7 +2860,7 @@ static void check_and_send_plist_metadata(plist_t messagePlist, const char *plis
 
 void handle_setup_2(rtsp_conn_info *conn, rtsp_message *req, rtsp_message *resp) {
   int err;
-  debug(2, "Connection %d: SETUP (AirPlay 2)", conn->connection_number);
+  debug(1, "Connection %d: SETUP (AirPlay 2)", conn->connection_number);
   debug_log_rtsp_message(3, "SETUP (AirPlay 2) SETUP incoming message", req);
 
   plist_t messagePlist = plist_from_rtsp_content(req);
@@ -2954,7 +2954,9 @@ void handle_setup_2(rtsp_conn_info *conn, rtsp_message *req, rtsp_message *resp)
             send_ssnc_metadata('svip', conn->self_ip_string, strlen(conn->self_ip_string), 1);
 #endif
 
-            if (ptp_shm_interface_open() !=
+            //Here
+            ptp_shm_interface_close();
+            if (ptp_shm_interface_open(conn->client_ip_string) !=
                 0) // it should be open already, but just in case it isn't...
               die("Can not access the NQPTP service. Has it stopped running?");
             // clear_ptp_clock();
@@ -5474,6 +5476,23 @@ void *rtsp_listen_loop(__attribute((unused)) void *arg) {
         ret |= setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &yes, sizeof(yes));
       }
 #endif
+      struct sockaddr_in *sa;
+      sa = (void*)p->ai_addr;
+      int ai_addrlen = p->ai_addrlen;
+      unsigned char ipbuff [sizeof(struct in6_addr)];
+      if (p->ai_family == AF_INET6) {
+
+      }else{
+        if (strcmp(config.service_name, "dinning") == 0 ){
+          debug(1, "Here 1" );
+          //something else
+          inet_pton(AF_INET, "192.168.1.116", &sa->sin_addr);
+        }else{
+          //Something
+          debug(1, "Here 2" );
+          inet_pton(AF_INET, "192.168.1.241", &sa->sin_addr);
+        }
+      }
 
       if (!ret)
         ret = bind(fd, p->ai_addr, p->ai_addrlen);

--- a/shairport.c
+++ b/shairport.c
@@ -893,6 +893,8 @@ int parse_options(int argc, char **argv) {
           config.playback_mode = ST_left_only;
         else if (strcasecmp(str, "both right") == 0)
           config.playback_mode = ST_right_only;
+        else if (strcasecmp(str, "one_channel") == 0)
+          config.playback_mode = ST_one_channel;
         else
           die("Invalid playback_mode choice \"%s\". It should be \"stereo\" (default), \"mono\", "
               "\"reverse stereo\", \"both left\", \"both right\"",
@@ -2652,7 +2654,7 @@ int main(int argc, char **argv) {
   int64_t time_spent_waiting = 0;
   do {
     continue_waiting = 0;
-    response = ptp_shm_interface_open();
+    response = ptp_shm_interface_open(NULL);
     if ((response == -1) && (errno == ENOENT)) {
       time_spent_waiting = get_absolute_time_in_ns() - nqptp_start_waiting_time;
       if (time_spent_waiting < 10000000000L) {


### PR DESCRIPTION
Add in mode option to allow for single channel speakers So left can go to one room and another room can be controlled with the right for #1877

Bind to a hardcode IP for now
Also try to get the 2 different clock sources needed.
Going from a laptop to the 2 different airplay targets seems to work fine.
But when 2 different devices connect

I really want to avoid having to use docker to have 2+ different airplay targets on one device.
After I do some rewiring I can try 6 speakers at once.

