### PR TITLE
Check swr_init() error code and exit early.

### DIFF
--- a/rtp.c
+++ b/rtp.c
@@ -2364,7 +2364,11 @@ void *rtp_buffered_audio_processor(void *arg) {
   };
 
   av_opt_set_sample_fmt(swr, "out_sample_fmt", av_format, 0);
-  swr_init(swr);
+  int swr_err = swr_init(swr);
+  if (swr_err !=0){
+    die("FFMpeg swr_init() failed Error %d (%s)",
+        swr_err, av_err2str(swr_err));
+  }
 
   uint8_t packet[16 * 1024];
   unsigned char m[16 * 1024]; // leave the first 7 bytes blank to make room for the ADTS


### PR DESCRIPTION
I did switch to the development branch and it works for me.
I would suggest it maybe nice to check the error code and exit cleanly for #1894

And do you have a way to keep the issue in a fixed in the next release state?
So it is easier to see the issue for other people until the next release is put out.