### PR TITLE
Send pvol metadata on mute

### DIFF
--- a/player.c
+++ b/player.c
@@ -3318,6 +3318,13 @@ static void player_send_volume_metadata(bool vol_mode_both, double airplay_volum
       snprintf(dv, 127, "%.2f,%.2f,%.2f,%.2f", airplay_volume, 0.0, 0.0, 0.0);
     }
     send_ssnc_metadata('pvol', dv, strlen(dv), 1);
+#else
+  (void)vol_mode_both;
+  (void)airplay_volume;
+  (void)scaled_attenuation;
+  (void)max_db;
+  (void)min_db;
+  (void)hw_max_db;
 #endif
 }
 

--- a/player.c
+++ b/player.c
@@ -36,7 +36,6 @@
 #include <math.h>
 #include <pthread.h>
 #include <stdarg.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -3297,7 +3296,7 @@ void *player_thread_func(void *arg) {
   pthread_exit(NULL);
 }
 
-static void player_send_volume_metadata(bool vol_mode_both, double airplay_volume, double scaled_attenuation, int32_t max_db, int32_t min_db, int32_t hw_max_db)
+static void player_send_volume_metadata(uint8_t vol_mode_both, double airplay_volume, double scaled_attenuation, int32_t max_db, int32_t min_db, int32_t hw_max_db)
 {
 #ifdef CONFIG_METADATA
     // here, send the 'pvol' metadata message when the airplay volume information
@@ -3305,7 +3304,7 @@ static void player_send_volume_metadata(bool vol_mode_both, double airplay_volum
     char dv[128];
     memset(dv, 0, 128);
     if (config.ignore_volume_control == 0) {
-      if (vol_mode_both) {
+      if (vol_mode_both == 1) {
         // normalise the maximum output to the hardware device's max output
         snprintf(dv, 127, "%.2f,%.2f,%.2f,%.2f", airplay_volume,
                  (scaled_attenuation - max_db + hw_max_db) / 100.0,
@@ -3417,7 +3416,8 @@ void player_volume_without_notification(double airplay_volume, rtsp_conn_info *c
       }
     }
 
-    player_send_volume_metadata(volume_mode == vol_both, airplay_volume, 0, 0, 0, 0);
+    uint8_t vol_mode_both = (volume_mode == vol_both) ? 1 : 0;
+    player_send_volume_metadata(vol_mode_both, airplay_volume, 0, 0, 0, 0);
   } else {
     int32_t max_db = 0, min_db = 0;
     switch (volume_mode) {
@@ -3528,7 +3528,8 @@ void player_volume_without_notification(double airplay_volume, rtsp_conn_info *c
       inform("Output Level set to: %.2f dB.", scaled_attenuation / 100.0);
     }
 
-    player_send_volume_metadata(volume_mode == vol_both, airplay_volume, scaled_attenuation, max_db, min_db, hw_max_db);
+    uint8_t vol_mode_both = (volume_mode == vol_both) ? 1 : 0;
+    player_send_volume_metadata(vol_mode_both, airplay_volume, scaled_attenuation, max_db, min_db, hw_max_db);
 
     if (config.output->mute)
       config.output->mute(0);

--- a/player.c
+++ b/player.c
@@ -36,6 +36,7 @@
 #include <math.h>
 #include <pthread.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -3296,6 +3297,30 @@ void *player_thread_func(void *arg) {
   pthread_exit(NULL);
 }
 
+static void player_send_volume_metadata(bool vol_mode_both, double airplay_volume, double scaled_attenuation, int32_t max_db, int32_t min_db, int32_t hw_max_db)
+{
+#ifdef CONFIG_METADATA
+    // here, send the 'pvol' metadata message when the airplay volume information
+    // is being used by shairport sync to control the output volume
+    char dv[128];
+    memset(dv, 0, 128);
+    if (config.ignore_volume_control == 0) {
+      if (vol_mode_both) {
+        // normalise the maximum output to the hardware device's max output
+        snprintf(dv, 127, "%.2f,%.2f,%.2f,%.2f", airplay_volume,
+                 (scaled_attenuation - max_db + hw_max_db) / 100.0,
+                 (min_db - max_db + hw_max_db) / 100.0, (max_db - max_db + hw_max_db) / 100.0);
+      } else {
+        snprintf(dv, 127, "%.2f,%.2f,%.2f,%.2f", airplay_volume, scaled_attenuation / 100.0,
+                 min_db / 100.0, max_db / 100.0);
+      }
+    } else {
+      snprintf(dv, 127, "%.2f,%.2f,%.2f,%.2f", airplay_volume, 0.0, 0.0, 0.0);
+    }
+    send_ssnc_metadata('pvol', dv, strlen(dv), 1);
+#endif
+}
+
 void player_volume_without_notification(double airplay_volume, rtsp_conn_info *conn) {
   debug_mutex_lock(&conn->volume_control_mutex, 5000, 1);
   // first, see if we are hw only, sw only, both with hw attenuation on the top or both with sw
@@ -3384,6 +3409,8 @@ void player_volume_without_notification(double airplay_volume, rtsp_conn_info *c
               volume_mode, airplay_volume);
       }
     }
+
+    player_send_volume_metadata(volume_mode == vol_both, airplay_volume, 0, 0, 0, 0);
   } else {
     int32_t max_db = 0, min_db = 0;
     switch (volume_mode) {
@@ -3494,26 +3521,7 @@ void player_volume_without_notification(double airplay_volume, rtsp_conn_info *c
       inform("Output Level set to: %.2f dB.", scaled_attenuation / 100.0);
     }
 
-#ifdef CONFIG_METADATA
-    // here, send the 'pvol' metadata message when the airplay volume information
-    // is being used by shairport sync to control the output volume
-    char dv[128];
-    memset(dv, 0, 128);
-    if (config.ignore_volume_control == 0) {
-      if (volume_mode == vol_both) {
-        // normalise the maximum output to the hardware device's max output
-        snprintf(dv, 127, "%.2f,%.2f,%.2f,%.2f", airplay_volume,
-                 (scaled_attenuation - max_db + hw_max_db) / 100.0,
-                 (min_db - max_db + hw_max_db) / 100.0, (max_db - max_db + hw_max_db) / 100.0);
-      } else {
-        snprintf(dv, 127, "%.2f,%.2f,%.2f,%.2f", airplay_volume, scaled_attenuation / 100.0,
-                 min_db / 100.0, max_db / 100.0);
-      }
-    } else {
-      snprintf(dv, 127, "%.2f,%.2f,%.2f,%.2f", airplay_volume, 0.0, 0.0, 0.0);
-    }
-    send_ssnc_metadata('pvol', dv, strlen(dv), 1);
-#endif
+    player_send_volume_metadata(volume_mode == vol_both, airplay_volume, scaled_attenuation, max_db, min_db, hw_max_db);
 
     if (config.output->mute)
       config.output->mute(0);


### PR DESCRIPTION
We discussed the possibility of sending mute state via MQTT a while ago here https://github.com/mikebrady/shairport-sync/discussions/1646

It seems the path of least resistance is to emit the same volume messages with the special muted volume value of `-144.0`.

This is in order to support implementing mute support in a Home Assistant custom integration: https://github.com/parautenbach/hass-shairport-sync/pull/14

Leaving as a draft as I have yet to fully test.