### PR TITLE
Add Home Assistant MQTT Auto-Discovery and active/playing State Messages

### DIFF
--- a/common.h
+++ b/common.h
@@ -175,6 +175,8 @@ typedef struct {
   int mqtt_publish_parsed;
   int mqtt_publish_cover;
   int mqtt_enable_remote;
+  int mqtt_enable_autodiscovery;
+  char *mqtt_autodiscovery_prefix;
   char *mqtt_empty_payload_substitute;
 #endif
   uint8_t ap1_prefix[6];

--- a/mqtt.c
+++ b/mqtt.c
@@ -101,6 +101,7 @@ void on_connect(struct mosquitto *mosq, __attribute__((unused)) void *userdata,
 void send_autodiscovery_messages(struct mosquitto *mosq) {
     const char *device_name = config.service_name;
     const char *device_id = config.airplay_device_id ? config.airplay_device_id : config.service_name;
+    const char *device_id_no_colons = str_replace(device_id, ":", "");
     const char *sw_version = get_version_string();
     const char *model = "shairport-sync";
     const char *model_friendly = "Shairport Sync";
@@ -189,9 +190,9 @@ void send_autodiscovery_messages(struct mosquitto *mosq) {
         bool is_binary_sensor = (strcmp(sensors[i], "active") == 0 || strcmp(sensors[i], "playing") == 0);
         bool is_volume_sensor = strcmp(sensors[i], "volume") == 0;
 
-        snprintf(topic, sizeof(topic), "%s/%ssensor/%s/%s_%s/config",
+        snprintf(topic, sizeof(topic), "%s/%ssensor/%s_%s/%s/config",
             autodiscovery_prefix, is_binary_sensor ? "binary_" : "",
-            model, device_name, sensors[i]);
+            model, device_id_no_colons, sensors[i]);
 
         snprintf(id_string, sizeof(id_string), "%s_%s_%s", model, device_name, sensors[i]);
 

--- a/mqtt.c
+++ b/mqtt.c
@@ -100,6 +100,7 @@ void on_connect(struct mosquitto *mosq, __attribute__((unused)) void *userdata,
 // function to send autodiscovery messages for Home Assistant
 void send_autodiscovery_messages(struct mosquitto *mosq) {
     const char *device_name = config.service_name;
+    const char *device_id = config.airplay_device_id ? config.airplay_device_id : config.service_name;
     const char *sw_version = get_version_string();
     const char *model = "shairport-sync";
     const char *model_friendly = "Shairport Sync";
@@ -120,7 +121,7 @@ void send_autodiscovery_messages(struct mosquitto *mosq) {
             "\"sw_version\": \"%s\","
             "\"manufacturer\": \"%s\""
         "}",
-        model, device_name, model_friendly, sw_version, manufacturer);
+        device_id, device_name, model_friendly, sw_version, manufacturer);
 
     // when adding sensors here, be sure to also update sensor_names and icons below!
     const char *sensors[] = {

--- a/mqtt.c
+++ b/mqtt.c
@@ -21,6 +21,10 @@ struct mosquitto *global_mosq = NULL;
 char *topic = NULL;
 int connected = 0;
 
+// track active/playing state
+int is_active = 0;
+int is_playing = 0;
+
 // mosquitto logging
 void _cb_log(__attribute__((unused)) struct mosquitto *mosq, __attribute__((unused)) void *userdata,
              int level, const char *str) {
@@ -167,12 +171,16 @@ void mqtt_process_metadata(uint32_t type, uint32_t code, char *data, uint32_t le
     } else if (type == 'ssnc') {
       switch (code) {
       case 'abeg':
+        is_active = 1;
+        mqtt_publish("is_active", "1", 1);
         mqtt_publish("active_start", data, length);
         break;
       case 'acre':
         mqtt_publish("active_remote_id", data, length);
         break;
       case 'aend':
+        is_active = 0;
+        mqtt_publish("is_active", "0", 1);
         mqtt_publish("active_end", data, length);
         break;
       case 'asal':
@@ -210,9 +218,13 @@ void mqtt_process_metadata(uint32_t type, uint32_t code, char *data, uint32_t le
         mqtt_publish("output_frame_rate", data, length);
         break;
       case 'pbeg':
+        is_playing = 1;
+        mqtt_publish("is_playing", "1", 1);
         mqtt_publish("play_start", data, length);
         break;
       case 'pend':
+        is_playing = 0;
+        mqtt_publish("is_playing", "0", 1);
         mqtt_publish("play_end", data, length);
         break;
       case 'pfls':
@@ -224,6 +236,8 @@ void mqtt_process_metadata(uint32_t type, uint32_t code, char *data, uint32_t le
         }
         break;
       case 'prsm':
+        is_playing = 1;
+        mqtt_publish("is_playing", "1", 1);
         mqtt_publish("play_resume", data, length);
         break;
       case 'pvol':

--- a/mqtt.h
+++ b/mqtt.h
@@ -7,6 +7,7 @@ int initialise_mqtt();
 void mqtt_process_metadata(uint32_t type, uint32_t code, char *data, uint32_t length);
 void mqtt_publish(char *topic, char *data, uint32_t length);
 void mqtt_setup();
+void send_autodiscovery_messages(struct mosquitto *mosq);
 void on_connect(struct mosquitto *mosq, void *userdata, int rc);
 void on_disconnect(struct mosquitto *mosq, void *userdata, int rc);
 void on_message(struct mosquitto *mosq, void *userdata, const struct mosquitto_message *msg);

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -285,6 +285,8 @@ mqtt =
 //	Currently published topics:artist,album,title,genre,format,songalbum,volume,client_ip,
 //	Additionally, messages at the topics play_start,play_end,play_flush,play_resume are published
 //	publish_cover = "no"; //whether to publish the cover over mqtt in binary form. This may lead to a bit of load on the broker
+//  enable_autodiscovery = "no"; //whether to publish an autodiscovery message to automatically appear in Home Assistant
+//  autodiscovery_prefix = "homeassistant"; //string to prepend to autodiscovery topic
 //	enable_remote = "no"; //whether to remote control via MQTT. RC is available under `topic`/remote.
 //	Available commands are "command", "beginff", "beginrew", "mutetoggle", "nextitem", "previtem", "pause", "playpause", "play", "stop", "playresume", "shuffle_songs", "volumedown", "volumeup"
 };

--- a/shairport.c
+++ b/shairport.c
@@ -1300,6 +1300,10 @@ int parse_options(int argc, char **argv) {
     if (config.mqtt_publish_cover && !config.get_coverart) {
       die("You need to have metadata.include_cover_art enabled in order to use mqtt.publish_cover");
     }
+    config_set_lookup_bool(config.cfg, "mqtt.enable_autodiscovery", &config.mqtt_enable_autodiscovery);
+    if (config_lookup_string(config.cfg, "mqtt.autodiscovery_prefix", &str)) {
+      config.mqtt_autodiscovery_prefix = (char *)str;
+    }
     config_set_lookup_bool(config.cfg, "mqtt.enable_remote", &config.mqtt_enable_remote);
     if (config_lookup_string(config.cfg, "mqtt.empty_payload_substitute", &str)) {
       if (strlen(str) == 0)
@@ -2550,6 +2554,7 @@ int main(int argc, char **argv) {
   debug(1, "mqtt will%s publish parsed metadata.", config.mqtt_publish_parsed ? "" : " not");
   debug(1, "mqtt will%s publish cover Art.", config.mqtt_publish_cover ? "" : " not");
   debug(1, "mqtt remote control is %sabled.", config.mqtt_enable_remote ? "en" : "dis");
+  debug(1, "mqtt autodiscovery is %sabled.", config.mqtt_enable_autodiscovery ? "en" : "dis");
 #endif
 
 #ifdef CONFIG_CONVOLUTION


### PR DESCRIPTION
This PR introduces support for MQTT auto-discovery in Home Assistant, making it easier for users to integrate shairport-sync without needing manual configuration. The feature is off by default but can be enabled through the following configuration:

```
mqtt = {
    enable_autodiscovery = "yes"; // default is "no"
    autodiscovery_prefix = "homeassistant"; // this is the default
}
```

In addition, I’ve added `active` and `playing` MQTT messages that publish a boolean state (0 or 1), representing whether shairport-sync is active or playing. This approach simplifies state tracking compared to the existing `active_start`, `active_end`, and `play_resume` events (which remain unchanged to avoid breaking compatibility).

I’ve tested these changes over the past 6 months in my home setup with three shairport-sync instances, and they’ve proven to be reliable.

I believe this feature will be useful for other users running Home Assistant and look forward to your feedback!