### PR TITLE
Fix "daemon" typos

### DIFF
--- a/CONFIGURATION FLAGS.md
+++ b/CONFIGURATION FLAGS.md
@@ -115,7 +115,7 @@ A [daemon](https://en.wikipedia.org/wiki/Daemon_(computing)) is a computer progr
 FreeBSD and most recent Linux distributions can run an application as a daemon without special modifications. However, in certain older distributions and in special cases it may be necessary to enable Shairport Sync to daemonise itself. Use the `--with-libdaemon` configuration option:
 
 - `--with-libdaemon` Includes a demonising library needed if you want Shairport Sync to demonise itself with the `-d` option. Not needed for `systemd`-based systems which demonise programs differently.
-- `--with-piddir=<pathname>` Specifies a pathname to a directory in which to write the PID file which is created when Shairport Sync daemonises itself and used to locate the deamon process to be killed with the `-k` command line option.
+- `--with-piddir=<pathname>` Specifies a pathname to a directory in which to write the PID file which is created when Shairport Sync daemonises itself and used to locate the daemon process to be killed with the `-k` command line option.
 
 ### Automatic Start
 | Flags |

--- a/shairport.c
+++ b/shairport.c
@@ -2165,7 +2165,7 @@ int main(int argc, char **argv) {
 #ifdef CONFIG_LIBDAEMON
   /* If we are going to daemonise, check that the daemon is not running already.*/
   if ((config.daemonise) && ((pid = daemon_pid_file_is_running()) >= 0)) {
-    warn("The %s deamon is already running with process ID (PID) %u.", config.appName, pid);
+    warn("The %s daemon is already running with process ID (PID) %u.", config.appName, pid);
     // daemon_log(LOG_ERR, "The %s daemon is already running as PID %u", config.appName, pid);
     return 1;
   }


### PR DESCRIPTION
A couple more typos of "daemon" (currently: "deamon").