### PR TITLE
Change tags for airplay2 build to use docker_image_name instead of mikebrady/sps-private

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   main:
+    environment: development
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -82,8 +82,8 @@ jobs:
           platforms: ${{ env.DOCKER_PLATFORMS }}
           push: true
           tags: |
-            mikebrady/sps-private:${{ env.GIT_TAG }}
-            mikebrady/sps-private:latest
+            ${{ secrets.DOCKER_IMAGE_NAME }}:${{ env.GIT_TAG }}
+            ${{ env.LATEST_TAG == 'true' && format('{0}:latest', secrets.DOCKER_IMAGE_NAME) || '' }}
           build-args: |
             SHAIRPORT_SYNC_BRANCH=${{ env.SHAIRPORT_SYNC_BRANCH }}
             NQPTP_BRANCH=${{ env.NQPTP_BRANCH }}


### PR DESCRIPTION
This seems to be the right tag at least it was in the other github workflows ;).