### PR TITLE
Add support for Sun/NetBSD audio.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -95,6 +95,10 @@ if USE_SNDIO
 shairport_sync_SOURCES += audio_sndio.c
 endif
 
+if USE_SUN
+shairport_sync_SOURCES += audio_sun.c
+endif
+
 if USE_STDOUT
 shairport_sync_SOURCES += audio_stdout.c
 endif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Shairport Sync
-Shairport Sync is an [AirPlay](https://www.pocket-lint.com/speakers/news/apple/144646-apple-airplay-2-vs-airplay-what-s-the-difference) audio player for Linux, FreeBSD and OpenBSD. It plays audio streamed from Apple devices and from AirPlay sources such as [OwnTone](https://github.com/owntone/owntone-server) (formerly `forked-daapd`).
+Shairport Sync is an [AirPlay](https://www.pocket-lint.com/speakers/news/apple/144646-apple-airplay-2-vs-airplay-what-s-the-difference) audio player for Linux, FreeBSD, NetBSD, and OpenBSD. It plays audio streamed from Apple devices and from AirPlay sources such as [OwnTone](https://github.com/owntone/owntone-server) (formerly `forked-daapd`).
 
 Shairport Sync can be built as an AirPlay 2 player (with [some limitations](AIRPLAY2.md#features-and-limitations)) or as "classic" Shairport Sync – a player for the older, but still supported, AirPlay (aka "AirPlay 1") protocol.
 
@@ -31,9 +31,9 @@ Some features require configuration at build time – see [CONFIGURATION FLAGS.m
 # Status
 Shairport Sync was designed to [run best](ADVANCED%20TOPICS/GetTheBest.md) on stable, dedicated, stand-alone low-power "headless" systems with ALSA as the audio system and with a decent CD-quality Digital to Analog Converter (DAC).
 
-Shairport Sync runs on recent (2018 onwards) Linux systems, FreeBSD from 12.1 onwards and OpenBSD. It requires a system with the power of a Raspberry Pi B or better.
+Shairport Sync runs on recent (2018 onwards) Linux systems, FreeBSD from 12.1 onwards, NetBSD, and OpenBSD. It requires a system with the power of a Raspberry Pi B or better.
 
-Classic Shairport Sync runs on a wider variety of Linux sytems, including OpenWrt and Cygwin and it also runs on OpenBSD. Many embedded devices are powerful enough to power classic Shairport Sync.
+Classic Shairport Sync runs on a wider variety of Linux systems, including OpenWrt and Cygwin and it also runs on NetBSD and OpenBSD. Many embedded devices are powerful enough to power classic Shairport Sync.
 
 # Heritage and Acknowledgements
 The functionality offered by Shairport Sync is the result of study and analysis of the AirPlay and AirPlay 2 protocols by many people over the years. These protocols have not been officially published, and there is no assurance that Shairport Sync will continue to work in future.

--- a/audio.c
+++ b/audio.c
@@ -38,6 +38,9 @@ extern audio_output audio_jack;
 #ifdef CONFIG_SNDIO
 extern audio_output audio_sndio;
 #endif
+#ifdef CONFIG_SUN
+extern audio_output audio_sun;
+#endif
 #ifdef CONFIG_AO
 extern audio_output audio_ao;
 #endif
@@ -69,6 +72,9 @@ static audio_output *outputs[] = {
 #endif
 #ifdef CONFIG_SNDIO
     &audio_sndio,
+#endif
+#ifdef CONFIG_SUN
+    &audio_sun,
 #endif
 #ifdef CONFIG_PIPEWIRE
     &audio_pw,

--- a/audio_sun.c
+++ b/audio_sun.c
@@ -1,0 +1,258 @@
+/*
+ * sun output driver. This file is part of Shairport Sync.
+ * Copyright (c) 2013 Dimitri Sokolyuk <demon@dim13.org>
+ * Copyright (c) 2017 Tobias Kortkamp <t@tobik.me>
+ * Copyright (c) 2021 Nia Alarie <nia@NetBSD.org>
+ *
+ * Modifications for audio synchronisation
+ * and related work, copyright (c) Mike Brady 2014 -- 2017
+ * All rights reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "audio.h"
+#include "common.h"
+#include <pthread.h>
+#include <sys/audioio.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#ifdef __sun
+#include <sys/conf.h>
+#include <stropts.h>
+#endif
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+static void help(void);
+static int init(int, char **);
+static void deinit(void);
+static void start(int, int);
+static int play(void *, int);
+static void stop(void);
+static int delay(long *);
+static void flush(void);
+
+audio_output audio_sun = {.name = "sun",
+                            .help = &help,
+                            .init = &init,
+                            .deinit = &deinit,
+                            .prepare = NULL,
+                            .start = &start,
+                            .stop = &stop,
+                            .is_running = NULL,
+                            .flush = &flush,
+                            .delay = &delay,
+                            .play = &play,
+                            .volume = NULL,
+                            .parameters = NULL,
+                            .mute = NULL};
+
+static pthread_mutex_t sun_mutex = PTHREAD_MUTEX_INITIALIZER;
+static int framesize;
+static int fd;
+
+struct sun_format {
+  const char *name;
+  sps_format_t fmt;
+  unsigned int encoding;
+  unsigned int precision;
+};
+
+/* SunOS compatibility defines for NetBSD extensions. */
+
+#ifndef AUDIO_ENCODING_SLINEAR
+#define AUDIO_ENCODING_SLINEAR AUDIO_ENCODING_LINEAR
+#endif
+
+#ifndef AUDIO_ENCODING_ULINEAR
+#define AUDIO_ENCODING_ULINEAR AUDIO_ENCODING_LINEAR8
+#endif
+
+#ifndef AUDIO_ENCODING_SLINEAR_LE
+#define AUDIO_ENCODING_SLINEAR_LE AUDIO_ENCODING_LINEAR
+#endif
+
+#ifndef AUDIO_ENCODING_SLINEAR_BE
+#define AUDIO_ENCODING_SLINEAR_BE AUDIO_ENCODING_LINEAR
+#endif
+
+#ifndef AUDIO_GETBUFINFO
+#define AUDIO_GETBUFINFO AUDIO_GETINFO
+#endif
+
+#ifndef DEFAULT_DEV
+#define DEFAULT_DEV "/dev/audio"
+#endif
+
+static struct sun_format formats[] = {{"U8", SPS_FORMAT_U8, AUDIO_ENCODING_ULINEAR, 8},
+                                         {"S8", SPS_FORMAT_S8, AUDIO_ENCODING_SLINEAR, 16},
+                                         {"S16", SPS_FORMAT_S16, AUDIO_ENCODING_SLINEAR, 16},
+                                         {"S16_LE", SPS_FORMAT_S16_LE, AUDIO_ENCODING_SLINEAR_LE, 16},
+                                         {"S16_BE", SPS_FORMAT_S16_BE, AUDIO_ENCODING_SLINEAR_BE, 16},
+                                         {"S32", SPS_FORMAT_S16, AUDIO_ENCODING_SLINEAR, 32},
+                                         {"S32_LE", SPS_FORMAT_S32_LE, AUDIO_ENCODING_SLINEAR_LE, 32},
+                                         {"S32_BE", SPS_FORMAT_S32_BE, AUDIO_ENCODING_SLINEAR_BE, 32}};
+
+static void help() { printf("    -d output-device    set the output device [default*|...]\n"); }
+
+static int init(int argc, char **argv) {
+  struct audio_info info;
+  int found, opt;
+  unsigned int i;
+  const char *devname, *tmp;
+
+  // set up default values first
+
+  AUDIO_INITINFO(&info);
+  info.play.encoding = AUDIO_ENCODING_SLINEAR_LE;
+  info.play.sample_rate = 44100;
+  info.play.channels = 2;
+  info.play.precision = 16;
+
+  devname = DEFAULT_DEV;
+
+  config.audio_backend_buffer_desired_length = 1.0;
+  config.audio_backend_buffer_interpolation_threshold_in_seconds =
+      0.25; // below this, soxr interpolation will not occur -- it'll be basic interpolation
+            // instead.
+  config.audio_backend_latency_offset = 0;
+
+  // get settings from settings file
+
+  // do the "general" audio  options. Note, these options are in the "general" stanza!
+  parse_general_audio_options();
+
+  // get the specific settings
+
+  if (config.cfg != NULL) {
+    if (!config_lookup_string(config.cfg, "sun.device", &devname))
+      devname = DEFAULT_DEV;
+    if (config_lookup_string(config.cfg, "sun.format", &tmp)) {
+      for (i = 0, found = 0; i < sizeof(formats) / sizeof(formats[0]); i++) {
+        if (strcasecmp(formats[i].name, tmp) == 0) {
+          config.output_format = formats[i].fmt;
+          info.play.encoding = formats[i].encoding;
+          info.play.precision = formats[i].precision;
+          found = 1;
+          break;
+        }
+      }
+      if (!found)
+        die("Invalid output format \"%s\". Should be one of: U8, S8, S16, S16_LE, S16_BE, S32, S32_LE, S32_BE",
+            tmp);
+    }
+  }
+  optind = 1; // optind=0 is equivalent to optind=1 plus special behaviour
+  argv--;     // so we shift the arguments to satisfy getopt()
+  argc++;
+  while ((opt = getopt(argc, argv, "d:")) > 0) {
+    switch (opt) {
+    case 'd':
+      devname = optarg;
+      break;
+    default:
+      help();
+      die("Invalid audio option -%c specified", opt);
+    }
+  }
+  if (optind < argc)
+    die("Invalid audio argument: %s", argv[optind]);
+
+  pthread_mutex_lock(&sun_mutex);
+  debug(1, "Output device name is \"%s\".", devname);
+  fd = open(devname, O_WRONLY);
+  if (fd < 0)
+    die("sun: cannot open audio device");
+
+  if (ioctl(fd, AUDIO_SETINFO, &info) < 0)
+    die("sun: failed to set audio parameters");
+  if (ioctl(fd, AUDIO_GETINFO, &info) < 0)
+    die("sun: failed to get audio parameters");
+
+  framesize = (info.play.precision / 8) * info.play.channels;
+  config.output_rate = info.play.sample_rate;
+  config.audio_backend_buffer_desired_length = 1.0 * info.play.buffer_size / info.play.sample_rate;
+  config.audio_backend_latency_offset = 0;
+
+  pthread_mutex_unlock(&sun_mutex);
+  return 0;
+}
+
+static void deinit() {
+  pthread_mutex_lock(&sun_mutex);
+  close(fd);
+  pthread_mutex_unlock(&sun_mutex);
+}
+
+static void start(__attribute__((unused)) int sample_rate,
+                  __attribute__((unused)) int sample_format) {
+  struct audio_info tmpinfo;
+
+  AUDIO_INITINFO(&tmpinfo);
+  tmpinfo.play.pause = false;
+
+  pthread_mutex_lock(&sun_mutex);
+  if (ioctl(fd, AUDIO_SETINFO, &tmpinfo) < 0)
+      die("sun: unable to start");
+  pthread_mutex_unlock(&sun_mutex);
+}
+
+static int play(void *buf, int frames) {
+  if (frames > 0) {
+    pthread_mutex_lock(&sun_mutex);
+    if (write(fd, buf, frames * framesize) < 0)
+      die("sun: unable to write");
+    pthread_mutex_unlock(&sun_mutex);
+  }
+  return 0;
+}
+
+static void stop() {
+  struct audio_info tmpinfo;
+
+  AUDIO_INITINFO(&tmpinfo);
+  tmpinfo.play.pause = true;
+
+  pthread_mutex_lock(&sun_mutex);
+  (void)ioctl(fd, AUDIO_DRAIN, NULL);
+  if (ioctl(fd, AUDIO_SETINFO, &tmpinfo) < 0)
+      die("sun: unable to stop");
+  pthread_mutex_unlock(&sun_mutex);
+}
+
+static int delay(long *_delay) {
+  struct audio_info tmpinfo;
+
+  pthread_mutex_lock(&sun_mutex);
+  if (ioctl(fd, AUDIO_GETBUFINFO, &tmpinfo) < 0)
+    die("sun: unable to get audio buffer info");
+  *_delay = tmpinfo.play.seek / framesize;
+  pthread_mutex_unlock(&sun_mutex);
+  return 0;
+}
+
+static void flush() {
+  pthread_mutex_lock(&sun_mutex);
+#ifdef AUDIO_FLUSH
+  if (ioctl(fd, AUDIO_FLUSH, NULL) < 0)
+    die("sun: unable to flush");
+#else
+  if (ioctl(fd, I_FLUSH, FLUSHW) < 0)
+    die("sun: unable to flush");
+#endif
+  pthread_mutex_unlock(&sun_mutex);
+}

--- a/common.c
+++ b/common.c
@@ -2182,6 +2182,9 @@ char *get_version_string() {
 #ifdef CONFIG_SNDIO
     strcat(version_string, "-sndio");
 #endif
+#ifdef CONFIG_SUN
+    strcat(version_string, "-sun");
+#endif
 #ifdef CONFIG_JACK
     strcat(version_string, "-jack");
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -278,6 +278,14 @@ if test "x$with_sndio" = "xyes" ; then
 fi
 AM_CONDITIONAL([USE_SNDIO], [test "x$with_sndio" = "xyes"])
 
+# Look for SUN flag
+AC_ARG_WITH(sun, [AS_HELP_STRING([--with-sun],[choose Sun/NetBSD audio API support])])
+if test "x$with_sun" = "xyes" ; then
+  AC_DEFINE([CONFIG_SUN], 1, [Include a Sun-compatible audio backend.])
+  AC_CHECK_HEADER([sys/audioio.h], , AC_MSG_ERROR(Sun audio support requires the sys/audioio.h header))
+fi
+AM_CONDITIONAL([USE_SUN], [test "x$with_sun" = "xyes"])
+
 # Look for AO flag
 AC_ARG_WITH(ao, [AS_HELP_STRING([--with-ao],[choose AO (Audio Output?) API support. N.B. no synchronisation -- so underflow or overflow is inevitable!])])
 if test "x$with_ao" = "xyes" ; then


### PR DESCRIPTION
Hi!

shairport-sync is in pkgsrc, I've just committed an update to 4.3.7, and in so doing I noticed that the NetBSD audio support has not yet been sent upstream.

The best attribution I know of for this work is the committer and date of [the pkgsrc commit where shairport-sync was added](https://github.com/NetBSD/pkgsrc/commit/3500d96c8c5100e2ad4ed2f06acf78461a74cd9a), so I've made this commit match that one.