### PR TITLE
Add ENABLE_AVAHI env var to control dbus/avahi usage in container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,8 +92,9 @@ COPY --from=shairport-sync /shairport-sync/build/install/etc/dbus-1/system.d/sha
 # Shairport Sync Runtime System
 FROM crazymax/alpine-s6:3.20-3.2.0.2
 
-ENV S6_CMD_WAIT_FOR_SERVICES=1
-ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
+ENV S6_CMD_WAIT_FOR_SERVICES=1 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    ENABLE_AVAHI=1
 
 RUN apk -U add \
         alsa-lib \

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -10,12 +10,15 @@ services:
     #  PULSE_SERVER: unix:/tmp/pulseaudio.socket # Path for PulseAudio socket
     #  PULSE_COOKIE: /tmp/pulseaudio.cookie # Path for PulseAudio cookie
     #  XDG_RUNTIME_DIR: /tmp # Path for pipewire
+    #  ENABLE_AVAHI: 0 # Disable DBus and Avahi daemon inside the container
     devices:
       - "/dev/snd" # ALSA device, omit if using PulseAudio
     # volumes:
     #   - ./volumes/shairport-sync/shairport-sync.conf:/etc/shairport-sync.conf # Customised Shairport Sync configuration file.
     #   - /run/user/1000/pulse/native:/tmp/pulseaudio.socket # PulseAudio socket when using that backend
     #   - /run/user/1000/pipewire-0:/tmp/pipewire-0 # Pipewire socket when using pipewire
+    #   - /var/run/dbus:/var/run/dbus # DBus when ENABLE_AVAHI set to 0
+    #   - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket # Avahi socket when ENABLE_AVAHI set to 0
     # command: -o pw # You can specify the desired output with command:
     logging:
       options:

--- a/docker/etc/s6-overlay/s6-rc.d/02-dbus/run
+++ b/docker/etc/s6-overlay/s6-rc.d/02-dbus/run
@@ -1,7 +1,9 @@
 #!/command/with-contenv sh
 
-# Set the limit to the same value Docker has been using in earlier version.
-ulimit -n 1048576
-
-echo "Starting dbus"
-exec s6-notifyoncheck  dbus-daemon --system --nofork --nopidfile
+if [ "$ENABLE_AVAHI" = "1" ]; then
+  echo "Starting dbus-daemon"
+  exec s6-notifyoncheck dbus-daemon --system --nofork --nopidfile
+else
+  echo "Avahi disabled, not starting dbus-daemon"
+  exec s6-notifyoncheck sleep infinity
+fi

--- a/docker/etc/s6-overlay/s6-rc.d/03-avahi/run
+++ b/docker/etc/s6-overlay/s6-rc.d/03-avahi/run
@@ -1,3 +1,12 @@
 #!/command/with-contenv sh
-echo "Starting avahi"
-exec s6-notifyoncheck avahi-daemon --no-chroot
+
+if [ "$ENABLE_AVAHI" = "1" ]; then
+  until [ -e /var/run/dbus/system_bus_socket ]; do
+    sleep 1s
+  done
+  echo "Starting Avahi daemon"
+  exec s6-notifyoncheck avahi-daemon --no-chroot
+else
+  echo "Avahi disabled, not starting avahi-daemon"
+  exec s6-notifyoncheck sleep infinity
+fi


### PR DESCRIPTION
ENABLE_AVAHI decides whether dbus and avahi daemons run inside the container or if the host's instances are reused. When set to 0, /var/run/dbus and /var/run/avahi-daemon/socket must be bind-mounted by the user from the host into the container.

It's similar to what is done in homebridge: https://github.com/homebridge/docker-homebridge/blob/latest/rootfs/etc/s6-overlay/s6-rc.d/avahi/run