### PR TITLE
Add ENABLE_AVAHI env var to control dbus/avahi usage in container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -165,5 +165,5 @@ RUN apk -U add \
 # Added the shairport-sync user to the pre-existing audio group, which has ID 29, for access to the ALSA stuff
 
 COPY --from=files / /
-
+ENV ENABLE_AVAHI=1
 ENTRYPOINT ["./run.sh"]

--- a/docker/classic/Dockerfile
+++ b/docker/classic/Dockerfile
@@ -139,5 +139,5 @@ RUN apk --no-cache add \
 # Added the shairport-sync user to the pre-existing audio group, which has ID 29, for access to the ALSA stuff
 
 COPY --from=files / /
-
+ENV ENABLE_AVAHI=1
 ENTRYPOINT ["./run.sh"]

--- a/docker/classic/run.sh
+++ b/docker/classic/run.sh
@@ -3,13 +3,14 @@
 # exist if any command returns a non-zero result
 set -e
 
-rm -rf /run/dbus/dbus.pid
-rm -rf /run/avahi-daemon/pid
+if [ -z ${ENABLE_AVAHI+x} ] || [ $ENABLE_AVAHI -eq 0 ]; then
+  rm -rf /run/dbus/dbus.pid
+  rm -rf /run/avahi-daemon/pid
 
 dbus-uuidgen --ensure
 dbus-daemon --system
 
-avahi-daemon --daemonize --no-chroot
+[ -z ${ENABLE_AVAHI+x} ] || [ $ENABLE_AVAHI -eq 0 ] || avahi-daemon --daemonize --no-chroot
 
 while [ ! -f /var/run/avahi-daemon/pid ]; do
   echo "Warning: avahi is not running, sleeping for 1 second before trying to start shairport-sync"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -10,12 +10,15 @@ services:
     #  PULSE_SERVER: unix:/tmp/pulseaudio.socket # Path for PulseAudio socket
     #  PULSE_COOKIE: /tmp/pulseaudio.cookie # Path for PulseAudio cookie
     #  XDG_RUNTIME_DIR: /tmp # Path for pipewire
+    #  ENABLE_AVAHI: 0 # Disable DBus and Avahi daemon inside the container
     devices:
       - "/dev/snd" # ALSA device, omit if using PulseAudio
     # volumes:
     #   - ./volumes/shairport-sync/shairport-sync.conf:/etc/shairport-sync.conf # Customised Shairport Sync configuration file.
     #   - /run/user/1000/pulse/native:/tmp/pulseaudio.socket # PulseAudio socket when using that backend
     #   - /run/user/1000/pipewire-0:/tmp/pipewire-0 # Pipewire socket when using pipewire
+    #   - /var/run/dbus:/var/run/dbus # DBus when ENABLE_AVAHI set to 0
+    #   - /var/run/avahi-daemon:/var/run/avahi-daemon # Avahi socket when ENABLE_AVAHI set to 0
     # command: -o pw # You can specify the desired output with command:
     logging:
       options:

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -3,15 +3,17 @@
 # exist if any command returns a non-zero result
 set -e
 
-rm -rf /run/dbus/dbus.pid
-rm -rf /run/avahi-daemon/pid
+if [ -z ${ENABLE_AVAHI+x} ] || [ $ENABLE_AVAHI -eq 0 ]; then
+  rm -rf /run/dbus/dbus.pid
+  rm -rf /run/avahi-daemon/pid
 
-dbus-uuidgen --ensure
-dbus-daemon --system
+  dbus-uuidgen --ensure
+  dbus-daemon --system
+fi
 
 (/usr/local/bin/nqptp > /dev/null 2>&1) &
 
-avahi-daemon --daemonize --no-chroot
+[ -z ${ENABLE_AVAHI+x} ] || [ $ENABLE_AVAHI -eq 0 ] || avahi-daemon --daemonize --no-chroot
 
 while [ ! -f /var/run/avahi-daemon/pid ]; do
   echo "Warning: avahi is not running, sleeping for 1 second before trying to start shairport-sync"


### PR DESCRIPTION
ENABLE_AVAHI decides whether dbus and avahi daemons run inside the container or if the host's instances are reused. When set to 0, /var/run/dbus and /var/run/avahi-daemon/socket must be bind-mounted by the user from the host into the container.

Corrected version of pull request #2067
