### PR TITLE
audio_pa.c: pa_delay, return "No latency data yet" on PA_ERR_NODATA

### DIFF
--- a/audio_pa.c
+++ b/audio_pa.c
@@ -648,7 +648,7 @@ int pa_delay(long *the_delay) {
   pa_threaded_mainloop_lock(mainloop);
   int gl = pa_stream_get_latency(stream, &latency, &negative);
   pa_threaded_mainloop_unlock(mainloop);
-  if (gl == PA_ERR_NODATA) {
+  if (gl == -PA_ERR_NODATA) {
     reply = -ENODEV;
   } else if (gl != 0) {
     reply = -EIO;


### PR DESCRIPTION
Hey, thank you for shareport sync!

(re-targetted / cherry-picked https://github.com/mikebrady/shairport-sync/pull/2113 
the commented out logging is from master, but the fix is the same)

when running with pa pulse audio backend,
i get was getting `0.000014998 "player.c:2713" Delay error -5 when checking running latency.`

if uncommenting
```
audio_pa.c: pa_delay()
} else if (gl != 0) {
    // debug(1,"Error %d getting latency.",gl);
    reply = -EIO; // -5
```

the error was
```
0.000014998 "player.c:2713" Delay error -5 when checking running latency.
0.000020518 "audio_pa.c:317" Error -16 getting latency.
```

seems we should be getting into 
```
if (gl == PA_ERR_NODATA) { 
    // debug(1, "No latency data yet.");
    reply = -ENODEV;
  }
```

PA_ERR_NODATA seems to be positive 16
https://freedesktop.org/software/pulseaudio/doxygen/def_8h_source.html

but pulse returns "-" 16 and we miss the branch.
this pr fixes it. 