### PR TITLE
Updated systemd unit file for more flexibility

### DIFF
--- a/scripts/shairport-sync.service.in
+++ b/scripts/shairport-sync.service.in
@@ -1,13 +1,10 @@
 [Unit]
 Description=Shairport Sync - AirPlay Audio Receiver
-After=sound.target
-Wants=network-online.target
-After=network.target network-online.target
+After=sound.target network.target
+Wants=network.target
 
 [Service]
-ExecStart=@prefix@/bin/shairport-sync --log-to-syslog
-User=shairport-sync
-Group=shairport-sync
+ExecStart=@prefix@/bin/shairport-sync
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I'm using shaiport on a Yocto-generated system. 

- Sometimes network is not available at boot, so shairport shouldn't depend on it. 
- Logs to syslog is already default, removing it from unit allows to override it in the conf file
- User shairport-sync doesn't always exists