### PR TITLE
Add MQTT retain flag support

### DIFF
--- a/MQTT.md
+++ b/MQTT.md
@@ -48,6 +48,7 @@ mqtt =
 //	publish_raw = "no"; // Whether to publish all available metadata under the codes given in the 'metadata' docs.
 	publish_parsed = "yes"; // Whether to publish a small (but useful) subset of metadata under human-understandable topics.
 	publish_cover = "yes"; // Whether to publish the cover over MQTT in binary form. This may lead to a bit of load on the broker.
+//	publish_retain = "no"; // Whether to set the retain flag on published MQTT messages. When enabled, the broker stores the last message for each topic so new subscribers receive the most recent value immediately.
 //	enable_remote = "no"; // Whether to remote control via MQTT. RC is available under `topic`/remote.
 };
 ```

--- a/common.h
+++ b/common.h
@@ -230,6 +230,7 @@ typedef struct {
   int mqtt_publish_raw;
   int mqtt_publish_parsed;
   int mqtt_publish_cover;
+  int mqtt_publish_retain;
   int mqtt_enable_remote;
   int mqtt_enable_autodiscovery;
   char *mqtt_autodiscovery_prefix;

--- a/mqtt.c
+++ b/mqtt.c
@@ -243,7 +243,8 @@ void mqtt_publish(char *topic, char *data_in, uint32_t length_in) {
   debug(2, "[MQTT]: publishing under %s", fulltopic);
 
   int rc;
-  if ((rc = mosquitto_publish(global_mosq, NULL, fulltopic, length, data, 0, 0)) !=
+  if ((rc = mosquitto_publish(global_mosq, NULL, fulltopic, length, data, 0,
+                              config.mqtt_publish_retain)) !=
       MOSQ_ERR_SUCCESS) {
     switch (rc) {
     case MOSQ_ERR_NO_CONN:

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -364,6 +364,7 @@ mqtt =
 //	Currently published topics:artist,album,title,genre,format,songalbum,volume,client_ip,
 //	Additionally, messages at the topics play_start,play_end,play_flush,play_resume are published
 //	publish_cover = "no"; //whether to publish the cover over mqtt in binary form. This may lead to a bit of load on the broker
+//	publish_retain = "no"; //whether to set the retain flag on published MQTT messages. When enabled, the broker stores the last message for each topic.
 //	enable_autodiscovery = "no"; //whether to publish an autodiscovery message to automatically appear in Home Assistant
 //	autodiscovery_prefix = "homeassistant"; //string to prepend to autodiscovery topic
 //	enable_remote = "no"; //whether to remote control via MQTT. RC is available under `topic`/remote.

--- a/shairport.c
+++ b/shairport.c
@@ -1440,6 +1440,7 @@ int parse_options(int argc, char **argv) {
     config_set_lookup_bool(config.cfg, "mqtt.publish_raw", &config.mqtt_publish_raw);
     config_set_lookup_bool(config.cfg, "mqtt.publish_parsed", &config.mqtt_publish_parsed);
     config_set_lookup_bool(config.cfg, "mqtt.publish_cover", &config.mqtt_publish_cover);
+    config_set_lookup_bool(config.cfg, "mqtt.publish_retain", &config.mqtt_publish_retain);
     if (config.mqtt_publish_cover && !config.get_coverart) {
       die("You need to have metadata.include_cover_art enabled in order to use mqtt.publish_cover");
     }
@@ -3131,6 +3132,8 @@ int main(int argc, char **argv) {
         config.mqtt_publish_parsed ? "" : " not");
   debug(option_print_level, "mqtt will%s publish cover Art.",
         config.mqtt_publish_cover ? "" : " not");
+  debug(option_print_level, "mqtt will%s set retain flag.",
+        config.mqtt_publish_retain ? "" : " not");
   debug(option_print_level, "mqtt remote control is %sabled.",
         config.mqtt_enable_remote ? "en" : "dis");
   debug(option_print_level, "mqtt autodiscovery is %sabled.",


### PR DESCRIPTION
#2141 but targeting development branch. 

This PR adds a new `publish_retain` boolean option to the `mqtt` config section. 
When enabled, published MQTT messages will have the retain flag set, so the broker stores the last message per topic and new subscribers receive the most recent value immediately.