### PR TITLE
fix handling of missing const type qualifier

### DIFF
--- a/mdns_avahi.c
+++ b/mdns_avahi.c
@@ -109,7 +109,7 @@ static void resolve_callback(AvahiServiceResolver *r, AVAHI_GCC_UNUSED AvahiIfIn
     //    char a[AVAHI_ADDRESS_STR_MAX], *t;
     debug(3, "resolve_callback: Service '%s' of type '%s' in domain '%s':", name, type, domain);
     if (dbs->dacp_id) {
-      char *dacpid = strstr(name, "iTunes_Ctrl_");
+      const char *dacpid = strstr(name, "iTunes_Ctrl_");
       if (dacpid) {
         dacpid += strlen("iTunes_Ctrl_");
         while (*dacpid == '0')


### PR DESCRIPTION
For ISO C23, the function strrchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

Update to const type for variable, as returned string is only used in comparisons which const can be used

fixes:
```c

../mdns_avahi.c: In function 'resolve_callback':
../mdns_avahi.c:112:22: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  112 |       char *dacpid = strstr(name, "iTunes_Ctrl_");
      |                      ^~~~~~

``` 