### PR TITLE
Fix systemd unit options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -228,8 +228,8 @@ if test "x$with_avahi" = "xyes" ; then
   AC_DEFINE([CONFIG_AVAHI], 1, [Include Avahi-based mDNS support.])
   AC_CHECK_LIB([avahi-client], [avahi_client_new], , AC_MSG_ERROR(Avahi support requires the avahi-client library!))
   AC_CHECK_LIB([avahi-common],[avahi_strerror], , AC_MSG_ERROR(Avahi support requires the avahi-common library!))
-  systemd_after_args="${systemd_after_args} avahi-daemon.service"
-  systemd_requires_args="${systemd_requires_args} avahi-daemon.service"
+  systemd_after_args="${systemd_after_args}${systemd_after_args:+ }avahi-daemon.service"
+  systemd_requires_args="${systemd_requires_args}${systemd_requires_args:+ }avahi-daemon.service"
 fi
 AM_CONDITIONAL([USE_AVAHI], [test "x$with_avahi" = "xyes"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -443,6 +443,8 @@ if test "x$with_airplay_2" = "xyes" ; then
     )
   ])
   AC_CHECK_LIB([uuid],[uuid_generate], [], [AC_MSG_ERROR([AirPlay 2 support requires the uuid library -- uuid-dev suggested])])
+  systemd_after_args="${systemd_after_args}${systemd_after_args:+ }nqptp.service"
+  systemd_requires_args="${systemd_requires_args}${systemd_requires_args:+ }nqptp.service"
 fi
 AM_CONDITIONAL([USE_AIRPLAY_2], [test "x$with_airplay_2" = "xyes"])
 


### PR DESCRIPTION
## Description

1. Uses POSIX shell [parameter expansion](https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_02) functionality to prevent adding leading space in option values.
2. Adds the missing `nqptp.service` to the `After` and `Requires` options when building for Airplay 2.


## Type of Change

Please delete options that are not relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Build/CI configuration change

## Testing

Please describe the tests you ran to verify your changes:

- [x] Tested on Linux
- [ ] Tested on FreeBSD
- [ ] Tested on OpenBSD
- [x] Tested with AirPlay 2
- [x] Tested with classic AirPlay

**Test Configuration:**
* Hardware/Platform: ASUS Zenbook UX3404VC
* OS Version: Arch Linux
* Build flags used:

```shell
--prefix=/usr
--sysconfdir=/etc
--with-airplay-2
--with-alsa
--with-pipewire
--with-pulseaudio
--with-jack
--with-stdout
--with-pipe
--with-soxr
--with-convolution
--with-metadata
--with-mqtt-client
--with-dbus-interface
--with-mpris-interface
--with-avahi
--with-dns_sd
--with-systemd-startup
--with-ssl=openssl
--with-configfiles
--with-pkg-config
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have tested my changes and verified they work as expected
- [x] I have checked that my PR targets the `development` branch