### PR TITLE
mqtt: promote publish-error log paths to inform() for debuggability

### DIFF
--- a/mqtt.c
+++ b/mqtt.c
@@ -259,10 +259,11 @@ void mqtt_publish(char *topic, char *data_in, uint32_t length_in) {
       MOSQ_ERR_SUCCESS) {
     switch (rc) {
     case MOSQ_ERR_NO_CONN:
-      debug(1, "[MQTT]: Publish failed: not connected to broker");
+      inform("[MQTT]: Publish to topic \"%s\" failed: not connected to broker", fulltopic);
       break;
     default:
-      debug(1, "[MQTT]: Publish failed: unknown error");
+      inform("[MQTT]: Publish to topic \"%s\" failed: %s (rc=%d)", fulltopic,
+             mosquitto_strerror(rc), rc);
       break;
     }
   }


### PR DESCRIPTION
## Summary

The two error branches in `mqtt_publish()` (`mqtt.c:260-267`) log at `debug(1)`, which is invisible at default syslog verbosity. A silently-dropped MQTT publish is the exact failure mode users report as "MQTT just stopped working" with nothing in the logs — no warning, no error, no hint that anything went wrong at the broker boundary. This promotes those two lines to `inform()` so the failure becomes legible without needing to re-run with `-v`.

Two small additions beyond the log-level bump, both motivated by the same "make it useful when it actually fires" goal:

- **Include the target topic** in the message. Without it, a log line saying "publish failed" is ambiguous on a device publishing 10+ topics per track change.
- **Use `mosquitto_strerror(rc)` + numeric `rc`** in the default branch, replacing the previous `"unknown error"` placeholder. `mosquitto_strerror` is a core libmosquitto API available since 1.0, so no new dependency.

## Test plan

- [x] Builds cleanly against `libmosquitto` ≥ 1.0 (no new API surface, `inform()` and `mosquitto_strerror()` are both already used elsewhere in the tree).
- [ ] Verified `inform()` output lands in syslog at default verbosity on a system where the broker is briefly unreachable (easy to reproduce by blocking the broker port with iptables for a few seconds during playback).
- [ ] No behavior change on the happy path: when `mosquitto_publish` returns `MOSQ_ERR_SUCCESS`, the code path is untouched.

No functional change. Purely observability.