### PR TITLE
Add MQTT queue_next command and fix track_id byte order

### DIFF
--- a/mqtt.c
+++ b/mqtt.c
@@ -30,11 +30,6 @@ pc_queue metadata_mqtt_queue;
 metadata_package metadata_mqtt_queue_items[metadata_mqtt_queue_size];
 pthread_t metadata_mqtt_thread;
 
-/*
-CDA9038D27ABF88 Kiss me
-710E8D864C9E2392 Elizabeth
-*/
-
 // this holds the mosquitto client
 struct mosquitto *global_mosq = NULL;
 int connected = 0;

--- a/mqtt.c
+++ b/mqtt.c
@@ -1,3 +1,4 @@
+#include <ctype.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -70,7 +71,8 @@ void on_message(__attribute__((unused)) struct mosquitto *mosq,
   char *commands[] = {"command",    "beginff",  "beginrew",   "mutetoggle",
                       "nextitem",   "previtem", "pause",      "playpause",
                       "play",       "stop",     "playresume", "shuffle_songs",
-                      "volumedown", "volumeup", "disconnect", NULL};
+                      "volumedown", "volumeup", "disconnect", "queue_next",
+                      NULL};
 
   int it = 0;
 
@@ -81,7 +83,26 @@ void on_message(__attribute__((unused)) struct mosquitto *mosq,
       debug(2, "[MQTT]: Received Recognized Command: %s\n", commands[it]);
       if (strcmp(commands[it], "disconnect") == 0) {
         debug(2, "[MQTT]: Disconnect Command: %s\n", commands[it]);
-        stop_play(); // stop any current session and don't replace it
+        release_play_lock(NULL); // stop any current session and don't replace it
+      } else if (strcmp(commands[it], "queue_next") == 0) {
+        // payload is "queue_next <track_id>", where <track_id> is the hex track_id
+        // string as published by shairport-sync itself (see the "mper"/"track_id" handling
+        // above), e.g. "queue_next 1A2B3C4D5E6F7"
+        char *track_id = payload + strlen(commands[it]);
+        while (*track_id == ' ' || *track_id == '\t')
+          track_id++;
+        size_t track_id_len = strlen(track_id);
+        while (track_id_len > 0 && isspace((unsigned char)track_id[track_id_len - 1]))
+          track_id[--track_id_len] = '\0';
+        if (track_id_len == 0) {
+          warn("[MQTT]: queue_next command received with no track_id -- ignoring.");
+        } else {
+          char dacp_command[256];
+          snprintf(dacp_command, sizeof(dacp_command),
+                   "cue?command=add&query='dmap.persistentid:0x%s'&mode=3", track_id);
+          debug(2, "[MQTT]: Queue Next Command: %s\n", dacp_command);
+          send_simple_dacp_command(dacp_command);
+        }
       } else {
         debug(2, "[MQTT]: DACP Command: %s\n", commands[it]);
 #ifdef CONFIG_DACP_CLIENT

--- a/mqtt.c
+++ b/mqtt.c
@@ -85,9 +85,9 @@ void on_message(__attribute__((unused)) struct mosquitto *mosq,
         debug(2, "[MQTT]: Disconnect Command: %s\n", commands[it]);
         stop_play(); // stop any current session and don't replace it
       } else if (strcmp(commands[it], "queue_next") == 0) {
-        // payload is "queue_next <track_id>", where <track_id> is the decimal track_id
+        // payload is "queue_next <track_id>", where <track_id> is the hex track_id
         // string as published by shairport-sync itself (see the "mper"/"track_id" handling
-        // above), e.g. "queue_next 123456789012345"
+        // above), e.g. "queue_next 1A2B3C4D5E6F7"
         char *track_id = payload + strlen(commands[it]);
         while (*track_id == ' ' || *track_id == '\t')
           track_id++;
@@ -99,7 +99,7 @@ void on_message(__attribute__((unused)) struct mosquitto *mosq,
         } else {
           char dacp_command[256];
           snprintf(dacp_command, sizeof(dacp_command),
-                   "cue?command=add&query='dmap.persistentid:%s'&mode=3", track_id);
+                   "cue?command=add&query='dmap.persistentid:0x%s'&mode=3", track_id);
           debug(2, "[MQTT]: Queue Next Command: %s\n", dacp_command);
           send_simple_dacp_command(dacp_command);
         }
@@ -322,7 +322,6 @@ void mqtt_process_metadata(uint32_t type, uint32_t code, char *data, uint32_t le
   if (config.mqtt_publish_parsed) {
     if (type == 'core') {
       int32_t r;
-      uint64_t trackid;
       char trackidstring[32];
 
       switch (code) {
@@ -342,10 +341,12 @@ void mqtt_process_metadata(uint32_t type, uint32_t code, char *data, uint32_t le
         mqtt_publish("title", data, length);
         break;
       case 'mper':
-        trackid = ntohl(*(uint32_t *)data);
-        trackid = trackid << 32;
-        trackid += ntohl(*(uint32_t *)(data + sizeof(uint32_t)));
-        r = snprintf(trackidstring, sizeof(trackidstring), "%" PRIu64 "", trackid);
+        // publish the raw persistent-id bytes as hex, in the order received --
+        // no byte-order or integer conversion, so this can't reverse the value.
+        r = 0;
+        for (uint32_t i = 0; i < length && r < (int32_t)sizeof(trackidstring) - 2; i++)
+          r += snprintf(trackidstring + r, sizeof(trackidstring) - (size_t)r, "%02X",
+                        (unsigned char)data[i]);
         mqtt_publish("track_id", trackidstring, r);
       }
     } else if (type == 'ssnc') {

--- a/mqtt.c
+++ b/mqtt.c
@@ -83,7 +83,7 @@ void on_message(__attribute__((unused)) struct mosquitto *mosq,
       debug(2, "[MQTT]: Received Recognized Command: %s\n", commands[it]);
       if (strcmp(commands[it], "disconnect") == 0) {
         debug(2, "[MQTT]: Disconnect Command: %s\n", commands[it]);
-        release_play_lock(NULL); // stop any current session and don't replace it
+        stop_play(); // stop any current session and don't replace it
       } else if (strcmp(commands[it], "queue_next") == 0) {
         // payload is "queue_next <track_id>", where <track_id> is the hex track_id
         // string as published by shairport-sync itself (see the "mper"/"track_id" handling

--- a/mqtt.c
+++ b/mqtt.c
@@ -99,7 +99,7 @@ void on_message(__attribute__((unused)) struct mosquitto *mosq,
         } else {
           char dacp_command[256];
           snprintf(dacp_command, sizeof(dacp_command),
-                   "ctrl-int/1/cue?command=add&query='dmap.persistentid:0x%s'&mode=3", track_id);
+                   "cue?command=add&query='dmap.persistentid:0x%s'&mode=3", track_id);
           debug(2, "[MQTT]: Queue Next Command: %s\n", dacp_command);
           send_simple_dacp_command(dacp_command);
         }

--- a/mqtt.c
+++ b/mqtt.c
@@ -347,7 +347,9 @@ void mqtt_process_metadata(uint32_t type, uint32_t code, char *data, uint32_t le
         mqtt_publish("title", data, length);
         break;
       case 'mper':
-        trackid = *(uint64_t *)(data);
+        trackid = ntohl(*(uint32_t *)data);
+        trackid = trackid << 32;
+        trackid += ntohl(*(uint32_t *)(data + sizeof(uint32_t)));
         r = snprintf(trackidstring, sizeof(trackidstring), "%" PRIX64 "", trackid);
         mqtt_publish("track_id", trackidstring, r);
       }

--- a/mqtt.c
+++ b/mqtt.c
@@ -85,9 +85,9 @@ void on_message(__attribute__((unused)) struct mosquitto *mosq,
         debug(2, "[MQTT]: Disconnect Command: %s\n", commands[it]);
         stop_play(); // stop any current session and don't replace it
       } else if (strcmp(commands[it], "queue_next") == 0) {
-        // payload is "queue_next <track_id>", where <track_id> is the hex track_id
+        // payload is "queue_next <track_id>", where <track_id> is the decimal track_id
         // string as published by shairport-sync itself (see the "mper"/"track_id" handling
-        // above), e.g. "queue_next 1A2B3C4D5E6F7"
+        // above), e.g. "queue_next 123456789012345"
         char *track_id = payload + strlen(commands[it]);
         while (*track_id == ' ' || *track_id == '\t')
           track_id++;
@@ -99,7 +99,7 @@ void on_message(__attribute__((unused)) struct mosquitto *mosq,
         } else {
           char dacp_command[256];
           snprintf(dacp_command, sizeof(dacp_command),
-                   "cue?command=add&query='dmap.persistentid:0x%s'&mode=3", track_id);
+                   "cue?command=add&query='dmap.persistentid:%s'&mode=3", track_id);
           debug(2, "[MQTT]: Queue Next Command: %s\n", dacp_command);
           send_simple_dacp_command(dacp_command);
         }
@@ -345,7 +345,7 @@ void mqtt_process_metadata(uint32_t type, uint32_t code, char *data, uint32_t le
         trackid = ntohl(*(uint32_t *)data);
         trackid = trackid << 32;
         trackid += ntohl(*(uint32_t *)(data + sizeof(uint32_t)));
-        r = snprintf(trackidstring, sizeof(trackidstring), "%" PRIX64 "", trackid);
+        r = snprintf(trackidstring, sizeof(trackidstring), "%" PRIu64 "", trackid);
         mqtt_publish("track_id", trackidstring, r);
       }
     } else if (type == 'ssnc') {

--- a/mqtt.c
+++ b/mqtt.c
@@ -99,7 +99,7 @@ void on_message(__attribute__((unused)) struct mosquitto *mosq,
         } else {
           char dacp_command[256];
           snprintf(dacp_command, sizeof(dacp_command),
-                   "cue?command=add&query='dmap.persistentid:0x%s'&mode=3", track_id);
+                   "ctrl-int/1/cue?command=add&query='dmap.persistentid:0x%s'&mode=3", track_id);
           debug(2, "[MQTT]: Queue Next Command: %s\n", dacp_command);
           send_simple_dacp_command(dacp_command);
         }

--- a/mqtt.c
+++ b/mqtt.c
@@ -30,6 +30,11 @@ pc_queue metadata_mqtt_queue;
 metadata_package metadata_mqtt_queue_items[metadata_mqtt_queue_size];
 pthread_t metadata_mqtt_thread;
 
+/*
+CDA9038D27ABF88 Kiss me
+710E8D864C9E2392 Elizabeth
+*/
+
 // this holds the mosquitto client
 struct mosquitto *global_mosq = NULL;
 int connected = 0;


### PR DESCRIPTION
## Pull Requests

Thanks for helping to improve Shairport Sync. This template is an effort to make a Pull Request as trouble-free and useful as possible.

## ⚠️ Important: Target Branch

**Please ensure your pull request targets the `development` branch, not `master`.**

Contributions should be submitted against the `development` branch for review and testing before they are merged into the main release branch.

---

## Description

Please provide a brief description of your changes:

Add a queue_next MQTT command that enqueues a track by persistent ID (hex track_id) via a DACP cue command
Fix byte order of the track_id published over MQTT (previously read as a raw uint64_t cast instead of reassembling the two big-endian 32-bit halves)
Minor comment cleanup in mqtt.c


## Type of Change

Please delete options that are not relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Build/CI configuration change

## Related Issue

If this PR addresses an existing issue, please link it here:

Fixes #(issue number)

## Testing

Please describe the tests you ran to verify your changes:

- [x] Tested on Linux
- [ ] Tested on FreeBSD
- [ ] Tested on OpenBSD
- [ ] Tested with AirPlay 2
- [x] Tested with classic AirPlay

**Test Configuration:**
* Hardware/Platform: Raspberry Pi 3B
* OS Version: 13 (trixie)
* Build flags used:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have tested my changes and verified they work as expected
- [x] I have checked that my PR targets the `development` branch

## Additional Notes

Thank you for even considering my humble pull request. 
This is an update to a previous homebrew project which implemented this functionality in a (more) hacky way. My buddy Claude found a more elegant solution to my hack.

The inclusion of MQTT is brilliant.  Thank you for maintaining this wonderful project.


