### PR TITLE
Fix broken link to `CONFIGURATION_FLAGS.md`

### DIFF
--- a/ADVANCED TOPICS/README.md
+++ b/ADVANCED TOPICS/README.md
@@ -14,4 +14,4 @@ The configuration file – which contains lots of documentation – is on your s
 placed at `/etc/shairport-sync.conf.sample` (`/usr/local/etc/shairport-sync.conf.sample` on FreeBSD).
 You can also view an online version [here](../scripts/shairport-sync.conf).
 
-Build configuration flags are discussed [here](CONFIGURATION%20FLAGS.md).
+Build configuration flags are discussed [here](../CONFIGURATION%20FLAGS.md).


### PR DESCRIPTION
## Description

Fix the broken link to `CONFIGURATION_FLAG.md` on the `ADVANCED TOPICS/README.md` page.


## Type of Change

- [x] Documentation update


## Testing

- [x] Tested on GitHub

Tested change on the Github website using the built-in markdown preview


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have tested my changes and verified they work as expected
- [x] I have checked that my PR targets the `development` branch