### PR TITLE
Comment out the last remaining call to log_to_syslog()

### DIFF
--- a/shairport.c
+++ b/shairport.c
@@ -2627,8 +2627,10 @@ int main(int argc, char **argv) {
     } else { /* pid == 0 means we are the daemon */
 
       this_is_the_daemon_process = 1;
+/*
       if (log_to_default != 0) // if a specific logging mode has not been selected
         log_to_syslog();       // automatically send logs to the daemon_log
+*/
 
       /* Close FDs */
       if (daemon_close_all(-1) < 0) {


### PR DESCRIPTION
## Description

`log_to_syslog()` is commented out in `common.c`/`common.h`, but one call to it remains in the libdaemon daemonise path in `shairport.c`, so building with `--with-libdaemon` fails:

- clang: `shairport.c:2631:9: error: use of undeclared identifier 'log_to_syslog'`
- gcc: `undefined reference to 'log_to_syslog'` at link time

The three other call sites (`shairport.c:517`, `881`, `2410`) are already commented out; this commits the same treatment for the last one.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

No existing issue. Found while updating the Homebrew formula to 5.2:
https://github.com/Homebrew/homebrew-core/pull/295756

## Testing

- [ ] Tested on Linux
- [ ] Tested on FreeBSD
- [ ] Tested on OpenBSD
- [ ] Tested with AirPlay 2
- [ ] Tested with classic AirPlay

Build only: `configure`/`make` succeed again with `--with-libdaemon`; the binary
runs and reports its configuration. No playback testing was done.

**Test Configuration:**
* Hardware/Platform: Apple Silicon (arm64)
* OS Version: macOS 26
* Build flags used: `--with-libdaemon --with-ssl=openssl --with-ao --with-stdout
  --with-pulseaudio --with-pipe --with-soxr --with-metadata --with-dns_sd
  --with-os=darwin`

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have tested my changes and verified they work as expected
- [x] I have checked that my PR targets the `development` branch

## Additional Notes

The same failure hits every Homebrew platform (macOS 14/15/26, Linux x86_64/arm64) since the formula configures with `--with-libdaemon`.