### PR TITLE
Defer buffered AirPlay 2 latency offset conversion

### DIFF
--- a/rtp.c
+++ b/rtp.c
@@ -1488,8 +1488,11 @@ int get_ptp_anchor_local_time_info(rtsp_conn_info *conn, uint32_t *anchorRTP,
     }
 
     if (conn->last_anchor_info_is_valid != 0) {
-      if (anchorRTP != NULL)
-        *anchorRTP = conn->last_anchor_rtptime;
+      if (anchorRTP != NULL) {
+        // Use the current rate in case the stream format has changed.
+        int32_t added_latency = (int32_t)(config.audio_backend_latency_offset * conn->input_rate);
+        *anchorRTP = conn->last_anchor_rtptime - added_latency;
+      }
       if (anchorLocalTime != NULL)
         *anchorLocalTime = conn->last_anchor_local_time;
     }

--- a/rtsp.c
+++ b/rtsp.c
@@ -1453,11 +1453,8 @@ void handle_setrateanchori(rtsp_conn_info *conn, rtsp_message *req, rtsp_message
       // debug(1, "anchor rtpTime is %" PRId64 ".", rtpTime);
       uint32_t anchorRTPTime = rtpTime;
 
-      int32_t added_latency = (int32_t)(config.audio_backend_latency_offset * conn->input_rate);
-      // debug(1,"anchorRTPTime: %" PRIu32 ", added latency: %" PRId32 ".", anchorRTPTime,
-      // added_latency);
-      set_ptp_anchor_info(conn, conn->networkTimeTimelineID, anchorRTPTime - added_latency,
-                          anchorTimeNanoseconds);
+      // Store the raw anchor; apply the latency offset when it is used.
+      set_ptp_anchor_info(conn, conn->networkTimeTimelineID, anchorRTPTime, anchorTimeNanoseconds);
     }
 
     item = plist_dict_get_item(messagePlist, "rate");


### PR DESCRIPTION
Fixes #2252.

For buffered AirPlay 2 streams, `SETRATEANCHORI` can arrive before the current input sample rate is reliably known. The configured latency offset was therefore converted from seconds to RTP frames using a zero or stale input rate.

This change stores the raw RTP anchor and defers the seconds-to-frames conversion until the anchor is consumed, using the current input rate. This also handles streams whose format or sample rate changes during a connection.

Equivalent behavior was validated on four AirPlay 2 receivers at 48 kHz:

- `-0.050` seconds -> `-2,400` frames
- `-0.045` seconds -> `-2,160` frames
- `-0.040` seconds -> `-1,920` frames
- `+0.030` seconds -> `+1,440` frames

`git diff --check` passes.
