### PR TITLE
Implement AirPlay 2 MediaRemote transport controls

### DIFF
--- a/ap2_event_message_handler.c
+++ b/ap2_event_message_handler.c
@@ -29,6 +29,10 @@
 #include "rtsp.h"
 #include "utilities/generate_random_uuid.h"
 #include "utilities/structured_buffer.h"
+#include <errno.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/time.h>
 
 void decodeAndLogPlist(plist_t plist_to_log) {
   if (plist_to_log != NULL) {
@@ -103,6 +107,206 @@ ssize_t ap2_event_port_post_command(rtsp_conn_info *conn, plist_t command) {
     }
     pthread_cleanup_pop(1); // delete the structured buffer
   }
+  return result;
+}
+
+static ssize_t ap2_event_port_send_media_remote_message(
+    rtsp_conn_info *conn, char *data, size_t data_length) {
+  ssize_t result = -1;
+  int receive_timeout_changed = 0;
+  int send_timeout_changed = 0;
+  int timeout_setup_ok = 1;
+  struct timeval old_receive_timeout;
+  struct timeval old_send_timeout;
+  socklen_t old_receive_timeout_length = sizeof(old_receive_timeout);
+  socklen_t old_send_timeout_length = sizeof(old_send_timeout);
+
+  pthread_mutex_lock(&conn->event_sender_mutex);
+  pthread_cleanup_push(mutex_unlock, &conn->event_sender_mutex);
+
+  if ((conn->event_channel_fd > 0) &&
+      (conn->ap2_pairing_context.event_cipher_bundle.cipher_ctx != NULL)) {
+    if (getsockopt(conn->event_channel_fd, SOL_SOCKET, SO_RCVTIMEO, &old_receive_timeout,
+                   &old_receive_timeout_length) == -1) {
+      debug(1, "Connection %d: unable to read MediaRemote receive timeout: %d.",
+            conn->connection_number, errno);
+      timeout_setup_ok = 0;
+    }
+    if (getsockopt(conn->event_channel_fd, SOL_SOCKET, SO_SNDTIMEO, &old_send_timeout,
+                   &old_send_timeout_length) == -1) {
+      debug(1, "Connection %d: unable to read MediaRemote send timeout: %d.",
+            conn->connection_number, errno);
+      timeout_setup_ok = 0;
+    }
+
+    if (timeout_setup_ok != 0) {
+      // Match the existing DACP control path's 500 ms socket timeout.
+      struct timeval event_timeout;
+      event_timeout.tv_sec = 0;
+      event_timeout.tv_usec = 500000;
+
+      if (setsockopt(conn->event_channel_fd, SOL_SOCKET, SO_RCVTIMEO, &event_timeout,
+                     sizeof(event_timeout)) == -1) {
+        debug(1, "Connection %d: unable to set MediaRemote receive timeout: %d.",
+              conn->connection_number, errno);
+        timeout_setup_ok = 0;
+      } else {
+        receive_timeout_changed = 1;
+      }
+
+      if ((timeout_setup_ok != 0) &&
+          (setsockopt(conn->event_channel_fd, SOL_SOCKET, SO_SNDTIMEO, &event_timeout,
+                      sizeof(event_timeout)) == -1)) {
+        debug(1, "Connection %d: unable to set MediaRemote send timeout: %d.",
+              conn->connection_number, errno);
+        timeout_setup_ok = 0;
+      } else if (timeout_setup_ok != 0) {
+        send_timeout_changed = 1;
+      }
+    }
+
+    // Do not risk an unbounded transaction if the socket timeout could not be established.
+    if (timeout_setup_ok != 0) {
+      errno = 0;
+      ssize_t written =
+          write_encrypted(conn->event_channel_fd, &conn->ap2_pairing_context.event_cipher_bundle,
+                          data, data_length);
+      if ((written >= 0) && ((size_t)written == data_length)) {
+        uint8_t packet[4097];
+        errno = 0;
+        result = read_encrypted(conn->event_channel_fd,
+                                &conn->ap2_pairing_context.event_cipher_bundle, packet,
+                                sizeof(packet) - 1);
+        if (result > 0) {
+          packet[result] = '\0';
+          int response_code = 0;
+          if (sscanf((char *)packet, "RTSP/%*s %d", &response_code) != 1) {
+            debug(1, "Connection %d: malformed MediaRemote RTSP response.",
+                  conn->connection_number);
+            result = -1;
+          } else if ((response_code < 200) || (response_code >= 300)) {
+            debug(1, "Connection %d: MediaRemote RTSP response status %d.",
+                  conn->connection_number, response_code);
+            result = -1;
+          } else {
+            debug(2, "Connection %d: MediaRemote RTSP response status %d.",
+                  conn->connection_number, response_code);
+          }
+        } else {
+          debug(1, "Connection %d: MediaRemote response failed or timed out (errno %d).",
+                conn->connection_number, errno);
+          result = -1;
+        }
+      } else {
+        debug(1, "Connection %d: MediaRemote write failed or timed out (errno %d).",
+              conn->connection_number, errno);
+        result = -1;
+      }
+    } else {
+      debug(1, "Connection %d: MediaRemote transaction not attempted because a bounded socket "
+               "timeout could not be established.",
+            conn->connection_number);
+      result = -1;
+    }
+
+    if (receive_timeout_changed != 0) {
+      if (setsockopt(conn->event_channel_fd, SOL_SOCKET, SO_RCVTIMEO, &old_receive_timeout,
+                     sizeof(old_receive_timeout)) == -1)
+        debug(1, "Connection %d: unable to restore event receive timeout: %d.",
+              conn->connection_number, errno);
+    }
+    if (send_timeout_changed != 0) {
+      if (setsockopt(conn->event_channel_fd, SOL_SOCKET, SO_SNDTIMEO, &old_send_timeout,
+                     sizeof(old_send_timeout)) == -1)
+        debug(1, "Connection %d: unable to restore event send timeout: %d.",
+              conn->connection_number, errno);
+    }
+  } else {
+    debug(1, "Connection %d: MediaRemote requested without a ready encrypted event channel.",
+          conn->connection_number);
+  }
+
+  pthread_cleanup_pop(1);
+  return result;
+}
+
+static ssize_t ap2_event_port_post_media_remote_command(rtsp_conn_info *conn, plist_t command) {
+  ssize_t result = -1;
+  decodeAndLogPlist(command);
+  structured_buffer *sbuf = sbuf_new(4096);
+  if (sbuf != NULL) {
+    pthread_cleanup_push(sbuf_cleanup, sbuf);
+    char *plist_string = NULL;
+    uint32_t plist_string_length = 0;
+    plist_to_bin(command, &plist_string, &plist_string_length);
+    if (plist_string != NULL) {
+      sbuf_printf(sbuf, "POST /command RTSP/1.0\r\nContent-Length: %u\r\n",
+                  plist_string_length);
+      sbuf_printf(sbuf, "Content-Type: application/x-apple-binary-plist\r\n\r\n");
+      sbuf_append(sbuf, plist_string, plist_string_length);
+      free(plist_string);
+      char *buffer = NULL;
+      size_t length = 0;
+      sbuf_buf_and_length(sbuf, &buffer, &length);
+      result = ap2_event_port_send_media_remote_message(conn, buffer, length);
+    }
+    pthread_cleanup_pop(1);
+  }
+  return result;
+}
+
+ssize_t ap2_event_send_modern_media_remote_command(rtsp_conn_info *conn,
+                                                   unsigned int command_number) {
+  ssize_t result = -1;
+
+  if (conn == NULL)
+    return result;
+
+  // Transport control support is intentionally limited to the six basic commands.
+  if (command_number > 5) {
+    debug(1, "Connection %d: unsupported AirPlay 2 MediaRemote transport command %u.",
+          conn->connection_number, command_number);
+    return result;
+  }
+
+  plist_t command_plist = plist_new_dict();
+  if (command_plist == NULL)
+    return result;
+
+  plist_t params_plist = plist_new_dict();
+  if (params_plist == NULL) {
+    plist_free(command_plist);
+    return result;
+  }
+
+  char *command_uuid = generate_random_uuid();
+  if (command_uuid == NULL) {
+    plist_free(params_plist);
+    plist_free(command_plist);
+    debug(1, "Connection %d: unable to generate MediaRemote command UUID.",
+          conn->connection_number);
+    return result;
+  }
+
+  plist_dict_set_item(command_plist, "type", plist_new_string("sendMediaRemoteCommand"));
+  plist_dict_set_item(command_plist, "modernMediaRemoteCommand", plist_new_uint(command_number));
+  plist_dict_set_item(params_plist, "kMRMediaRemoteOptionCommandID",
+                      plist_new_string(command_uuid));
+  free(command_uuid);
+
+  plist_dict_set_item(params_plist, "kMRMediaRemoteOptionOriginatedFromRemoteDevice",
+                      plist_new_uint(1));
+  plist_dict_set_item(params_plist, "kMRMediaRemoteOptionSendOptionsNumber", plist_new_uint(0));
+  plist_dict_set_item(params_plist, "kMRMediaRemoteOptionIsRedirectingCommand",
+                      plist_new_uint(1));
+  plist_dict_set_item(command_plist, "params", params_plist);
+
+  debug(2, "Connection %d: sending AirPlay 2 MediaRemote transport command %u.",
+        conn->connection_number, command_number);
+  result = ap2_event_port_post_media_remote_command(conn, command_plist);
+  debug(2, "Connection %d: AirPlay 2 MediaRemote transport command %u result %zd.",
+        conn->connection_number, command_number, result);
+  plist_free(command_plist);
   return result;
 }
 

--- a/dbus-service.c
+++ b/dbus-service.c
@@ -379,9 +379,12 @@ static gboolean on_handle_toggle_mute(ShairportSyncRemoteControl *skeleton,
 static gboolean on_handle_next(ShairportSyncRemoteControl *skeleton,
                                GDBusMethodInvocation *invocation,
                                __attribute__((unused)) gpointer user_data) {
-#ifdef CONFIG_DACP_CLIENT
-  send_simple_dacp_command("nextitem");
-#endif
+if (send_airplay_transport_command("nextitem") != 0) {
+    g_dbus_method_invocation_return_dbus_error(
+        invocation, "org.gnome.ShairportSync.Error.ControlFailed",
+        "AirPlay transport command failed");
+    return TRUE;
+  }
   shairport_sync_remote_control_complete_next(skeleton, invocation);
   return TRUE;
 }
@@ -389,9 +392,12 @@ static gboolean on_handle_next(ShairportSyncRemoteControl *skeleton,
 static gboolean on_handle_previous(ShairportSyncRemoteControl *skeleton,
                                    GDBusMethodInvocation *invocation,
                                    __attribute__((unused)) gpointer user_data) {
-#ifdef CONFIG_DACP_CLIENT
-  send_simple_dacp_command("previtem");
-#endif
+if (send_airplay_transport_command("previtem") != 0) {
+    g_dbus_method_invocation_return_dbus_error(
+        invocation, "org.gnome.ShairportSync.Error.ControlFailed",
+        "AirPlay transport command failed");
+    return TRUE;
+  }
   shairport_sync_remote_control_complete_previous(skeleton, invocation);
   return TRUE;
 }
@@ -399,9 +405,12 @@ static gboolean on_handle_previous(ShairportSyncRemoteControl *skeleton,
 static gboolean on_handle_pause(ShairportSyncRemoteControl *skeleton,
                                 GDBusMethodInvocation *invocation,
                                 __attribute__((unused)) gpointer user_data) {
-#ifdef CONFIG_DACP_CLIENT
-  send_simple_dacp_command("pause");
-#endif
+if (send_airplay_transport_command("pause") != 0) {
+    g_dbus_method_invocation_return_dbus_error(
+        invocation, "org.gnome.ShairportSync.Error.ControlFailed",
+        "AirPlay transport command failed");
+    return TRUE;
+  }
   shairport_sync_remote_control_complete_pause(skeleton, invocation);
   return TRUE;
 }
@@ -409,9 +418,12 @@ static gboolean on_handle_pause(ShairportSyncRemoteControl *skeleton,
 static gboolean on_handle_play_pause(ShairportSyncRemoteControl *skeleton,
                                      GDBusMethodInvocation *invocation,
                                      __attribute__((unused)) gpointer user_data) {
-#ifdef CONFIG_DACP_CLIENT
-  send_simple_dacp_command("playpause");
-#endif
+if (send_airplay_transport_command("playpause") != 0) {
+    g_dbus_method_invocation_return_dbus_error(
+        invocation, "org.gnome.ShairportSync.Error.ControlFailed",
+        "AirPlay transport command failed");
+    return TRUE;
+  }
   shairport_sync_remote_control_complete_play_pause(skeleton, invocation);
   return TRUE;
 }
@@ -419,9 +431,12 @@ static gboolean on_handle_play_pause(ShairportSyncRemoteControl *skeleton,
 static gboolean on_handle_play(ShairportSyncRemoteControl *skeleton,
                                GDBusMethodInvocation *invocation,
                                __attribute__((unused)) gpointer user_data) {
-#ifdef CONFIG_DACP_CLIENT
-  send_simple_dacp_command("play");
-#endif
+if (send_airplay_transport_command("play") != 0) {
+    g_dbus_method_invocation_return_dbus_error(
+        invocation, "org.gnome.ShairportSync.Error.ControlFailed",
+        "AirPlay transport command failed");
+    return TRUE;
+  }
   shairport_sync_remote_control_complete_play(skeleton, invocation);
   return TRUE;
 }
@@ -429,9 +444,12 @@ static gboolean on_handle_play(ShairportSyncRemoteControl *skeleton,
 static gboolean on_handle_stop(ShairportSyncRemoteControl *skeleton,
                                GDBusMethodInvocation *invocation,
                                __attribute__((unused)) gpointer user_data) {
-#ifdef CONFIG_DACP_CLIENT
-  send_simple_dacp_command("stop");
-#endif
+if (send_airplay_transport_command("stop") != 0) {
+    g_dbus_method_invocation_return_dbus_error(
+        invocation, "org.gnome.ShairportSync.Error.ControlFailed",
+        "AirPlay transport command failed");
+    return TRUE;
+  }
   shairport_sync_remote_control_complete_stop(skeleton, invocation);
   return TRUE;
 }

--- a/dbus-service.c
+++ b/dbus-service.c
@@ -379,7 +379,7 @@ static gboolean on_handle_toggle_mute(ShairportSyncRemoteControl *skeleton,
 static gboolean on_handle_next(ShairportSyncRemoteControl *skeleton,
                                GDBusMethodInvocation *invocation,
                                __attribute__((unused)) gpointer user_data) {
-if (send_airplay_transport_command("nextitem") != 0) {
+  if (send_airplay_transport_command("nextitem") != 0) {
     g_dbus_method_invocation_return_dbus_error(
         invocation, "org.gnome.ShairportSync.Error.ControlFailed",
         "AirPlay transport command failed");
@@ -392,7 +392,7 @@ if (send_airplay_transport_command("nextitem") != 0) {
 static gboolean on_handle_previous(ShairportSyncRemoteControl *skeleton,
                                    GDBusMethodInvocation *invocation,
                                    __attribute__((unused)) gpointer user_data) {
-if (send_airplay_transport_command("previtem") != 0) {
+  if (send_airplay_transport_command("previtem") != 0) {
     g_dbus_method_invocation_return_dbus_error(
         invocation, "org.gnome.ShairportSync.Error.ControlFailed",
         "AirPlay transport command failed");
@@ -405,7 +405,7 @@ if (send_airplay_transport_command("previtem") != 0) {
 static gboolean on_handle_pause(ShairportSyncRemoteControl *skeleton,
                                 GDBusMethodInvocation *invocation,
                                 __attribute__((unused)) gpointer user_data) {
-if (send_airplay_transport_command("pause") != 0) {
+  if (send_airplay_transport_command("pause") != 0) {
     g_dbus_method_invocation_return_dbus_error(
         invocation, "org.gnome.ShairportSync.Error.ControlFailed",
         "AirPlay transport command failed");
@@ -418,7 +418,7 @@ if (send_airplay_transport_command("pause") != 0) {
 static gboolean on_handle_play_pause(ShairportSyncRemoteControl *skeleton,
                                      GDBusMethodInvocation *invocation,
                                      __attribute__((unused)) gpointer user_data) {
-if (send_airplay_transport_command("playpause") != 0) {
+  if (send_airplay_transport_command("playpause") != 0) {
     g_dbus_method_invocation_return_dbus_error(
         invocation, "org.gnome.ShairportSync.Error.ControlFailed",
         "AirPlay transport command failed");
@@ -431,7 +431,7 @@ if (send_airplay_transport_command("playpause") != 0) {
 static gboolean on_handle_play(ShairportSyncRemoteControl *skeleton,
                                GDBusMethodInvocation *invocation,
                                __attribute__((unused)) gpointer user_data) {
-if (send_airplay_transport_command("play") != 0) {
+  if (send_airplay_transport_command("play") != 0) {
     g_dbus_method_invocation_return_dbus_error(
         invocation, "org.gnome.ShairportSync.Error.ControlFailed",
         "AirPlay transport command failed");
@@ -444,7 +444,7 @@ if (send_airplay_transport_command("play") != 0) {
 static gboolean on_handle_stop(ShairportSyncRemoteControl *skeleton,
                                GDBusMethodInvocation *invocation,
                                __attribute__((unused)) gpointer user_data) {
-if (send_airplay_transport_command("stop") != 0) {
+  if (send_airplay_transport_command("stop") != 0) {
     g_dbus_method_invocation_return_dbus_error(
         invocation, "org.gnome.ShairportSync.Error.ControlFailed",
         "AirPlay transport command failed");

--- a/mpris-service.c
+++ b/mpris-service.c
@@ -242,7 +242,7 @@ static gboolean on_handle_quit(MediaPlayer2 *skeleton, GDBusMethodInvocation *in
 
 static gboolean on_handle_next(MediaPlayer2Player *skeleton, GDBusMethodInvocation *invocation,
                                __attribute__((unused)) gpointer user_data) {
-if (send_airplay_transport_command("nextitem") != 0) {
+  if (send_airplay_transport_command("nextitem") != 0) {
     g_dbus_method_invocation_return_dbus_error(
         invocation, "org.mpris.MediaPlayer2.ShairportSync.Error.ControlFailed",
         "AirPlay transport command failed");
@@ -254,7 +254,7 @@ if (send_airplay_transport_command("nextitem") != 0) {
 
 static gboolean on_handle_previous(MediaPlayer2Player *skeleton, GDBusMethodInvocation *invocation,
                                    __attribute__((unused)) gpointer user_data) {
-if (send_airplay_transport_command("previtem") != 0) {
+  if (send_airplay_transport_command("previtem") != 0) {
     g_dbus_method_invocation_return_dbus_error(
         invocation, "org.mpris.MediaPlayer2.ShairportSync.Error.ControlFailed",
         "AirPlay transport command failed");
@@ -266,7 +266,7 @@ if (send_airplay_transport_command("previtem") != 0) {
 
 static gboolean on_handle_stop(MediaPlayer2Player *skeleton, GDBusMethodInvocation *invocation,
                                __attribute__((unused)) gpointer user_data) {
-if (send_airplay_transport_command("stop") != 0) {
+  if (send_airplay_transport_command("stop") != 0) {
     g_dbus_method_invocation_return_dbus_error(
         invocation, "org.mpris.MediaPlayer2.ShairportSync.Error.ControlFailed",
         "AirPlay transport command failed");
@@ -278,7 +278,7 @@ if (send_airplay_transport_command("stop") != 0) {
 
 static gboolean on_handle_pause(MediaPlayer2Player *skeleton, GDBusMethodInvocation *invocation,
                                 __attribute__((unused)) gpointer user_data) {
-if (send_airplay_transport_command("pause") != 0) {
+  if (send_airplay_transport_command("pause") != 0) {
     g_dbus_method_invocation_return_dbus_error(
         invocation, "org.mpris.MediaPlayer2.ShairportSync.Error.ControlFailed",
         "AirPlay transport command failed");
@@ -291,7 +291,7 @@ if (send_airplay_transport_command("pause") != 0) {
 static gboolean on_handle_play_pause(MediaPlayer2Player *skeleton,
                                      GDBusMethodInvocation *invocation,
                                      __attribute__((unused)) gpointer user_data) {
-if (send_airplay_transport_command("playpause") != 0) {
+  if (send_airplay_transport_command("playpause") != 0) {
     g_dbus_method_invocation_return_dbus_error(
         invocation, "org.mpris.MediaPlayer2.ShairportSync.Error.ControlFailed",
         "AirPlay transport command failed");
@@ -303,7 +303,7 @@ if (send_airplay_transport_command("playpause") != 0) {
 
 static gboolean on_handle_play(MediaPlayer2Player *skeleton, GDBusMethodInvocation *invocation,
                                __attribute__((unused)) gpointer user_data) {
-if (send_airplay_transport_command("play") != 0) {
+  if (send_airplay_transport_command("play") != 0) {
     g_dbus_method_invocation_return_dbus_error(
         invocation, "org.mpris.MediaPlayer2.ShairportSync.Error.ControlFailed",
         "AirPlay transport command failed");

--- a/mpris-service.c
+++ b/mpris-service.c
@@ -242,36 +242,48 @@ static gboolean on_handle_quit(MediaPlayer2 *skeleton, GDBusMethodInvocation *in
 
 static gboolean on_handle_next(MediaPlayer2Player *skeleton, GDBusMethodInvocation *invocation,
                                __attribute__((unused)) gpointer user_data) {
-#ifdef CONFIG_DACP_CLIENT
-  send_simple_dacp_command("nextitem");
-#endif
+if (send_airplay_transport_command("nextitem") != 0) {
+    g_dbus_method_invocation_return_dbus_error(
+        invocation, "org.mpris.MediaPlayer2.ShairportSync.Error.ControlFailed",
+        "AirPlay transport command failed");
+    return TRUE;
+  }
   media_player2_player_complete_next(skeleton, invocation);
   return TRUE;
 }
 
 static gboolean on_handle_previous(MediaPlayer2Player *skeleton, GDBusMethodInvocation *invocation,
                                    __attribute__((unused)) gpointer user_data) {
-#ifdef CONFIG_DACP_CLIENT
-  send_simple_dacp_command("previtem");
-#endif
+if (send_airplay_transport_command("previtem") != 0) {
+    g_dbus_method_invocation_return_dbus_error(
+        invocation, "org.mpris.MediaPlayer2.ShairportSync.Error.ControlFailed",
+        "AirPlay transport command failed");
+    return TRUE;
+  }
   media_player2_player_complete_previous(skeleton, invocation);
   return TRUE;
 }
 
 static gboolean on_handle_stop(MediaPlayer2Player *skeleton, GDBusMethodInvocation *invocation,
                                __attribute__((unused)) gpointer user_data) {
-#ifdef CONFIG_DACP_CLIENT
-  send_simple_dacp_command("stop");
-#endif
+if (send_airplay_transport_command("stop") != 0) {
+    g_dbus_method_invocation_return_dbus_error(
+        invocation, "org.mpris.MediaPlayer2.ShairportSync.Error.ControlFailed",
+        "AirPlay transport command failed");
+    return TRUE;
+  }
   media_player2_player_complete_stop(skeleton, invocation);
   return TRUE;
 }
 
 static gboolean on_handle_pause(MediaPlayer2Player *skeleton, GDBusMethodInvocation *invocation,
                                 __attribute__((unused)) gpointer user_data) {
-#ifdef CONFIG_DACP_CLIENT
-  send_simple_dacp_command("pause");
-#endif
+if (send_airplay_transport_command("pause") != 0) {
+    g_dbus_method_invocation_return_dbus_error(
+        invocation, "org.mpris.MediaPlayer2.ShairportSync.Error.ControlFailed",
+        "AirPlay transport command failed");
+    return TRUE;
+  }
   media_player2_player_complete_pause(skeleton, invocation);
   return TRUE;
 }
@@ -279,18 +291,24 @@ static gboolean on_handle_pause(MediaPlayer2Player *skeleton, GDBusMethodInvocat
 static gboolean on_handle_play_pause(MediaPlayer2Player *skeleton,
                                      GDBusMethodInvocation *invocation,
                                      __attribute__((unused)) gpointer user_data) {
-#ifdef CONFIG_DACP_CLIENT
-  send_simple_dacp_command("playpause");
-#endif
+if (send_airplay_transport_command("playpause") != 0) {
+    g_dbus_method_invocation_return_dbus_error(
+        invocation, "org.mpris.MediaPlayer2.ShairportSync.Error.ControlFailed",
+        "AirPlay transport command failed");
+    return TRUE;
+  }
   media_player2_player_complete_play_pause(skeleton, invocation);
   return TRUE;
 }
 
 static gboolean on_handle_play(MediaPlayer2Player *skeleton, GDBusMethodInvocation *invocation,
                                __attribute__((unused)) gpointer user_data) {
-#ifdef CONFIG_DACP_CLIENT
-  send_simple_dacp_command("play");
-#endif
+if (send_airplay_transport_command("play") != 0) {
+    g_dbus_method_invocation_return_dbus_error(
+        invocation, "org.mpris.MediaPlayer2.ShairportSync.Error.ControlFailed",
+        "AirPlay transport command failed");
+    return TRUE;
+  }
   media_player2_player_complete_play(skeleton, invocation);
   return TRUE;
 }

--- a/mqtt.c
+++ b/mqtt.c
@@ -103,6 +103,15 @@ void on_message(__attribute__((unused)) struct mosquitto *mosq,
           debug(2, "[MQTT]: Queue Next Command: %s\n", dacp_command);
           send_simple_dacp_command(dacp_command);
         }
+      } else if ((strcmp(commands[it], "play") == 0) ||
+                 (strcmp(commands[it], "pause") == 0) ||
+                 (strcmp(commands[it], "playpause") == 0) ||
+                 (strcmp(commands[it], "stop") == 0) ||
+                 (strcmp(commands[it], "nextitem") == 0) ||
+                 (strcmp(commands[it], "previtem") == 0)) {
+        debug(2, "[MQTT]: AirPlay transport command: %s\n", commands[it]);
+        if (send_airplay_transport_command(commands[it]) != 0)
+          debug(1, "[MQTT]: AirPlay transport command failed: %s\n", commands[it]);
       } else {
         debug(2, "[MQTT]: DACP Command: %s\n", commands[it]);
 #ifdef CONFIG_DACP_CLIENT

--- a/rtsp.c
+++ b/rtsp.c
@@ -76,6 +76,10 @@
 #include "rtp.h"
 #include "rtsp.h"
 
+#ifdef CONFIG_DACP_CLIENT
+#include "dacp.h"
+#endif
+
 #ifdef CONFIG_METADATA
 #include "metadata/core.h"
 #include "metadata/pc_queue.h"
@@ -93,6 +97,7 @@
 
 #ifdef CONFIG_AIRPLAY_2
 #include "ap2_buffered_audio_processor.h"
+#include "ap2_event_message_handler.h"
 #include "ap2_event_receiver.h"
 #include "pair_ap/pair.h"
 #include "plists/get_info_response.h"
@@ -133,6 +138,84 @@ rtsp_conn_info **conns = NULL;
 // use a read lock when consulting and holding it
 // use a write lock if you want to change it
 pthread_rwlock_t principal_conn_lock = PTHREAD_RWLOCK_INITIALIZER;
+
+static int media_remote_command_number(const char *command) {
+  if (command == NULL)
+    return -1;
+  if (strcmp(command, "play") == 0)
+    return 0;
+  if (strcmp(command, "pause") == 0)
+    return 1;
+  if (strcmp(command, "playpause") == 0)
+    return 2;
+  if (strcmp(command, "stop") == 0)
+    return 3;
+  if (strcmp(command, "nextitem") == 0)
+    return 4;
+  if (strcmp(command, "previtem") == 0)
+    return 5;
+  return -1;
+}
+
+int send_airplay_transport_command(const char *command) {
+  int result = -1;
+  int have_principal = 0;
+  int use_airplay_2 = 0;
+  int command_number = media_remote_command_number(command);
+
+  if (command_number < 0) {
+    debug(1, "Unsupported AirPlay transport command \"%s\".",
+          command != NULL ? command : "(null)");
+    return result;
+  }
+
+#ifdef CONFIG_AIRPLAY_2
+  /*
+   * The principal connection owns the AP2 event socket, cipher state and mutex.
+   * Keep the read lock for the bounded MediaRemote transaction so teardown cannot
+   * reclaim those objects while the command is in flight.
+   */
+  pthread_rwlock_rdlock(&principal_conn_lock);
+  pthread_cleanup_push(rwlock_unlock, (void *)&principal_conn_lock);
+  if (principal_conn != NULL) {
+    have_principal = 1;
+    if (principal_conn->airplay_type == ap_2) {
+      use_airplay_2 = 1;
+      ssize_t wire_result = ap2_event_send_modern_media_remote_command(
+          principal_conn, (unsigned int)command_number);
+      result = wire_result > 0 ? 0 : -1;
+    }
+  }
+  pthread_cleanup_pop(1);
+
+  if (use_airplay_2) {
+    debug(result == 0 ? 2 : 1,
+          "AirPlay 2 transport command %d (%s) event-channel %s.",
+          command_number, command, result == 0 ? "accepted" : "failed");
+    return result; // Never mask an AP2 failure by falling through to DACP.
+  }
+#else
+  (void)command_number;
+  have_principal = 1; // AirPlay 1-only builds preserve the existing DACP path.
+#endif
+
+  if (!have_principal) {
+    debug(2, "No active principal connection for transport command %s.", command);
+    return result;
+  }
+
+#ifdef CONFIG_DACP_CLIENT
+  debug(2, "Classic AirPlay transport command %s via DACP.", command);
+  int dacp_result = send_simple_dacp_command((char *)command);
+  result = ((dacp_result >= 200) && (dacp_result < 300)) ? 0 : -1;
+  if (result != 0)
+    debug(1, "Classic AirPlay transport command %s failed with DACP status %d.",
+          command, dacp_result);
+#else
+  debug(2, "Classic AirPlay transport command %s requested without DACP support.", command);
+#endif
+  return result;
+}
 
 // always lock this when accessing the list of connection threads
 pthread_mutex_t conns_lock = PTHREAD_MUTEX_INITIALIZER;

--- a/rtsp.h
+++ b/rtsp.h
@@ -41,4 +41,8 @@ plist_t generateInfoPlist(rtsp_conn_info *conn);
 char *plist_as_xml_text(plist_t the_plist); // caller must free the returned NUL-terminated string
 #endif
 
+// Route the six basic transport commands through the active session protocol.
+// AirPlay 1 uses DACP; AirPlay 2 uses the encrypted event-channel /command path.
+int send_airplay_transport_command(const char *command);
+
 #endif // _RTSP_H


### PR DESCRIPTION
## Summary

Implement AirPlay 2 transport controls using the encrypted AirPlay 2 event channel for:

- Play
- Pause
- PlayPause
- Stop
- Next
- Previous

Classic AirPlay continues to use the existing DACP transport-control path.

## Implementation

The change completes the existing `ap2_event_send_modern_media_remote_command()` path and routes the existing MPRIS, D-Bus and supported MQTT transport commands through the AirPlay 2 event channel when the active session is AirPlay 2.

AirPlay 2 command transactions are bounded with socket timeouts and fail closed if the event-channel transaction cannot be completed successfully.

The principal AirPlay 2 connection is held under the existing `principal_conn_lock` while the event-channel transaction is in progress so connection teardown cannot invalidate the connection or cipher state during the command.

Classic AirPlay DACP behaviour is unchanged.

## Testing

Built from `development` commit:

`59ea8b6e6d4a3aa246d7a828c2365265e35d14f4`

Live-tested on Raspberry Pi / aarch64 with an iPhone / Apple Music AirPlay 2 session.

Results:

- Play: PASS
- Pause: PASS
- PlayPause: PASS
- Stop: PASS
- Next: PASS
- Previous: PASS
- 7 MediaRemote sends
- 7 RTSP 200 responses
- 7 event-channel accepted responses
- 0 ALSA underruns
- 0 sync errors

The full build retained AirPlay 2, ALSA, PipeWire, SOXR, convolution, metadata, MQTT, D-Bus and MPRIS support.

A live-qualified aarch64 build and SHA256 are preserved in the qualification release on the contributor fork.

## Scope

This PR intentionally does not change:

- audio timing or buffering
- volume control
- seek control
- AirPlay identity or advertised device capabilities
- group behaviour
- media/audio transport
- classic AirPlay DACP behaviour

Developed collaboratively by **paintarm287 and ChatGPT (OpenAI)**.
