### PR TITLE
Harden AirPlay 2 Event Port response handling

### DIFF
--- a/ap2_event_receiver.c
+++ b/ap2_event_receiver.c
@@ -35,8 +35,8 @@
 #include "metadata/core.h"
 #endif
 
-// will return -1 if there is an error or port is not open, 0 if the port was closed and a positive
-// number if okay
+// will return -1 if there is an error, the port is not open or the response is not a valid
+// successful RTSP response, 0 if the port was closed and a positive number if okay
 ssize_t ap2_event_port_send_message(rtsp_conn_info *conn, char *data, size_t data_length) {
   ssize_t result = -1; // assume a problem
   pthread_mutex_lock(&conn->event_sender_mutex);
@@ -57,6 +57,30 @@ ssize_t ap2_event_port_send_message(rtsp_conn_info *conn, char *data, size_t dat
         packet[result] = '\0';
         debug(3, "Connection %d: Packet Received on Event Port with contents: \n--\n%s\n--\n",
               conn->connection_number, packet);
+
+        if ((result < 12) ||
+            (((strncmp((char *)packet, "RTSP/1.0 ", 9) != 0) &&
+              (strncmp((char *)packet, "RTSP/1.1 ", 9) != 0))) ||
+            (packet[9] < '0') || (packet[9] > '9') ||
+            (packet[10] < '0') || (packet[10] > '9') ||
+            (packet[11] < '0') || (packet[11] > '9') ||
+            ((packet[12] != ' ') && (packet[12] != '\r') &&
+             (packet[12] != '\n') && (packet[12] != '\0'))) {
+          debug(1, "Connection %d: invalid RTSP response from the Event Port.",
+                conn->connection_number);
+          result = -1;
+        } else {
+          unsigned int response_code =
+              ((unsigned int)(packet[9] - '0') * 100) +
+              ((unsigned int)(packet[10] - '0') * 10) +
+              (unsigned int)(packet[11] - '0');
+
+          if ((response_code < 200) || (response_code >= 300)) {
+            debug(1, "Connection %d: Event Port returned RTSP status %u.",
+                  conn->connection_number, response_code);
+            result = -1;
+          }
+        }
       } else {
         debug(2, "Connection %d: Event Port connection closed by client", conn->connection_number);
       }

--- a/ap2_event_receiver.c
+++ b/ap2_event_receiver.c
@@ -47,10 +47,10 @@ ssize_t ap2_event_port_send_message(rtsp_conn_info *conn, char *data, size_t dat
     if ((result != -1) && ((size_t)result == data_length)) {
       debug(3, "Connection %d: Packet of %zu bytes successfully written on the Event Port.",
             conn->connection_number, result);
-      uint8_t packet[4096];
+      uint8_t packet[4096 + 1];
       result =
           read_encrypted(conn->event_channel_fd, &conn->ap2_pairing_context.event_cipher_bundle,
-                         packet, sizeof(packet));
+                         packet, sizeof(packet) - 1);
       debug(3, "Connection %d: Packet of %zu bytes successfully read on the Event Port.",
             conn->connection_number, result);
       if (result > 0) {


### PR DESCRIPTION
## Summary

This makes two small robustness improvements to the AirPlay 2 Event Port response path.

1. Reserve a byte for the terminating NUL when logging an Event Port response. Previously, if `read_encrypted()` returned the full 4096-byte buffer, `packet[result] = '\0'` could write one byte beyond the array.

2. Validate the RTSP response received after a command. A positive read is now considered successful only when the response begins with a valid RTSP/1.0 or RTSP/1.1 status line containing a 2xx status code. Malformed or non-2xx responses return `-1`.

The two changes are kept as separate commits.

## Testing

Built successfully on a Raspberry Pi 3B running Debian aarch64.

Standalone response-validation tests:

- RTSP/1.0 200: accepted
- RTSP/1.1 204: accepted
- RTSP 299: accepted
- RTSP 400/500: recognised as unsuccessful
- malformed status codes, unsupported protocol versions, HTTP responses and short/garbage responses: rejected

14/14 test cases passed.

Live AirPlay 2 testing was then performed with Apple Music from an iPhone16,2 running iOS 26.6.

Verified remotely:

- Pause / Play
- Next / Previous
- Shuffle On / Off
- Repeat All / One / Off
- AirPlay volume changes

All behaved correctly.

The captured Event Port transactions returned:

    RTSP/1.0 200 OK

No `invalid RTSP response` or non-2xx validator errors were produced during the live test.

Final tested binary SHA256:

    23c52913fda2d0e0badd4028d2929e0288c2ca8d4f2d54da52450f59730f46bf