### PR TITLE
rtsp: fix stack buffer overflow when hex-dumping unrecognised RTSP methods

### DIFF
--- a/rtsp.c
+++ b/rtsp.c
@@ -4205,7 +4205,7 @@ static void *rtsp_conversation_thread_func(void *pconn) {
 
           int y = req->contentlength;
           if (y > 0) {
-            char obf[4096];
+            char obf[2 * 4096 + 1]; // two hex chars per input byte, plus a terminating nul
             if (y > 4096)
               y = 4096;
             char *p = req->content;


### PR DESCRIPTION
## Description

The hex-dump helper for unrecognised RTSP methods sizes its output buffer at
half the length it can actually write, so a sufficiently large request body
overflows it on the stack.

In `rtsp_conversation_thread_func()`, when a request's method is not found in
`method_handlers[]`, the body is hex-dumped for logging:

```c
int y = req->contentlength;
if (y > 0) {
  char obf[4096];
  if (y > 4096)
    y = 4096;
  char *p = req->content;
  char *obfp = obf;
  for (int obfc = 0; obfc < y; obfc++) {
    snprintf(obfp, 3, "%02X", (unsigned int)*p);   // two chars per byte
    p++;
    obfp += 2;
  }
  *obfp = 0;
  debug(dl, "Content: \"%s\".", obf);
}
```

`y` is clamped to 4096 **bytes**, but each byte is written as **two** hex
characters plus a final nul, so up to `4096 * 2 + 1 = 8193` bytes can be
written into the 4096-byte `obf`. The buffer needs to be twice as large.

Note the fill loop runs regardless of log level — only the final `debug()`
output is gated by verbosity — so the out-of-bounds writes happen even when
nothing is logged.

This changes only the buffer size to `2 * 4096 + 1`, matching the amount the
loop can write. Behaviour is otherwise unchanged: up to 4096 input bytes are
still dumped, with no truncation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

None. (This is unrelated to the pairing-TLV hardening in #2218; it's a
separate fixed-buffer sizing bug in `rtsp.c`.)

## Testing

- [x] Tested on Linux — full `--with-airplay-2` build (Debian bookworm), clean
      compile of `rtsp.o` and successful link, no new warnings.
- [ ] Tested on FreeBSD
- [ ] Tested on OpenBSD
- [x] Tested with AirPlay 2 — build only (compiled with `--with-airplay-2`;
      not runtime-tested against a live receiver).
- [ ] Tested with classic AirPlay

**Test Configuration:**
* Platform: Debian bookworm container (aarch64)
* Build flags: `--with-alsa --with-soxr --with-avahi --with-ssl=openssl --with-airplay-2`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have tested my changes and verified they work as expected
- [x] I have checked that my PR targets the `development` branch

## Additional Notes

This path is reached for any request whose method isn't recognised, and on an
AirPlay 2 connection it is reached before pairing/authentication, so the
overflow is remotely triggerable pre-auth by sending an unknown method with a
body larger than ~2 KB. I'd suggest treating it as a security fix.

Unrelated aside: this repo currently has GitHub's private vulnerability
reporting disabled and no `SECURITY.md`, so there's no private channel to
report issues like this — you may want to enable "Report a vulnerability" under
Settings → Security for the future. Happy to share fuller reproduction details
privately if useful.
