### PR TITLE
Backport pre-auth security fixes to master (obf overflow, pairing NULL deref)

### DIFF
--- a/pair_ap/pair_homekit.c
+++ b/pair_ap/pair_homekit.c
@@ -858,7 +858,7 @@ message_process(const uint8_t *data, size_t data_len, const char **errmsg)
 #endif
 
   error = pair_tlv_get_value(response, TLVType_Error);
-  if (error)
+  if (error && error->size > 0)
     {
       if (error->value[0] == TLVError_Authentication)
 	*errmsg = "Device returned an authentication failure";

--- a/rtsp.c
+++ b/rtsp.c
@@ -4241,7 +4241,7 @@ static void *rtsp_conversation_thread_func(void *pconn) {
 
           int y = req->contentlength;
           if (y > 0) {
-            char obf[4096];
+            char obf[2 * 4096 + 1]; // two hex chars per input byte, plus a terminating nul
             if (y > 4096)
               y = 4096;
             char *p = req->content;


### PR DESCRIPTION
Backports two pre-auth fixes already merged to `development` so the stable `master` branch is patched too:

- **Stack buffer overflow** in the RTSP unrecognised-method hex-dump (`obf[4096]` → `obf[2*4096+1]`) — merged to development as #2263.
- **NULL-pointer dereference** in pairing TLV handling (`message_process()` guards `error->size > 0`) — merged to development as #2264.

Both are reachable pre-authentication on AirPlay 2. `master` was still unpatched for these while `development` has them. Fixes are identical to the merged development versions (applied at the master line locations). Built with `--with-airplay-2`, no new warnings.