### PR TITLE
Bind RTSP listener to general.interface's address when set

### DIFF
--- a/common.c
+++ b/common.c
@@ -360,6 +360,39 @@ uint16_t nextFreeUDPPort() {
   return UDPPortIndex;
 }
 
+// Resolve config.interface (a device name) to its first non-loopback IP
+// address, so that listening sockets can be bound to that interface only
+// instead of the wildcard address. This mirrors the interface-matching walk
+// already used in mdns_tinysvcmdns.c for mDNS advertisement, applied here to
+// socket binding instead.
+int resolve_interface_to_address(char *addr_out, size_t addr_out_len, int *family_out) {
+  if (config.interface == NULL)
+    return -1;
+  struct ifaddrs *ifaddr, *ifa;
+  int result = -1;
+  if (getifaddrs(&ifaddr) == -1)
+    return -1;
+  for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == NULL)
+      continue;
+    if (strcmp(config.interface, ifa->ifa_name) != 0)
+      continue;
+    if (ifa->ifa_addr->sa_family == AF_INET) {
+      inet_ntop(AF_INET, &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr, addr_out, addr_out_len);
+      *family_out = AF_INET;
+      result = 0;
+      break;
+    } else if (ifa->ifa_addr->sa_family == AF_INET6) {
+      inet_ntop(AF_INET6, &((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr, addr_out, addr_out_len);
+      *family_out = AF_INET6;
+      result = 0;
+      break;
+    }
+  }
+  freeifaddrs(ifaddr);
+  return result;
+}
+
 // if port is zero, pick any port
 // otherwise, try the given port only
 int bind_socket_and_port(int type, int ip_family, const char *self_ip_address, uint32_t scope_id,

--- a/common.h
+++ b/common.h
@@ -589,6 +589,12 @@ int bind_socket_and_port(int type, int ip_family, const char *self_ip_address, u
 
 uint16_t bind_UDP_port(int ip_family, const char *self_ip_address, uint32_t scope_id, int *sock);
 
+// Resolve config.interface (a device name, e.g. "macvlan0") to its first
+// non-loopback IPv4/IPv6 address. Returns 0 on success, -1 if config.interface
+// is NULL or no matching address was found. addr_out must be at least
+// INET6_ADDRSTRLEN bytes. family_out receives AF_INET or AF_INET6.
+int resolve_interface_to_address(char *addr_out, size_t addr_out_len, int *family_out);
+
 // for pthread_push and pop
 // careful with the difference between cleanup and unlock!
 

--- a/rtsp.c
+++ b/rtsp.c
@@ -4372,13 +4372,30 @@ void *rtsp_listen_loop(__attribute((unused)) void *arg) {
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
-  hints.ai_flags = AI_PASSIVE;
 
   snprintf(portstr, 6, "%d", config.port);
 
   // debug(1,"listen socket port request is \"%s\".",portstr);
 
-  ret = getaddrinfo(NULL, portstr, &hints, &info);
+  // If general.interface names a specific network interface, resolve it to
+  // its IP address and bind the RTSP listener to that address only, instead
+  // of the wildcard (0.0.0.0 / ::) address. This allows multiple
+  // shairport-sync instances -- each bound to a distinct interface/IP, e.g.
+  // via macvlan -- to coexist on one host, each listening on its own address.
+  // Falls back to the original wildcard-bind behavior when general.interface
+  // is not set, or the named interface can't be resolved to an address.
+  char bound_ip[INET6_ADDRSTRLEN];
+  int bound_family;
+  const char *bind_node = NULL;
+  if (resolve_interface_to_address(bound_ip, sizeof(bound_ip), &bound_family) == 0) {
+    bind_node = bound_ip;
+    debug(1, "rtsp_listen_loop: binding to interface \"%s\" address \"%s\" instead of wildcard.",
+          config.interface, bound_ip);
+  } else {
+    hints.ai_flags = AI_PASSIVE;
+  }
+
+  ret = getaddrinfo(bind_node, portstr, &hints, &info);
   if (ret) {
     die("getaddrinfo failed: %s", gai_strerror(ret));
   }


### PR DESCRIPTION
Previously the RTSP listen socket always bound to the wildcard address (0.0.0.0 / ::) regardless of the general.interface configuration setting, which is otherwise used only for mDNS interface selection.

This means that when general.interface names a specific interface -- for example a macvlan sub-interface used to give one host multiple independent MAC/IP identities -- the RTSP listener still claims the wildcard address, so a second shairport-sync instance on the same host cannot bind the same port even though it is configured for a different interface/IP. This is the root cause of the documented limitation that "multiple instances of the AirPlay 2 version of Shairport Sync can not be hosted on the same system."

Add resolve_interface_to_address(), which resolves general.interface to its first non-loopback address (reusing the interface-matching walk already used for mDNS advertisement in mdns_tinysvcmdns.c), and use it in rtsp_listen_loop() to bind to that specific address instead of the wildcard when general.interface is set. Falls back to the original wildcard-bind behavior when general.interface is unset or does not resolve to an address, so this is a no-op for existing configurations.

Tested on Raspberry Pi OS with two shairport-sync AirPlay 2 instances on one host, each bound to its own macvlan interface/IP, listening concurrently on the same RTSP port (7000) with no collision.

## Pull Requests

Thanks for helping to improve Shairport Sync. This template is an effort to make a Pull Request as trouble-free and useful as possible.

## ⚠️ Important: Target Branch

**Please ensure your pull request targets the `development` branch, not `master`.**

Contributions should be submitted against the `development` branch for review and testing before they are merged into the main release branch.

---

## Description

Please provide a brief description of your changes:



## Type of Change

Please delete options that are not relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Build/CI configuration change

## Related Issue

If this PR addresses an existing issue, please link it here:

Fixes #(issue number)

## Testing

Please describe the tests you ran to verify your changes:

- [ ] Tested on Linux
- [ ] Tested on FreeBSD
- [ ] Tested on OpenBSD
- [ ] Tested with AirPlay 2
- [ ] Tested with classic AirPlay

**Test Configuration:**
* Hardware/Platform:
* OS Version:
* Build flags used:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have tested my changes and verified they work as expected
- [ ] I have checked that my PR targets the `development` branch

## Additional Notes

Any additional information, context, or screenshots that would help reviewers understand your changes:


