### PR TITLE
Don't automatically hide the volume control when ignore_volume_control is set.

### DIFF
--- a/rtsp.c
+++ b/rtsp.c
@@ -1131,13 +1131,9 @@ plist_t generateInfoPlist(rtsp_conn_info *conn) {
     plist_dict_set_item(response_plist, "senderAddress", plist_new_string(senderAddress));
     plist_dict_set_item(response_plist, "initialVolume", plist_new_real(suggested_volume(conn)));
     plist_dict_set_item(response_plist, "vv", plist_new_uint(config.vv));
-    // don't display volume control if we're asking to ignore the volume control
-    if (config.ignore_volume_control == 0) {
-      plist_dict_set_item(response_plist, "volumeControlType",
-                          plist_new_uint(config.volumeControlType));
-    } else {
-      plist_dict_set_item(response_plist, "volumeControlType", plist_new_uint(0));
-    }
+    // Local volume handling must not affect the volume capability advertised to the sender.
+    plist_dict_set_item(response_plist, "volumeControlType",
+                        plist_new_uint(config.volumeControlType));
     pthread_cleanup_pop(1); // release the principal_conn lock
     // Create a dictionary of supported formats for the bufferStream
     uint64_t bufferStreamFormats = 0L;


### PR DESCRIPTION
## Description

Fix the AirPlay 2 `getInfo` response so that `ignore_volume_control` no longer changes the volume capability advertised to the sender.

Previously, when `ignore_volume_control = "yes"`, Shairport Sync reported:

`volumeControlType = 0`

This could cause the AirPlay sender's volume control to disappear.

Local arrangements for handling volume should not affect the capability reported to the sender. With this change, `volumeControlType` is always reported using the configured value, regardless of `ignore_volume_control`.

This keeps `ignore_volume_control` responsible only for local volume handling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Build/CI configuration change

## Testing

- [x] Tested on Linux
- [ ] Tested on FreeBSD
- [ ] Tested on OpenBSD
- [x] Tested with AirPlay 2
- [ ] Tested with classic AirPlay

**Test configuration:**

- Raspberry Pi 3B, aarch64
- Debian Linux 6.18.39+rpt-rpi-v8
- AirPlay 2
- OpenSSL
- Avahi
- PipeWire / ALSA
- soxr
- convolution
- metadata
- D-Bus
- MPRIS
- MQTT

The change was rebuilt successfully from the current `development` branch with the full feature set above.

Live AirPlay 2 testing confirmed that with:

`ignore_volume_control = "yes"`

the sender-side volume control remains visible and usable.

The sender volume state also remained available through the existing Shairport Sync remote-control interface.

This PR intentionally does not change the existing local volume-handling semantics of `ignore_volume_control`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented the non-obvious area
- [x] The contribution builds successfully
- [x] I have tested the fix with AirPlay 2
- [x] The pull request targets the `development` branch

## Additional Notes

This PR has been reduced from the original external-volume-control proposal following discussion in the PR.

The external-controller use case is separate from this bug fix and is not part of this change.