### PR TITLE
Export session identity to the sessioncontrol hooks

### DIFF
--- a/player.c
+++ b/player.c
@@ -5315,8 +5315,33 @@ void player_flush(uint32_t timestamp, rtsp_conn_info *conn) {
 #endif
 }
 
+// Export the current session's identity into the environment so that the
+// sessioncontrol hooks (run_this_before_play_begins / run_this_after_play_ends)
+// can tell a brand-new AirPlay stream from an additional room joining an
+// AirPlay 2 group that is already playing. command_start() and command_stop()
+// fork and execv, so the child inherits whatever is set here. One
+// shairport-sync process serves one session at a time, so there is no
+// cross-session race on these variables.
+static void export_session_identity(rtsp_conn_info *conn) {
+  char numbuf[16];
+  if (conn == NULL)
+    return;
+  setenv("SPS_CLIENT_IP", conn->client_ip_string, 1);
+  snprintf(numbuf, sizeof(numbuf), "%u", (unsigned int)conn->connection_number);
+  setenv("SPS_CONNECTION_NUMBER", numbuf, 1);
+#ifdef CONFIG_AIRPLAY_2
+  setenv("SPS_GROUP_ID", conn->airplay_gid ? conn->airplay_gid : "", 1);
+  snprintf(numbuf, sizeof(numbuf), "%u", (unsigned int)conn->groupContainsGroupLeader);
+  setenv("SPS_GROUP_CONTAINS_LEADER", numbuf, 1);
+#else
+  setenv("SPS_GROUP_ID", "", 1);
+  setenv("SPS_GROUP_CONTAINS_LEADER", "0", 1);
+#endif
+}
+
 int player_play(rtsp_conn_info *conn) {
   debug(2, "Connection %d: player_play.", conn->connection_number);
+  export_session_identity(conn);
   command_start(); // before startup, and before the prepare() method runs
   // give the output device as much advance warning as possible to get ready
   // and make sure it's done before launching the player thread
@@ -5389,6 +5414,7 @@ int player_stop(rtsp_conn_info *conn) {
 #ifdef CONFIG_METADATA
     send_ssnc_metadata('pend', NULL, 0, 1); // contains cancellation points
 #endif
+    export_session_identity(conn);
     command_stop();
   }
   return response;


### PR DESCRIPTION
command_start() and command_stop() run the sessioncontrol commands
(run_this_before_play_begins / run_this_after_play_ends) via fork and
execv of a fixed command string: no arguments, and nothing about the
session that triggered them. A hook can therefore be told that play
began, but not by whom -- which makes it impossible to distinguish
independent streams from several receivers carrying one grouped
AirPlay 2 stream.

Export the session's identity into the environment immediately before
running each hook. The child inherits it across fork/execv, so neither
the hook command string nor command_start()/command_stop() need to
change:

  SPS_CLIENT_IP              conn->client_ip_string
  SPS_CONNECTION_NUMBER      conn->connection_number
  SPS_GROUP_ID               conn->airplay_gid, the AirPlay 2 group UUID
                             from the SETUP plist ("" if none)
  SPS_GROUP_CONTAINS_LEADER  conn->groupContainsGroupLeader

The last two are set to ""/0 on non-AirPlay 2 builds so that a hook can
rely on all four always being present. Nothing inside shairport-sync
reads these; behaviour is unchanged for any configuration that does not
use sessioncontrol hooks.

