### PR TITLE
Add general.address / --address to bind the RTSP listener to a specific local IP

### DIFF
--- a/common.h
+++ b/common.h
@@ -305,6 +305,7 @@ typedef struct {
                    // by default “_raop._tcp.” for AirPlay 2.
   char *interface; // a string containg the interface name, or NULL if nothing specified
   int interface_index;                        // only valid if the interface string is non-NULL
+  char *address; // local IP address to bind the RTSP listening socket to, or NULL for all addresses
   double audio_backend_buffer_desired_length; // this will be the length in seconds of the
                                               // audio backend buffer -- the DAC buffer for ALSA
   double audio_backend_buffer_interpolation_threshold_in_seconds; // below this, soxr interpolation

--- a/rtsp.c
+++ b/rtsp.c
@@ -4345,7 +4345,15 @@ void *rtsp_listen_loop(__attribute((unused)) void *arg) {
 
   // debug(1,"listen socket port request is \"%s\".",portstr);
 
-  ret = getaddrinfo(NULL, portstr, &hints, &info);
+  // If a local address is configured (--address / general.address), bind the
+  // listener to just that address; NULL preserves the all-addresses behaviour.
+  // For an IP literal, getaddrinfo returns just that one address, so the bind
+  // loop below binds a single socket instead of the v4+v6 wildcard pair.
+  char *bind_node = (config.address && config.address[0]) ? config.address : NULL;
+  if (bind_node)
+    debug(1, "rtsp_listen_loop: binding listener to address \"%s\".", bind_node);
+
+  ret = getaddrinfo(bind_node, portstr, &hints, &info);
   if (ret) {
     die("getaddrinfo failed: %s", gai_strerror(ret));
   }

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -29,6 +29,7 @@ general =
 //	output_backend = "alsa"; // Run "shairport-sync -h" to get a list of all output_backends, e.g. "alsa", "pipe", "stdout". The default is the first one.
 //	mdns_backend = "avahi"; // Run "shairport-sync -h" to get a list of all mdns_backends. The default is the first one.
 //	interface = "name"; // Use this advanced setting to specify the interface on which Shairport Sync should provide its service. Leave it commented out to get the default, which is to select the interface(s) automatically.
+//	address = "a.b.c.d"; // Use this advanced setting to bind the listening (RTSP) socket to a single local IP address. Leave it commented out to get the default, which is to listen on all local addresses. (Note: "interface" above only scopes the mDNS advertisement; "address" scopes the listening socket.)
 //	port = <number>; // Listen for service requests on this port. 5000 for AirPlay 1, 7000 for AirPlay 2
 //	udp_port_base = 6001; // (AirPlay 1 only) start allocating UDP ports from this port number when needed 
 //	udp_port_range = 10; // (AirPlay 1 only) look for free ports in this number of places, starting at the UDP port base. Allow at least 10, though only three are needed in a steady state.

--- a/shairport.c
+++ b/shairport.c
@@ -413,6 +413,7 @@ int parse_options(int argc, char **argv) {
       {"version", 'V', POPT_ARG_NONE, NULL, 0, NULL, NULL},
       {"displayConfig", 'X', POPT_ARG_NONE, &display_config_selected, 0, NULL, NULL},
       {"port", 'p', POPT_ARG_INT, &config.port, 0, NULL, NULL},
+      {"address", 0, POPT_ARG_STRING, &config.address, 0, NULL, NULL},
       {"name", 'a', POPT_ARG_STRING, &raw_service_name, 0, NULL, NULL},
       {"output", 'o', POPT_ARG_STRING, &config.output_name, 0, NULL, NULL},
       {"on-start", 'B', POPT_ARG_STRING, &config.cmd_start, 0, NULL, NULL},
@@ -686,6 +687,12 @@ int parse_options(int argc, char **argv) {
         else
           config.port = value;
       }
+
+      /* Get the local address to bind the listening socket to. NULL = all
+         addresses. The CLI --address (applied in the second popt pass below)
+         overrides this, mirroring general.port / -p. */
+      if (config_lookup_string(config.cfg, "general.address", &str))
+        config.address = strdup(str);
 
       /* Get the udp port base setting. */
       if (config_lookup_int(config.cfg, "general.udp_port_base", &value)) {


### PR DESCRIPTION
`rtsp_listen_loop()` passes `NULL` as the `getaddrinfo` node, so the RTSP listener
always binds the wildcard address (all local addresses); `general.interface` only
scopes the mDNS advertisement.

This adds an optional `general.address` (and matching `--address`), passed as the
bind node instead:

- unset  -> unchanged all-addresses (wildcard) bind
- an IP  -> the listener binds that address only

CLI overrides config, mirroring `general.port` / `-p`. The advertisement scope
(`general.interface`) is intentionally left separate: `--address` restricts the
socket, `interface` the advertisement.

Motivation and the broader multi-instance discussion are in #2266. Tested with
classic and AirPlay 2 builds, including end-to-end playback.
