### PR TITLE
Publish a distinct mDNS hostname per instance

### DIFF
--- a/common.h
+++ b/common.h
@@ -305,6 +305,7 @@ typedef struct {
                    // by default “_raop._tcp.” for AirPlay 2.
   char *interface; // a string containg the interface name, or NULL if nothing specified
   int interface_index;                        // only valid if the interface string is non-NULL
+  char *address; // local IP address to bind the RTSP listening socket to, or NULL for all addresses
   double audio_backend_buffer_desired_length; // this will be the length in seconds of the
                                               // audio backend buffer -- the DAC buffer for ALSA
   double audio_backend_buffer_interpolation_threshold_in_seconds; // below this, soxr interpolation

--- a/mdns_avahi.c
+++ b/mdns_avahi.c
@@ -282,16 +282,25 @@ static void register_service(AvahiClient *c) {
     // every instance on the host resolves to the same address no matter which
     // one it is bound to: clients discover distinct service names but can end
     // up connecting to a different instance than the one they selected.
+    //
+    // The label carries BOTH the address and the RTSP port, because the address
+    // alone is not unique per instance. Instances may share one address and be
+    // told apart only by general.port -- an eleven-room host on a single IP with
+    // ports 7000..7010 is a normal deployment -- and in that arrangement an
+    // address-only label gives all eleven the same hostname, which is exactly
+    // the collision this code exists to prevent. Including the port makes the
+    // hostname unique whichever way the instances are separated.
     char instance_hostname[256];
     const char *host_to_use = NULL; // NULL => default Avahi behaviour, unchanged
     if ((config.address != NULL) && (config.address[0] != '\0')) {
       AvahiAddress addr;
       memset(&addr, 0, sizeof(addr));
       if (avahi_address_parse(config.address, AVAHI_PROTO_UNSPEC, &addr) != NULL) {
-        // Build the label from the address itself, which is unique among the
-        // instances on this host by construction -- config.service_name is a
-        // free-form display string that may hold characters not valid in a
-        // hostname.
+        // Build the label from the address and port, which together are unique
+        // among the instances on this host by construction -- config.service_name
+        // is a free-form display string that may hold characters not valid in a
+        // hostname. Dots and colons become hyphens so an IPv6 literal yields a
+        // valid single DNS label.
         char address_label[INET6_ADDRSTRLEN];
         size_t i;
         strncpy(address_label, config.address, sizeof(address_label) - 1);
@@ -299,7 +308,8 @@ static void register_service(AvahiClient *c) {
         for (i = 0; address_label[i] != '\0'; i++)
           if ((address_label[i] == '.') || (address_label[i] == ':'))
             address_label[i] = '-';
-        snprintf(instance_hostname, sizeof(instance_hostname), "shairport-%s.local", address_label);
+        snprintf(instance_hostname, sizeof(instance_hostname), "shairport-%s-%d.local",
+                 address_label, port);
 
         // The Avahi daemon already auto-publishes an address record mapping
         // this same IP to the system's default hostname. Publishing a second

--- a/mdns_avahi.c
+++ b/mdns_avahi.c
@@ -50,6 +50,7 @@
 
 #include <avahi-client/lookup.h>
 #include <avahi-common/alternative.h>
+#include <avahi-common/address.h>
 
 void threaded_poll_unlock(void *arg) { avahi_threaded_poll_unlock((AvahiThreadedPoll *)arg); }
 
@@ -272,18 +273,74 @@ static void register_service(AvahiClient *c) {
       selected_interface = config.interface_index;
     else
       selected_interface = AVAHI_IF_UNSPEC;
+
+    // When general.address / --address binds this instance to one local IP,
+    // publish its service(s) against a hostname of their own rather than the
+    // system's default hostname. avahi_entry_group_add_service_strlst() with
+    // host=NULL advertises the SRV record against the system hostname, which
+    // resolves to whichever address the Avahi daemon associates with it, so
+    // every instance on the host resolves to the same address no matter which
+    // one it is bound to: clients discover distinct service names but can end
+    // up connecting to a different instance than the one they selected.
+    char instance_hostname[256];
+    const char *host_to_use = NULL; // NULL => default Avahi behaviour, unchanged
+    if ((config.address != NULL) && (config.address[0] != '\0')) {
+      AvahiAddress addr;
+      memset(&addr, 0, sizeof(addr));
+      if (avahi_address_parse(config.address, AVAHI_PROTO_UNSPEC, &addr) != NULL) {
+        // Build the label from the address itself, which is unique among the
+        // instances on this host by construction -- config.service_name is a
+        // free-form display string that may hold characters not valid in a
+        // hostname.
+        char address_label[INET6_ADDRSTRLEN];
+        size_t i;
+        strncpy(address_label, config.address, sizeof(address_label) - 1);
+        address_label[sizeof(address_label) - 1] = '\0';
+        for (i = 0; address_label[i] != '\0'; i++)
+          if ((address_label[i] == '.') || (address_label[i] == ':'))
+            address_label[i] = '-';
+        snprintf(instance_hostname, sizeof(instance_hostname), "shairport-%s.local", address_label);
+
+        // The Avahi daemon already auto-publishes an address record mapping
+        // this same IP to the system's default hostname. Publishing a second
+        // hostname for that address is not a collision as far as this API is
+        // concerned. AVAHI_PUBLISH_NO_REVERSE is used because only forward
+        // (A/AAAA) resolution is needed -- asking for the reverse mapping
+        // would collide with the PTR record the daemon already publishes for
+        // the system hostname. (AVAHI_PUBLISH_ALLOW_MULTIPLE is rejected here
+        // with AVAHI_ERR_INVALID_FLAGS: it is accepted only by the lower-level
+        // avahi_entry_group_add_record(). NO_REVERSE alone is sufficient.)
+        int aret = avahi_entry_group_add_address(group, selected_interface, addr.proto,
+                                                 AVAHI_PUBLISH_NO_REVERSE, instance_hostname, &addr);
+        if (aret == 0) {
+          host_to_use = instance_hostname;
+          debug(1, "avahi: published distinct hostname \"%s\" -> \"%s\".", instance_hostname,
+                config.address);
+        } else {
+          debug(1,
+                "avahi: avahi_entry_group_add_address failed (%d) for hostname \"%s\" -- falling "
+                "back to the default host advertisement.",
+                aret, instance_hostname);
+        }
+      } else {
+        debug(1,
+              "avahi: avahi_address_parse failed for \"%s\" -- falling back to the default host "
+              "advertisement.",
+              config.address);
+      }
+    }
     if (ap2_text_record_string_list) {
       ret = avahi_entry_group_add_service_strlst(group, selected_interface, AVAHI_PROTO_UNSPEC, 0,
-                                                 ap2_service_name, config.regtype2, NULL, NULL,
-                                                 port, ap2_text_record_string_list);
+                                                 ap2_service_name, config.regtype2, NULL,
+                                                 host_to_use, port, ap2_text_record_string_list);
       if (ret == AVAHI_ERR_COLLISION) {
         die("Error: AirPlay 2 name \"%s\" is already in use.", ap2_service_name);
       }
     }
     if ((ret == 0) && (text_record_string_list)) {
       ret = avahi_entry_group_add_service_strlst(group, selected_interface, AVAHI_PROTO_UNSPEC, 0,
-                                                 service_name, config.regtype, NULL, NULL, port,
-                                                 text_record_string_list);
+                                                 service_name, config.regtype, NULL, host_to_use,
+                                                 port, text_record_string_list);
       if (ret == AVAHI_ERR_COLLISION) {
         die("Error: AirPlay 1 name \"%s\" is already in use.", service_name);
       }

--- a/rtsp.c
+++ b/rtsp.c
@@ -4345,7 +4345,15 @@ void *rtsp_listen_loop(__attribute((unused)) void *arg) {
 
   // debug(1,"listen socket port request is \"%s\".",portstr);
 
-  ret = getaddrinfo(NULL, portstr, &hints, &info);
+  // If a local address is configured (--address / general.address), bind the
+  // listener to just that address; NULL preserves the all-addresses behaviour.
+  // For an IP literal, getaddrinfo returns just that one address, so the bind
+  // loop below binds a single socket instead of the v4+v6 wildcard pair.
+  char *bind_node = (config.address && config.address[0]) ? config.address : NULL;
+  if (bind_node)
+    debug(1, "rtsp_listen_loop: binding listener to address \"%s\".", bind_node);
+
+  ret = getaddrinfo(bind_node, portstr, &hints, &info);
   if (ret) {
     die("getaddrinfo failed: %s", gai_strerror(ret));
   }

--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -29,6 +29,7 @@ general =
 //	output_backend = "alsa"; // Run "shairport-sync -h" to get a list of all output_backends, e.g. "alsa", "pipe", "stdout". The default is the first one.
 //	mdns_backend = "avahi"; // Run "shairport-sync -h" to get a list of all mdns_backends. The default is the first one.
 //	interface = "name"; // Use this advanced setting to specify the interface on which Shairport Sync should provide its service. Leave it commented out to get the default, which is to select the interface(s) automatically.
+//	address = "a.b.c.d"; // Use this advanced setting to bind the listening (RTSP) socket to a single local IP address. Leave it commented out to get the default, which is to listen on all local addresses. (Note: "interface" above only scopes the mDNS advertisement; "address" scopes the listening socket.)
 //	port = <number>; // Listen for service requests on this port. 5000 for AirPlay 1, 7000 for AirPlay 2
 //	udp_port_base = 6001; // (AirPlay 1 only) start allocating UDP ports from this port number when needed 
 //	udp_port_range = 10; // (AirPlay 1 only) look for free ports in this number of places, starting at the UDP port base. Allow at least 10, though only three are needed in a steady state.

--- a/shairport.c
+++ b/shairport.c
@@ -413,6 +413,7 @@ int parse_options(int argc, char **argv) {
       {"version", 'V', POPT_ARG_NONE, NULL, 0, NULL, NULL},
       {"displayConfig", 'X', POPT_ARG_NONE, &display_config_selected, 0, NULL, NULL},
       {"port", 'p', POPT_ARG_INT, &config.port, 0, NULL, NULL},
+      {"address", 0, POPT_ARG_STRING, &config.address, 0, NULL, NULL},
       {"name", 'a', POPT_ARG_STRING, &raw_service_name, 0, NULL, NULL},
       {"output", 'o', POPT_ARG_STRING, &config.output_name, 0, NULL, NULL},
       {"on-start", 'B', POPT_ARG_STRING, &config.cmd_start, 0, NULL, NULL},
@@ -686,6 +687,12 @@ int parse_options(int argc, char **argv) {
         else
           config.port = value;
       }
+
+      /* Get the local address to bind the listening socket to. NULL = all
+         addresses. The CLI --address (applied in the second popt pass below)
+         overrides this, mirroring general.port / -p. */
+      if (config_lookup_string(config.cfg, "general.address", &str))
+        config.address = strdup(str);
 
       /* Get the udp port base setting. */
       if (config_lookup_int(config.cfg, "general.udp_port_base", &value)) {


### PR DESCRIPTION
**Stacks on #2275.** This branch contains @haavar's `--address` commit as its
base, so GitHub shows extra commits here until #2275 merges — the first is his,
unmodified. **Only the commits touching `mdns_avahi.c` are mine and up for
review.**

### The problem

`avahi_entry_group_add_service_strlst()` is called with `host=NULL`, so every
service's SRV record is advertised against the system's default hostname. That
hostname resolves to whichever address the Avahi daemon associates with it, so
when several instances run on one host, clients discover distinct service names
but every one of them resolves back to the same address. Selecting one instance
can therefore activate a different one.

This is the mDNS half of the multi-instance problem discussed in #2266; @mikebrady
called it the blocker there.

### The change

Publish an additional hostname derived from the instance's bound address **and
its RTSP port** (`shairport-192-168-1-31-7003.local`), map it to that address
with `avahi_entry_group_add_address()`, and pass it as the host for the service
records, so each instance's SRV resolves independently.

- **Applies only when `general.address` is set.** With no address the host stays
  `NULL` and the advertisement is byte-for-byte what it is today.
- **The label comes from the address and port, not the service name.** Together
  they are unique among the instances on a host by construction;
  `config.service_name` is a free-form display string that may hold characters
  invalid in a hostname. Dots and colons become hyphens so an IPv6 literal
  yields a valid single DNS label.
- **`AVAHI_PUBLISH_NO_REVERSE`** because only forward resolution is wanted: the
  daemon already publishes a PTR record for this address under the system
  hostname, and a second reverse mapping collides with it. Publishing a second
  *forward* mapping for an address already in use is not treated as a collision.
  (`AVAHI_PUBLISH_ALLOW_MULTIPLE` looks like the flag for this but
  `avahi_entry_group_add_address()` rejects it with `AVAHI_ERR_INVALID_FLAGS`;
  it is accepted only by the lower-level `avahi_entry_group_add_record()`.)

Note for existing users: where a hostname is published at all — i.e. only when
`general.address` is set — the published name gains a port suffix. It changes
from `shairport-<address>.local` to `shairport-<address>-<port>.local`.

### Correcting an earlier claim in this PR

An earlier revision of this description said that instances sharing one address
would derive the same hostname, and that this was "harmless — it maps to the one
correct address, and the SRV port distinguishes the services."

**That was wrong, and the port suffix above is the fix.** Running eleven
instances on a single IP separated only by `general.port`, all eleven published
`shairport-192-168-1-31.local`. Clients that follow the SRV record's port are
indeed unaffected — iOS and macOS select the right room every time, which is why
the fault survived a fortnight of daily use unnoticed. But a client that treats
the SRV target host as the device's identity sees eleven services collapse onto
one host. A non-Apple AirPlay sender on that network produced duplicate player
entries and repeatedly connected to a different room than the one requested —
which is precisely the failure this commit series exists to prevent, reappearing
in the single-IP topology because the label was not unique.

So the address-only label was not "inert for single-IP"; it was silently broken
there. Labelling with address *and* port makes the hostname unique whichever way
the instances are separated.

### Testing

Bare-metal Debian, the single system Avahi daemon — no per-instance
`avahi-daemon`, no container entrypoint.

**Multi-IP (unchanged from the previous revision).** Two instances on their own
IPs, on a host already running eleven other AirPlay 2 instances. Each service
resolves one-to-one. From an iPhone: both appear, each selection activates the
one selected, and grouping works — both carried the same group UUID, played
together, and I dropped one from the group and re-added it twice with the other
playing throughout, no drops.

**Single IP, eleven instances separated by port (the case this commit adds).**
All eleven bound to `192.168.1.31` on ports 7000–7010:

```
Back Deck        port=7000  host=shairport-192-168-1-31-7000.local
Family Surround  port=7001  host=shairport-192-168-1-31-7001.local
Foyer            port=7002  host=shairport-192-168-1-31-7002.local
Kitchen          port=7003  host=shairport-192-168-1-31-7003.local
...
WorkRoom         port=7010  host=shairport-192-168-1-31-7010.local
```

Eleven distinct hostnames on both `_airplay._tcp` and `_raop._tcp`, against one
before this commit. Each resolves to `192.168.1.31`. AirPlay device IDs are
unchanged, so no client needed re-pairing. Verified afterwards: all eleven
advertise on `_airplay._tcp` with `flags=0x4`, ports unchanged, and two rooms
played simultaneously from an iPhone with no underruns.

Details and the wider discussion are in #2266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
