### PR TITLE
Honour a user-set RTSP port for AirPlay 2

### DIFF
--- a/shairport.c
+++ b/shairport.c
@@ -2822,14 +2822,17 @@ int main(int argc, char **argv) {
 
 #endif
 
+  // Default the RTSP port only if the user did not set one (-p / general.port);
+  // config.port is 0 when unset. Honouring an explicit port -- and advertising it,
+  // since mdns_register passes config.port -- lets several AirPlay 2 instances share
+  // one IP on distinct ports. (AirPlay 2 clients follow the SRV-advertised port,
+  // verified on iOS; a port set for AirPlay 2 was previously ignored.)
 #ifdef CONFIG_AIRPLAY_2
-  if (config.service_type == APST_airplay2) {
-    config.port = 7000;
-  } else {
-    config.port = 5000;
-  }
+  if (config.port == 0)
+    config.port = (config.service_type == APST_airplay2) ? 7000 : 5000;
 #else
-  config.port = 5000;
+  if (config.port == 0)
+    config.port = 5000;
 #endif
 
 #ifdef CONFIG_AIRPLAY_2


### PR DESCRIPTION
AirPlay 2 overwrote `config.port` with 7000, discarding `-p` / `general.port`
(which classic AirPlay honours). This defaults the port only when it is unset, so
an explicit port takes effect for AirPlay 2 as well. `mdns_register` already
advertises `config.port`, so the SRV record carries the chosen port -- and
AirPlay 2 clients follow it (verified on iOS), which lets several AirPlay 2
instances share one IP on distinct ports (7000, 7001, ...), with no per-instance
address, macvlan, or veth.

Unset behaviour is unchanged: 7000 for AirPlay 2, 5000 for classic. The only
change is that AirPlay 2 now honours a port it previously ignored; since the SRV
advertises whatever it binds, clients follow -- worth a release note rather than a
new setting.

Background and testing in #2266. Independently confirmed there by @jslove, who is
now running eleven AirPlay 2 instances on a single IP (ports 7000-7010) in
production.
