### PR TITLE
Suggestion: expand ${NAME} environment variables in the config file

### DIFF
--- a/scripts/shairport-sync.conf
+++ b/scripts/shairport-sync.conf
@@ -3,6 +3,15 @@
 // Some sections are operative only if Shairport Sync has been built with the right configuration flags.
 // See the individual sections for details.
 
+// Environment variable substitution:
+// Before this file is parsed, any "${NAME}" is replaced by the value of the
+// environment variable NAME (NAME must match [A-Za-z_][A-Za-z0-9_]*). The braces
+// are required, so a bare "$NAME" or a stray "$" is left untouched. Write "$${"
+// to get a literal "${". Referencing a variable that is not set is a fatal error.
+// This lets one shared configuration file serve several instances, and lets
+// secrets (such as an MQTT password) be supplied from the environment.
+// For example: name = "${SPS_NAME}";
+
 // General Settings
 general =
 {

--- a/shairport.c
+++ b/shairport.c
@@ -637,8 +637,20 @@ int parse_options(int argc, char **argv) {
     debug(2, "can't resolve the configuration file \"%s\".", config.configfile);
   } else {
     debug(1, "looking for configuration file at full path \"%s\"", config_file_real_path);
-    /* Read the file. If there is an error, report it and exit. */
-    if (config_read_file(&config_file_stuff, config_file_real_path)) {
+    /* Read the file into memory and expand ${NAME} environment-variable
+       references before parsing it, so that one shared configuration file can
+       serve many instances and so that secrets can live in the environment.
+       See expand_environment_variables() for the syntax. A file containing no
+       "${" is unchanged by this, so it is parsed exactly as before. */
+    char *config_text = read_file_to_string(config_file_real_path);
+    if (config_text == NULL)
+      die("Error reading configuration file \"%s\": \"%s\".", config_file_real_path,
+          strerror(errno));
+    char *expanded_config_text = expand_environment_variables(config_text, config_file_real_path);
+    free(config_text);
+    /* Parse the expanded text. If there is an error, report it and exit. */
+    if (config_read_string(&config_file_stuff, expanded_config_text)) {
+      free(expanded_config_text);
       config_set_auto_convert(&config_file_stuff,
                               1); // allow autoconversion from int/float to int/float
       // make config.cfg point to it
@@ -1460,13 +1472,12 @@ int parse_options(int argc, char **argv) {
 #endif
 
     } else {
-      if (config_error_type(&config_file_stuff) == CONFIG_ERR_FILE_IO)
-        die("Error reading configuration file \"%s\": \"%s\".", config_file_real_path,
-            config_error_text(&config_file_stuff));
-      else {
-        die("Line %d of the configuration file \"%s\":\n%s", config_error_line(&config_file_stuff),
-            config_error_file(&config_file_stuff), config_error_text(&config_file_stuff));
-      }
+      // The file was read successfully above, so any error here is a parse
+      // error in the (environment-expanded) text. config_read_string() does not
+      // record a filename, so fall back to config_file_real_path.
+      const char *error_file = config_error_file(&config_file_stuff);
+      die("Line %d of the configuration file \"%s\":\n%s", config_error_line(&config_file_stuff),
+          error_file ? error_file : config_file_real_path, config_error_text(&config_file_stuff));
     }
 
 #if defined(CONFIG_DBUS_INTERFACE)

--- a/utilities/string_utilities.c
+++ b/utilities/string_utilities.c
@@ -24,6 +24,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <ctype.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -191,4 +193,117 @@ char *service_name(const char *raw_service_name) {
   free(i4);
   free(vs);
   return response;
+}
+
+// Read an entire file into a newly-allocated, null-terminated buffer.
+// Returns NULL (with errno set) if the file cannot be opened or read.
+// The caller must free the returned buffer.
+char *read_file_to_string(const char *pathname) {
+  FILE *f = fopen(pathname, "rb");
+  if (f == NULL)
+    return NULL;
+  char *buffer = NULL;
+  if (fseek(f, 0, SEEK_END) == 0) {
+    long size = ftell(f);
+    if ((size >= 0) && (fseek(f, 0, SEEK_SET) == 0)) {
+      buffer = malloc((size_t)size + 1);
+      if (buffer != NULL) {
+        size_t got = fread(buffer, 1, (size_t)size, f);
+        if (ferror(f)) {
+          free(buffer);
+          buffer = NULL;
+          errno = EIO;
+        } else {
+          buffer[got] = '\0';
+        }
+      }
+    }
+  }
+  int saved_errno = errno;
+  fclose(f);
+  errno = saved_errno;
+  return buffer;
+}
+
+// Append n bytes of src to the growable, null-terminated buffer *dst (of length
+// *length and allocation *capacity), growing it if needed, and return the
+// (possibly moved) buffer.
+static char *append_to_string(char *dst, size_t *length, size_t *capacity, const char *src,
+                              size_t n) {
+  if (*length + n + 1 > *capacity) {
+    while (*length + n + 1 > *capacity)
+      *capacity = *capacity ? *capacity * 2 : 64;
+    char *bigger = realloc(dst, *capacity);
+    if (bigger == NULL)
+      die("could not allocate memory in append_to_string.");
+    dst = bigger;
+  }
+  memcpy(dst + *length, src, n);
+  *length += n;
+  dst[*length] = '\0';
+  return dst;
+}
+
+// Expand ${NAME} environment-variable references in the given text.
+//
+// Syntax:
+//   ${NAME}  is replaced by the value of environment variable NAME, where NAME
+//            matches [A-Za-z_][A-Za-z0-9_]*. The braces are required: a bare
+//            "$NAME", or a stray "$", is never touched.
+//   $${      is replaced by a literal "${", so the text can still contain a
+//            literal "${".
+// Referencing an undefined variable is a fatal error (die) rather than a silent
+// empty substitution, because an empty value in the wrong place is nasty to
+// debug. Text containing no "${" is returned byte-for-byte unchanged.
+//
+// The name_for_errors argument is only used to identify the text in error
+// messages (for the configuration file, its pathname).
+//
+// Returns a newly-allocated, null-terminated string; the caller must free it.
+char *expand_environment_variables(const char *text, const char *name_for_errors) {
+  size_t capacity = strlen(text) + 1;
+  size_t length = 0;
+  char *result = malloc(capacity);
+  if (result == NULL)
+    die("could not allocate memory while expanding \"%s\".", name_for_errors);
+  result[0] = '\0';
+
+  for (size_t i = 0; text[i] != '\0';) {
+    if ((text[i] == '$') && (text[i + 1] == '$') && (text[i + 2] == '{')) {
+      // "$${" -> literal "${"
+      result = append_to_string(result, &length, &capacity, "${", 2);
+      i += 3;
+    } else if ((text[i] == '$') && (text[i + 1] == '{')) {
+      // "${NAME}" -> value of environment variable NAME
+      size_t start = i + 2;
+      size_t end = start;
+      if (!(isalpha((unsigned char)text[end]) || (text[end] == '_')))
+        die("malformed environment-variable reference in \"%s\": \"${\" must be followed by a name "
+            "matching [A-Za-z_][A-Za-z0-9_]* (use \"$${\" for a literal \"${\").",
+            name_for_errors);
+      while (isalnum((unsigned char)text[end]) || (text[end] == '_'))
+        end++;
+      if (text[end] != '}')
+        die("unterminated environment-variable reference \"${%.*s\" in \"%s\": expected a closing "
+            "\"}\".",
+            (int)(end - start), text + start, name_for_errors);
+      size_t name_length = end - start;
+      char *variable_name = malloc(name_length + 1);
+      if (variable_name == NULL)
+        die("could not allocate memory while expanding \"%s\".", name_for_errors);
+      memcpy(variable_name, text + start, name_length);
+      variable_name[name_length] = '\0';
+      const char *value = getenv(variable_name);
+      if (value == NULL)
+        die("the environment variable \"${%s}\", referenced in \"%s\", is not set.", variable_name,
+            name_for_errors);
+      result = append_to_string(result, &length, &capacity, value, strlen(value));
+      free(variable_name);
+      i = end + 1; // skip past the '}'
+    } else {
+      result = append_to_string(result, &length, &capacity, &text[i], 1);
+      i++;
+    }
+  }
+  return result;
 }

--- a/utilities/string_utilities.h
+++ b/utilities/string_utilities.h
@@ -6,3 +6,17 @@
 char *str_replace(const char *string, const char *substr, const char *replacement);
 
 char *service_name(const char *raw_service_name);
+
+// Read an entire file into a newly-allocated, null-terminated buffer.
+// Returns NULL (with errno set) if the file cannot be opened or read.
+// The caller must free the returned buffer.
+char *read_file_to_string(const char *pathname);
+
+// Expand ${NAME} environment-variable references in the given text, taking the
+// values from the process environment. "${NAME}" (NAME matching
+// [A-Za-z_][A-Za-z0-9_]*) is replaced by the value of NAME; "$${" yields a
+// literal "${"; a reference to an unset variable is a fatal error. Text with no
+// "${" is returned unchanged. name_for_errors identifies the text in error
+// messages. Returns a newly-allocated, null-terminated string to be freed by
+// the caller.
+char *expand_environment_variables(const char *text, const char *name_for_errors);


### PR DESCRIPTION
This is a suggestion rather than a finished proposal — happy to change the syntax, the undefined-variable behaviour, or drop it entirely if you'd prefer a different approach.

### What it does

Reads the configuration file into memory and expands `${NAME}` references from the process environment *before* handing the text to libconfig (which does no variable or include expansion of its own). Parsing then happens via `config_read_string()` instead of `config_read_file()`.

### Why

It lets a single shared configuration file serve many instances (each sets different environment variables), and lets secrets such as an MQTT password live in the environment instead of being rendered into the file at deploy time. This is an alternative to adding a per-setting command-line flag for the multi-instance use case discussed in #2266 — a single shared config file can drive every instance from the environment.

### Syntax

- `${NAME}` is replaced by the value of environment variable `NAME`, where `NAME` matches `[A-Za-z_][A-Za-z0-9_]*`. The braces are required, so a bare `$NAME` or a stray `$` is never touched.
- `$${` is replaced by a literal `${`, so a config can still contain a literal `${`.
- Referencing an undefined variable is a fatal error naming the variable, rather than a silent empty substitution (which is nasty to debug). This is a deliberate choice — an empty-string default would be easy to switch to if you'd prefer.

### Backward compatibility

- A configuration file containing no `${` is passed through byte-for-byte and parses exactly as before.
- The file-not-found path and the parse-error reporting (line / text / filename) are preserved. Since `config_read_string()` records no filename, the parse-error message falls back to the resolved config path.

### Documentation

`scripts/shairport-sync.conf` gains a short block describing the syntax.

### Testing

Built the musl/Alpine binary and exercised it with `-vv`:

1. `name = "${SP_NAME}"` with `SP_NAME` set → the service name is the env value.
2. Undefined `${VAR}` → dies naming the variable.
3. `$${SP_NAME}` → the literal `${SP_NAME}` survives into the parsed value (no expansion).
4. A config with no `${...}` → parses unchanged, and a bare `$` in a string is left alone.
5. A deliberate syntax error → still reported as "Line N of the configuration file ...".