### PR TITLE
Derive per-instance AirPlay 2 identity from the bound address

### DIFF
--- a/common.c
+++ b/common.c
@@ -52,6 +52,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <net/if.h>
 
@@ -2245,12 +2246,43 @@ int get_device_id(uint8_t *id, int int_length) {
       t = id;
       int found = 0;
 
+      // When bound to a specific --address, take the device id from the MAC of the
+      // interface that owns that address, not just the first non-loopback one, so
+      // several AirPlay 2 instances on one host get distinct identities from their
+      // addresses alone. An empty target keeps the original "first MAC" behaviour.
+      char target_ifname[IF_NAMESIZE];
+      target_ifname[0] = '\0';
+      if ((config.address != NULL) && (config.address[0] != '\0')) {
+        struct in_addr a4;
+        struct in6_addr a6;
+        int is4 = (inet_pton(AF_INET, config.address, &a4) == 1);
+        int is6 = ((is4 == 0) && (inet_pton(AF_INET6, config.address, &a6) == 1));
+        struct ifaddrs *xa;
+        for (xa = ifaddr; xa != NULL; xa = xa->ifa_next) {
+          if (xa->ifa_addr == NULL)
+            continue;
+          if (is4 && (xa->ifa_addr->sa_family == AF_INET) &&
+              (memcmp(&((struct sockaddr_in *)xa->ifa_addr)->sin_addr, &a4, sizeof(a4)) == 0)) {
+            strncpy(target_ifname, xa->ifa_name, IF_NAMESIZE - 1);
+            target_ifname[IF_NAMESIZE - 1] = '\0';
+            break;
+          }
+          if (is6 && (xa->ifa_addr->sa_family == AF_INET6) &&
+              (memcmp(&((struct sockaddr_in6 *)xa->ifa_addr)->sin6_addr, &a6, sizeof(a6)) == 0)) {
+            strncpy(target_ifname, xa->ifa_name, IF_NAMESIZE - 1);
+            target_ifname[IF_NAMESIZE - 1] = '\0';
+            break;
+          }
+        }
+      }
+
       for (ifa = ifaddr; ((ifa != NULL) && (found == 0)); ifa = ifa->ifa_next) {
 #ifdef AF_PACKET
         if ((ifa->ifa_addr) && (ifa->ifa_addr->sa_family == AF_PACKET)) {
           struct sockaddr_ll *s = (struct sockaddr_ll *)ifa->ifa_addr;
           if (((ifa->ifa_flags & IFF_UP) != 0) && ((ifa->ifa_flags & IFF_RUNNING) != 0) &&
-              ((ifa->ifa_flags & IFF_LOOPBACK) == 0) && (ifa->ifa_addr != 0)) {
+              ((ifa->ifa_flags & IFF_LOOPBACK) == 0) && (ifa->ifa_addr != 0) &&
+              ((target_ifname[0] == '\0') || (strcmp(ifa->ifa_name, target_ifname) == 0))) {
             found = 1;
             response = 0;
             for (i = 0; ((i < s->sll_halen) && (i < int_length)); i++) {
@@ -2262,7 +2294,8 @@ int get_device_id(uint8_t *id, int int_length) {
 #ifdef AF_LINK
         struct sockaddr_dl *sdl = (struct sockaddr_dl *)ifa->ifa_addr;
         if ((sdl) && (sdl->sdl_family == AF_LINK)) {
-          if (sdl->sdl_type == IFT_ETHER) {
+          if ((sdl->sdl_type == IFT_ETHER) &&
+              ((target_ifname[0] == '\0') || (strcmp(ifa->ifa_name, target_ifname) == 0))) {
             found = 1;
             response = 0;
             uint8_t *s = (uint8_t *)LLADDR(sdl);

--- a/shairport.c
+++ b/shairport.c
@@ -1491,18 +1491,8 @@ int parse_options(int argc, char **argv) {
 #endif
 #endif
 #ifdef CONFIG_AIRPLAY_2
-      long long aid;
-
-      // replace the airplay_device_id with this, if provided
-      if (config_lookup_int64(config.cfg, "general.airplay_device_id", &aid)) {
-        temporary_airplay_id = aid;
-      }
-
-      // add the airplay_device_id_offset if provided
-      if (config_lookup_int64(config.cfg, "general.airplay_device_id_offset", &aid)) {
-        temporary_airplay_id += aid;
-      }
-
+      // The AirPlay 2 device id (general.airplay_device_id / _offset) is applied
+      // in one place further down, once --address is also resolved.
 #endif
 
     } else {
@@ -1624,18 +1614,8 @@ int parse_options(int argc, char **argv) {
 #endif
 
 #ifdef CONFIG_AIRPLAY_2
-    long long aid;
-
-    // replace the airplay_device_id with this, if provided
-    if (config_lookup_int64(config.cfg, "general.airplay_device_id", &aid)) {
-      temporary_airplay_id = aid;
-    }
-
-    // add the airplay_device_id_offset if provided
-    if (config_lookup_int64(config.cfg, "general.airplay_device_id_offset", &aid)) {
-      temporary_airplay_id += aid;
-    }
-
+    // The AirPlay 2 device id (general.airplay_device_id / _offset) is applied
+    // in one place further down, once --address is also resolved.
 #endif
 #endif
   }
@@ -1748,6 +1728,22 @@ int parse_options(int argc, char **argv) {
 
 #ifdef CONFIG_AIRPLAY_2
 
+  // Derive the AirPlay 2 device id now that --address and the configuration file
+  // are both resolved. get_device_id() bases it on the MAC of the --address
+  // interface when one is set (from the command line or general.address), or the
+  // first non-loopback MAC otherwise, so several instances on distinct addresses
+  // are distinct with no per-instance id to set. An explicit general.airplay_device_id
+  // then replaces it and general.airplay_device_id_offset adds to it, as before.
+  get_device_id((uint8_t *)&config.hw_addr, 6);
+  temporary_airplay_id = nctoh64(config.hw_addr) >> 16;
+  if (config.cfg != NULL) {
+    long long aid;
+    if (config_lookup_int64(config.cfg, "general.airplay_device_id", &aid))
+      temporary_airplay_id = aid;
+    if (config_lookup_int64(config.cfg, "general.airplay_device_id_offset", &aid))
+      temporary_airplay_id += aid;
+  }
+
   char shared_memory_interface_name[256] = "";
   snprintf(shared_memory_interface_name, sizeof(shared_memory_interface_name), "/%s-%" PRIx64 "",
            config.appName, temporary_airplay_id);
@@ -1780,6 +1776,28 @@ int parse_options(int argc, char **argv) {
     if (config.nqptp_shared_memory_interface_name != NULL)
       free(config.nqptp_shared_memory_interface_name);
     config.nqptp_shared_memory_interface_name = strdup(cli_nqptp_shared_memory_interface_name);
+  }
+
+  // If no name was set explicitly (config or command line) but a specific --address
+  // is in use, derive a per-instance name from the address, so several AirPlay 2
+  // instances on distinct addresses each get their own nqptp clock with no extra
+  // configuration. nqptp learns the name from the control message it is sent, so
+  // nothing has to match on the nqptp side. e.g. 192.168.1.118 -> "/nqptp-192-168-1-118".
+  if ((config.nqptp_shared_memory_interface_name == NULL) && (config.address != NULL) &&
+      (config.address[0] != '\0') && (strchr(config.address, '/') == NULL)) {
+    char addr[48];
+    size_t i;
+    for (i = 0; (config.address[i] != '\0') && (i < sizeof(addr) - 1); i++)
+      addr[i] =
+          ((config.address[i] == '.') || (config.address[i] == ':')) ? '-' : config.address[i];
+    addr[i] = '\0';
+    char derived[64]; // a POSIX shm name is at most 63 characters plus the NUL
+    int n = snprintf(derived, sizeof(derived), "/nqptp-%s", addr);
+    if ((n > 0) && (n < (int)sizeof(derived))) { // only if it fits the shm-name limit
+      config.nqptp_shared_memory_interface_name = strdup(derived);
+      debug(1, "nqptp shared memory interface name derived from address: \"%s\".",
+            config.nqptp_shared_memory_interface_name);
+    }
   }
   if (config.nqptp_shared_memory_interface_name == NULL)
     config.nqptp_shared_memory_interface_name = strdup(NQPTP_INTERFACE_NAME);
@@ -2654,7 +2672,9 @@ int main(int argc, char **argv) {
 
   config.service_type = APST_auto; // this may be changed by the settings...
 
-  // get a device id -- the first non-local MAC address
+  // get a device id -- the first non-local MAC address. When an instance is bound
+  // to a specific --address, the device id is re-derived from that interface's MAC
+  // in parse_options() once the address is known (see get_device_id).
   get_device_id((uint8_t *)&config.hw_addr, 6);
 
   // get the endianness


### PR DESCRIPTION
### What this is

When an AirPlay 2 instance is bound to a specific local IP with `--address` / `general.address` (merged in #2275), derive its identity from that address when it isn't set explicitly:

- the **device id** from the MAC of the `--address` interface, rather than the first non-loopback one;
- the **nqptp shared-memory name** from the address (`/nqptp-<address>`).

So several instances on **distinct addresses** can run from **one shared configuration file**, differing only in `--address`: each gets a distinct device id and its own nqptp clock, with no per-instance `airplay_device_id` or `nqptp_shared_memory_interface_name` to set. Explicit values still take precedence, and an instance with no `--address` is unchanged — a single instance and any existing configuration behave exactly as before.

### How it's wired

The device id is derived in **one place** in `parse_options()`, after both the command line and the configuration file are parsed. `get_device_id()` selects the MAC of the interface that owns `config.address`; `general.airplay_device_id` / `_offset` are applied there too, in the same order as before. Because it runs after parsing, the address is picked up from **either** the command line *or* `general.address` in the config file, and there's no separate argument parsing.

### Testing

Built for AirPlay 2 on the current `development`. Cases, one shared config except where noted:

| case | result |
|---|---|
| two CLI `--address` (`.118`, `.160`, different interfaces), default port | device ids `0242C0A80176` / `0242C0A801A0`, shm `/nqptp-192-168-1-118` / `/nqptp-192-168-1-160` |
| two **config-file `general.address`** (`.118`, `.160`), no `--address` | same as above — address taken from the config file |
| `general.address=.118` + explicit `airplay_device_id=0xAABBCCDDEEFFL` | device id `AABBCCDDEEFF` (explicit wins) |
| no address at all | device id from the first non-loopback MAC, shm-name `/nqptp` (unchanged) |

Distinct device ids and distinct nqptp clocks from the shared config alone; no fatal. This is the per-room-IP model I run in a five-room setup.

### Note

Split out of the original combined PR. The **shared-IP / multi-port** half — distinguishing instances that share one address by their `--port` — is a small follow-up stacked on this: **#2286**. This PR is self-contained and useful on its own for per-address setups.

Marked a proposed direction rather than a finished proposal (see #2266): the question of auto-deriving identity vs. setting explicit per-instance flags is still open. Happy to adjust.
