### PR TITLE
Derive per-instance AirPlay 2 identity from the instance name

### DIFF
--- a/shairport.c
+++ b/shairport.c
@@ -1781,6 +1781,55 @@ int parse_options(int argc, char **argv) {
       free(config.nqptp_shared_memory_interface_name);
     config.nqptp_shared_memory_interface_name = strdup(cli_nqptp_shared_memory_interface_name);
   }
+  // When this looks like one of several instances on a host -- a specific address
+  // or a port has been configured -- derive a per-instance identity from the
+  // instance's name, unless it was set explicitly. Keying on the name rather than
+  // the address or port keeps the identity stable if the address or port later
+  // changes. A single default instance configures neither, so it is unchanged.
+  {
+    int looks_multi_instance = ((config.address != NULL) && (config.address[0] != '\0')) ||
+                               (config.port != 0);
+    long long aid_probe;
+    int device_id_is_explicit =
+        (config.cfg != NULL) &&
+        (config_lookup_int64(config.cfg, "general.airplay_device_id", &aid_probe) ||
+         config_lookup_int64(config.cfg, "general.airplay_device_id_offset", &aid_probe));
+    if (looks_multi_instance && (raw_service_name != NULL) && (raw_service_name[0] != '\0')) {
+      const char *p;
+      // nqptp shared-memory name: "/nqptp-<name>" unless one was set explicitly.
+      // The name is reduced to the shm-name character set and kept within the
+      // 63-character limit.
+      if (config.nqptp_shared_memory_interface_name == NULL) {
+        char nm[64];
+        int k = snprintf(nm, sizeof(nm), "/nqptp-");
+        for (p = raw_service_name; (*p != '\0') && (k < (int)sizeof(nm) - 1); p++) {
+          char c = *p;
+          if (!(((c >= 'A') && (c <= 'Z')) || ((c >= 'a') && (c <= 'z')) ||
+                ((c >= '0') && (c <= '9')) || (c == '-') || (c == '.') || (c == '_')))
+            c = '-';
+          nm[k++] = c;
+        }
+        nm[k] = '\0';
+        config.nqptp_shared_memory_interface_name = strdup(nm);
+        debug(1, "nqptp shared memory interface name derived from name: \"%s\".",
+              config.nqptp_shared_memory_interface_name);
+      }
+      // device id: a locally-administered, unicast MAC-shaped value hashed from the
+      // name, unless airplay_device_id / airplay_device_id_offset was set.
+      if (device_id_is_explicit == 0) {
+        uint64_t h = 1469598103934665603ULL; // FNV-1a 64-bit offset basis
+        for (p = raw_service_name; *p != '\0'; p++) {
+          h ^= (uint64_t)(unsigned char)*p;
+          h *= 1099511628211ULL; // FNV-1a prime
+        }
+        uint64_t id48 = h & 0xFFFFFFFFFFFFULL;
+        uint8_t top = (uint8_t)((id48 >> 40) & 0xFF);
+        top = (uint8_t)((top & 0xFE) | 0x02); // clear multicast bit, set locally-administered
+        temporary_airplay_id = (id48 & 0x000000FFFFFFFFFFULL) | ((uint64_t)top << 40);
+        debug(1, "airplay device id derived from the instance name.");
+      }
+    }
+  }
   if (config.nqptp_shared_memory_interface_name == NULL)
     config.nqptp_shared_memory_interface_name = strdup(NQPTP_INTERFACE_NAME);
   debug(1, "nqptp shared memory interface name: \"%s\".",


### PR DESCRIPTION
### What this is

A proposal (PoC) for letting several AirPlay 2 instances run on one host from **one shared configuration file**, deriving each instance's identity from its **name** (`general.name` / `-a`) — the thing that already distinguishes one room from another.

When an instance looks like one of several on a host — i.e. a specific `address` **or** a `port` has been configured — and its identity is not set explicitly, Shairport Sync derives:

- the **AirPlay 2 device id** from a hash of the name, formatted as a locally-administered unicast MAC;
- the **nqptp shared-memory interface name** as `/nqptp-<name>`.

So the per-instance configuration is just a name, a port (or address), and an output device:

```bash
# one shared config; each room differs only by name + port + device
shairport-sync -c /etc/shairport-sync.conf -a "Kitchen"     --port=7000 -- -d room_kitchen
shairport-sync -c /etc/shairport-sync.conf -a "Living Room" --port=7001 -- -d room_livingroom
```

### Why key on the name

Earlier PoCs (#2283, #2286) derived identity from `(address, port)`. Keying on the **name** instead is:

- **more stable** — identity survives an address/port change (renumbering a network, moving a room to another port), whereas an address/port-derived id would re-register the device in iOS/HomeKit;
- **less to configure** — no `--address` is needed just to get a distinct identity (a distinct `--port` is enough), and there is no per-instance device id or nqptp name to manage;
- **network-independent** — the name is the natural identity of a room.

### Backward compatibility

The derivation only fires when an `address` or `port` is configured. A single default instance sets neither, so **its MAC-based device id and default `/nqptp` are unchanged** — including the very common case of a single instance that only sets a custom `general.name`. Explicit `general.airplay_device_id` / `airplay_device_id_offset` and `general.nqptp_shared_memory_interface_name` (or `--nqptp-shared-memory-interface-name`) still take precedence. No new configuration option is introduced.

### Relationship to #2283 / #2286

This **supersedes** #2283 (derive from address) and #2286 (distinguish by port), following the #2266 discussion about auto-derivation vs. explicit flags. If this direction is preferred, I'll close those two. The whole change is one self-contained block in `parse_options()` — no changes to `common.c` or `get_device_id()`.

### Testing

Built for AirPlay 2 on the current `development` and exercised on a testbed:

| case | result |
|---|---|
| two instances, **no `--address`**, names + ports 7000/7001 | `Kitchen` → `7A5C4BE733FD` + `/nqptp-Kitchen`; `Living Room` → `C6B5D4E194DD` + `/nqptp-Living-Room` |
| single instance, name only, no port/address | first-MAC device id + `/nqptp` (unchanged) |
| explicit `airplay_device_id` + `nqptp_shared_memory_interface_name` (config) | both win over the name derivation |
| explicit `--nqptp-shared-memory-interface-name` (command line) | wins over the name derivation |
| same names, restarted | identical device ids (derivation is deterministic) |
| `--address` set, default port | identity derived from the name |

Derived device ids are locally-administered unicast MACs. Marked a proposed direction (see #2266) rather than a finished proposal — happy to adjust the trigger, the naming, or the hash.
