### PR TITLE
docker: add ENABLE_NQPTP to opt out of starting NQPTP

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -15,7 +15,7 @@ if [ -z ${ENABLE_AVAHI+x} ] || [ $ENABLE_AVAHI -eq 1 ]; then
   avahi-daemon --daemonize --no-chroot
 fi
 
-# Don't launch NQPTP if it classic only
+# Don't launch NQPTP if it classic only, or if ENABLE_NQPTP=0
 
 SERVICE_TYPE=""
 
@@ -27,8 +27,10 @@ for arg in "$@"; do
   esac
 done
 
-if [ -z "$SERVICE_TYPE" ]; then
-  # not looking for Classic aka AirPlay 1 so start NQPTP for AirPlay 2
+# Start NQPTP for AirPlay 2, unless ENABLE_NQPTP=0. Set ENABLE_NQPTP=0 when a
+# separate, shared NQPTP already serves this host -- for example when running
+# several AirPlay 2 instances that share one NQPTP. The default is to start it.
+if [ -z "$SERVICE_TYPE" ] && { [ -z ${ENABLE_NQPTP+x} ] || [ $ENABLE_NQPTP -eq 1 ]; }; then
   echo "Starting NQPTP ($(date))"
   (/usr/local/bin/nqptp > /dev/null 2>&1) &
 fi


### PR DESCRIPTION
### What this is

Adds an `ENABLE_NQPTP` environment variable to the Docker image's launcher (`docker/run.sh`) so a container can be told **not** to start its own NQPTP.

```sh
if [ -z "$SERVICE_TYPE" ] && { [ -z ${ENABLE_NQPTP+x} ] || [ $ENABLE_NQPTP -eq 1 ]; }; then
  echo "Starting NQPTP ($(date))"
  (/usr/local/bin/nqptp > /dev/null 2>&1) &
fi
```

### Why

The launcher starts NQPTP for every AirPlay 2 container. When several AirPlay 2 instances run on one host they should share a **single** NQPTP — it needs exclusive use of ports 319/320 and is multi-client (it keeps a separate clock per shared-memory interface name). Today, running one instance per room means every container also starts its own NQPTP, and they contend for 319/320. The only way to avoid it was a custom entrypoint.

With this change, you run one dedicated NQPTP (e.g. a sidecar with `entrypoint: ["/usr/local/bin/nqptp"]`) and set `ENABLE_NQPTP=0` on each instance container:

```yaml
  kitchen:
    image: mikebrady/shairport-sync:latest
    network_mode: host
    ipc: host
    environment: [ENABLE_NQPTP=0]
    command: ["-a", "Kitchen", "--port=7000", "--", "-d", "room_kitchen"]
    depends_on: [nqptp]
```

### Notes

- Mirrors the existing `ENABLE_AVAHI` convention in the same script.
- **Default is unchanged** — with `ENABLE_NQPTP` unset (or `1`), NQPTP is started exactly as before, so single-instance users and existing setups are unaffected.
- Classic-only launches (`--service-type=classic` / `airplay1`) already skip NQPTP; that is unchanged.

### Testing

Built container runs of the image with the modified launcher:

- `ENABLE_NQPTP=0` → the launcher does not print "Starting NQPTP" and no `nqptp` process is started;
- default (unset) → "Starting NQPTP" is printed and NQPTP starts, as before.

`sh -n docker/run.sh` is clean.

This supports the multi-instance-per-host setup discussed in #2266.
